### PR TITLE
feat: add CHANGELOG/ROADMAP templates and three-file task tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Each phase is hard-gated — you cannot skip ahead. The most critical gate is be
 | `starter-kit/SAFEGUARDS.md` | Commit discipline, blast radius limits, mode-switching rules |
 | `starter-kit/SESSION_NOTES.md` | Empty template for session continuity between sessions |
 | `starter-kit/BOOTSTRAP.md` | Step-by-step setup guide for new projects |
+| `starter-kit/CHANGELOG.md` | Completed work history template — keeps BACKLOG.md lean |
+| `starter-kit/ROADMAP.md` | Feature inventory and future plans template |
 | `starter-kit/methodology_dashboard.py` | Health scanner — copy to project root for per-project dashboard |
 
 ### Tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,9 +74,10 @@ Each phase is hard-gated — you cannot skip ahead. The most critical gate is be
 
 ## Versioning
 
-Changes are tracked via git commits and the README's "What's New" section. Current version: v2.0. Key additions by version:
+Changes are tracked via git commits and the README's "What's New" section. Current version: v2.1. Key additions by version:
 
 - **v1.0:** Initial 9 principles, 6 phases, 4 workstreams
 - **v1.1:** Protocol erosion detection, ghost session prevention, minimum handoff requirements, 4 new failure modes (#14-17)
 - **v1.2:** Planning session discipline, evidence-based inventory, phase boundaries
 - **v2.0:** Methodology Dashboard — portfolio health scanner with dual-mode detection, health/risk scoring, methodology compliance checking, live HTML dashboard with auto-refresh, color-coded terminal output, starter-kit inclusion
+- **v2.1:** CHANGELOG.md and ROADMAP.md templates, three-file task tracking split, migration guide for monolithic backlogs, dashboard compliance updates

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Each phase is gated. You cannot enter the next phase until the current one is co
 
 ### 1. Copy files to your project
 
-Copy `starter-kit/SESSION_RUNNER.md`, `starter-kit/SAFEGUARDS.md`, and `starter-kit/SESSION_NOTES.md` to your project root. Copy the framework files (`ITERATIVE_METHODOLOGY.md`, `HOW_TO_USE.md`, `workstreams/`) to `docs/methodology/`.
+Copy `starter-kit/SESSION_RUNNER.md`, `starter-kit/SAFEGUARDS.md`, `starter-kit/SESSION_NOTES.md`, `starter-kit/CHANGELOG.md`, and `starter-kit/ROADMAP.md` to your project root. Copy the framework files (`ITERATIVE_METHODOLOGY.md`, `HOW_TO_USE.md`, `workstreams/`) to `docs/methodology/`.
 
 ### 2. Tell Claude to use it
 
@@ -91,6 +91,8 @@ See **[`starter-kit/BOOTSTRAP.md`](starter-kit/BOOTSTRAP.md)** for the complete 
 | `SESSION_RUNNER.md` | Cockpit checklist template (no project-specific history) |
 | `SESSION_NOTES.md` | Empty template for session continuity |
 | `SAFEGUARDS.md` | Safety rails: commit discipline, blast radius limits, mode switching |
+| `CHANGELOG.md` | Completed work history template — keeps BACKLOG.md lean |
+| `ROADMAP.md` | Feature inventory and future plans template |
 | `methodology_dashboard.py` | Health scanner: project scoring, risk assessment, compliance dashboard |
 
 ### Methodology Dashboard
@@ -144,6 +146,8 @@ Expand any project card to see health breakdown by dimension, risk factors, git 
 │   ├── SESSION_RUNNER.md             ← Cockpit checklist template
 │   ├── SESSION_NOTES.md              ← Session continuity template
 │   ├── SAFEGUARDS.md                 ← Safety rails template
+│   ├── CHANGELOG.md                  ← Completed work history template
+│   ├── ROADMAP.md                    ← Feature inventory & future plans template
 │   └── methodology_dashboard.py      ← Health scanner (also in tools/)
 │
 └── tools/                            ← Portfolio-level tooling

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ for every session. It tells you what to read, when to stop, and how to close out
 
 **That's it.** Claude will orient, wait for your task, execute one deliverable, and auto-close with handoff notes for the next session. Everything cascades from that one instruction — `SESSION_RUNNER.md` tells Claude to read `SAFEGUARDS.md` and `SESSION_NOTES.md`, which establish commit discipline and session continuity.
 
-### 3. Create a backlog
+### 3. Set up task tracking
 
-Create a `BACKLOG.md` at your project root with your current tasks and priorities. The session runner reads this during orientation. You can also tell claude to make a plan for your effort that follows this methodology. Once the plan is created, start a new session and either tell claude to implement the next phase of your plan, and tell it what file the plan is in, or build the backlog from that plan.
+Create a `BACKLOG.md` at your project root with your current tasks and priorities — open work items only. Copy `starter-kit/CHANGELOG.md` and `starter-kit/ROADMAP.md` to your project root for completed work history and feature inventory. This three-file split keeps BACKLOG.md scannable (agents read it at session start) while preserving history in dedicated files. When you complete work, remove it from `BACKLOG.md` and add an entry to `CHANGELOG.md`. See **[`starter-kit/BOOTSTRAP.md`](starter-kit/BOOTSTRAP.md)** for migration steps if you have an existing monolithic BACKLOG.md.
 
 ### Full setup guide
 
@@ -205,12 +205,19 @@ Developed by Terrell Deppe (KJ5HST) using Claude Code (Anthropic) during develop
 
 The framework is agent-independent — it works with any AI coding agent that supports persistent files and session-based interaction. It also works for human developers, though the Session Runner and known failure modes are specifically tuned for AI agent tendencies.
 
+### What's New in v2.1
+
+- **CHANGELOG.md and ROADMAP.md templates** — new starter-kit files that split task tracking into three focused files: BACKLOG.md (open work only), CHANGELOG.md (completed work history), ROADMAP.md (feature inventory and future plans)
+- **Migration guide** — step-by-step instructions in BOOTSTRAP.md for projects with an existing monolithic BACKLOG.md
+- **Dashboard compliance updated** — methodology dashboard now checks for CHANGELOG.md and ROADMAP.md presence
+- **Consistent references** — SAFEGUARDS.md, SESSION_RUNNER.md, and README updated to reference the three-file approach
+
 ### What's New in v2.0
 
 - **Methodology Dashboard** — new portfolio health scanner (`tools/methodology_dashboard.py`) that scores projects on 5 dimensions (activity, testing, documentation, CI/CD, methodology compliance) and generates a self-contained HTML dashboard
 - **Two scanning modes** — portfolio mode (scans sibling git repos) and single-project mode (scans the project + git submodules), auto-detected based on placement
 - **Health scoring (0-100)** with 5 weighted dimensions and rule-based risk assessment (critical/high/medium/low flags)
-- **Methodology compliance scoring (0-100)** — weighted checklist of 6 required items (SESSION_RUNNER, SAFEGUARDS, SESSION_NOTES, BACKLOG, docs/methodology/, workstreams/)
+- **Methodology compliance scoring (0-100)** — weighted checklist of 8 required items (SESSION_RUNNER, SAFEGUARDS, SESSION_NOTES, BACKLOG, CHANGELOG, ROADMAP, docs/methodology/, workstreams/)
 - **Color-coded terminal output** — at-a-glance status without opening the browser
 - **Live HTML dashboard** — auto-refreshes every 60 seconds; collapsible project cards sortable by health, risk, name, or activity
 - **Starter kit includes dashboard** — `starter-kit/methodology_dashboard.py` for per-project use

--- a/starter-kit/BOOTSTRAP.md
+++ b/starter-kit/BOOTSTRAP.md
@@ -85,6 +85,17 @@ Create three files at your project root for tracking work:
 
 When you complete work: remove it from `BACKLOG.md`, add an entry to `CHANGELOG.md`.
 
+### Migrating an existing BACKLOG.md
+
+If your project already has a `BACKLOG.md` that has accumulated completed items, split it:
+
+1. Create `CHANGELOG.md` — move all completed work entries (with dates and notes) out of BACKLOG.md into reverse-chronological sections
+2. Create `ROADMAP.md` — move the feature inventory ("what's built") and future plans/proposals out of BACKLOG.md
+3. Trim `BACKLOG.md` — remove all completed items, struck-through entries, and historical sections. Only open/actionable work remains.
+4. Update your `CLAUDE.md` (or equivalent) references to mention all three files
+
+After the split, `BACKLOG.md` should be scannable in under a minute.
+
 **Minimal BACKLOG.md:**
 
 ```markdown

--- a/starter-kit/BOOTSTRAP.md
+++ b/starter-kit/BOOTSTRAP.md
@@ -16,7 +16,9 @@ your-projects/                        <-- parent directory (portfolio level)
 │   ├── SESSION_RUNNER.md             ← Cockpit checklist (copied from starter kit)
 │   ├── SAFEGUARDS.md                 ← Safety rails (copied from starter kit)
 │   ├── SESSION_NOTES.md              ← Session continuity (copied from starter kit)
-│   ├── BACKLOG.md                    ← Your project's task list (you create this)
+│   ├── BACKLOG.md                    ← Open work items only (you create this)
+│   ├── CHANGELOG.md                  ← Completed work history (copied from starter kit)
+│   ├── ROADMAP.md                    ← Feature inventory & future plans (copied from starter kit)
 │   │
 │   └── docs/methodology/             ← The framework (copied from parent dir)
 │       ├── ITERATIVE_METHODOLOGY.md  ← Master framework (9 principles, 6 phases)
@@ -50,6 +52,8 @@ Copy these files from `starter-kit/` to your **project root**:
 | `SESSION_RUNNER.md` | The operating procedure — every session follows this |
 | `SAFEGUARDS.md` | Safety rails — commit discipline, blast radius limits, mode switching |
 | `SESSION_NOTES.md` | Session continuity — where handoff notes live between sessions |
+| `CHANGELOG.md` | Completed work history — add entries as work is finished |
+| `ROADMAP.md` | Feature inventory and future plans — what's built, what's next |
 | `methodology_dashboard.py` | Health scanner — scores project health and methodology compliance |
 
 The markdown files are templates designed to be customized. The dashboard is a standalone Python 3 script (no dependencies) that works out of the box.
@@ -64,15 +68,27 @@ This generates `dashboard.html` and opens it in your browser. The page auto-refr
 
 Add `dashboard.html` to your `.gitignore` — it's a generated artifact.
 
-## Step 3: Create Your BACKLOG.md
+## Step 3: Create Your Task Tracking Files
 
-Create a `BACKLOG.md` at your project root. This is project-specific — there's no template because every project's task structure is different. At minimum, include:
+Create three files at your project root for tracking work:
+
+| File | Purpose | Source |
+|------|---------|--------|
+| `BACKLOG.md` | Open work items only (actionable tasks) | You create this — see example below |
+| `CHANGELOG.md` | Completed work history with dates | Copy from `starter-kit/CHANGELOG.md` |
+| `ROADMAP.md` | Feature inventory and future plans | Copy from `starter-kit/ROADMAP.md` |
+
+**Why three files?** A single backlog file that accumulates completed items becomes unreadable over time. Keeping open work, completed work, and plans in separate files means:
+- `BACKLOG.md` stays scannable (agents read this at session start)
+- `CHANGELOG.md` captures what was done and when (reference only, not read at session start)
+- `ROADMAP.md` tracks what's built and what's planned (reference only)
+
+When you complete work: remove it from `BACKLOG.md`, add an entry to `CHANGELOG.md`.
+
+**Minimal BACKLOG.md:**
 
 ```markdown
 # Backlog
-
-## Current Milestone
-[What you're working toward]
 
 ## Active
 - [ ] [Task 1]
@@ -80,9 +96,6 @@ Create a `BACKLOG.md` at your project root. This is project-specific — there's
 
 ## Up Next
 - [ ] [Task 3]
-
-## Done
-- [x] [Completed task]
 ```
 
 ## Step 4: Add the Session Protocol to Your Agent Instructions
@@ -187,7 +200,8 @@ git config core.hooksPath .githooks
 |------|---------------|
 | `SESSION_RUNNER.md` | Phase 1 task-to-workstream mapping table |
 | `SAFEGUARDS.md` | Add project-specific hard rules if needed |
-| `BACKLOG.md` | Your project's actual tasks |
+| `BACKLOG.md` | Your project's open work items |
+| `ROADMAP.md` | Your feature inventory and future plans |
 
 ### What to Customize Over Time
 
@@ -212,7 +226,7 @@ git config core.hooksPath .githooks
 
 After setup, your first session should:
 
-1. Agent reads `SAFEGUARDS.md`, `SESSION_NOTES.md`, `BACKLOG.md`
+1. Agent reads `SAFEGUARDS.md`, `SESSION_NOTES.md`, `BACKLOG.md` (CHANGELOG.md and ROADMAP.md are reference docs — not required at session start)
 2. Agent runs `git status`, `git log --oneline -5`
 3. Agent reports findings to you
 4. Agent waits for you to give a task

--- a/starter-kit/CHANGELOG.md
+++ b/starter-kit/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project are documented here.
+Format loosely follows [Keep a Changelog](https://keepachangelog.com/).
+
+When completing work, remove the item from `BACKLOG.md` and add an entry here.
+
+## [Unreleased]
+
+<!-- Add entries here as work is completed. Group by month when the list grows. -->

--- a/starter-kit/ROADMAP.md
+++ b/starter-kit/ROADMAP.md
@@ -1,0 +1,18 @@
+# Roadmap
+
+## Current Milestone
+<!-- What you're working toward and why -->
+
+## Planned
+<!-- Future work that has been scoped but not started. Include enough context
+     (rationale, phases, effort estimates) so the next session can pick it up.
+     The active task list is in BACKLOG.md. -->
+
+## What's Built
+<!-- Feature inventory -- what the project can do today.
+     Organize by domain. Keep this as a quick-reference summary,
+     not a detailed changelog (that's in CHANGELOG.md). -->
+
+## Completed Milestones
+<!-- High-level summaries of past milestones -- one paragraph each.
+     These give context for how the project reached its current state. -->

--- a/starter-kit/SAFEGUARDS.md
+++ b/starter-kit/SAFEGUARDS.md
@@ -101,7 +101,7 @@ For documentation projects, rendering also verifies cross-references, citations,
 ### Step 1: Orient (Read Only — Change Nothing)
 ```
 1. Read SESSION_NOTES.md          — What was the last session doing?
-2. Check GitHub Issues (`gh issue list`) — What are the current priorities? (Fall back to BACKLOG.md if no repo)
+2. Check GitHub Issues (`gh issue list`) — What are the current priorities? (Fall back to BACKLOG.md if no repo. BACKLOG.md should contain only open work items — for history see `CHANGELOG.md`, for feature inventory see `ROADMAP.md`.)
 3. Read SAFEGUARDS.md             — Refresh the rules (this file)
 4. git status                     — What's committed? What's not?
 5. git log --oneline -10          — What were the recent commits?

--- a/starter-kit/SESSION_RUNNER.md
+++ b/starter-kit/SESSION_RUNNER.md
@@ -12,7 +12,7 @@ Every session has exactly ONE deliverable. When it's done, you close out. You do
 
 1. Read `SAFEGUARDS.md` — **in full, not skimmed. Every section.**
 2. Read `SESSION_NOTES.md` — focus on the ACTIVE TASK section at the top
-3. Check GitHub Issues (`gh issue list`) if the project has a repo — understand current priorities. Fall back to `BACKLOG.md` if no repo exists.
+3. Check GitHub Issues (`gh issue list`) if the project has a repo — understand current priorities. Fall back to `BACKLOG.md` if no repo exists. (BACKLOG.md should contain only open work items — for history see `CHANGELOG.md`, for feature inventory see `ROADMAP.md`.)
 4. Run: `git status`, `git log --oneline -5`, `git diff --stat`
 5. Run: `python3 methodology_dashboard.py` — refresh the project health dashboard. Leave `dashboard.html` open in a browser; it auto-refreshes every 60 seconds.
 6. **Check for ghost sessions:** Compare the session number in SESSION_NOTES.md against `git log`. If there are commits between the last documented session and now that don't correspond to any session notes, report: "Detected [N] undocumented session(s) between Session [X] and now. Commits: [list]. No session notes exist for this work."

--- a/starter-kit/methodology_dashboard.py
+++ b/starter-kit/methodology_dashboard.py
@@ -104,6 +104,8 @@ METHODOLOGY_ITEMS = [
     ("SAFEGUARDS.md", 20, "file"),
     ("SESSION_NOTES.md", 20, "file"),
     ("BACKLOG.md", 15, "file"),
+    ("CHANGELOG.md", 5, "file"),
+    ("ROADMAP.md", 5, "file"),
     ("docs/methodology", 10, "dir"),
     ("docs/methodology/workstreams", 10, "dir"),
 ]

--- a/tools/methodology_dashboard.py
+++ b/tools/methodology_dashboard.py
@@ -104,6 +104,8 @@ METHODOLOGY_ITEMS = [
     ("SAFEGUARDS.md", 20, "file"),
     ("SESSION_NOTES.md", 20, "file"),
     ("BACKLOG.md", 15, "file"),
+    ("CHANGELOG.md", 5, "file"),
+    ("ROADMAP.md", 5, "file"),
     ("docs/methodology", 10, "dir"),
     ("docs/methodology/workstreams", 10, "dir"),
 ]


### PR DESCRIPTION
## Summary

- **New starter-kit templates**: `CHANGELOG.md` (completed work history) and `ROADMAP.md` (feature inventory and future plans) split task tracking into three focused files so `BACKLOG.md` stays lean and scannable
- **Migration guide**: Step-by-step instructions in `BOOTSTRAP.md` for projects with an existing monolithic `BACKLOG.md`
- **Consistent references**: Updated `SAFEGUARDS.md`, `SESSION_RUNNER.md`, `README.md`, `CLAUDE.md`, and both dashboard scripts to reference the three-file approach; version bumped to v2.1

## Changes to dashboard scripts

Both `tools/methodology_dashboard.py` and `starter-kit/methodology_dashboard.py` add `CHANGELOG.md` (5 pts) and `ROADMAP.md` (5 pts) to `METHODOLOGY_ITEMS` so the compliance checker recognizes the new files. No other dashboard logic is modified in this PR.

## Test plan

- [ ] Copy all three starter-kit templates to a test project and verify they work with `SESSION_RUNNER.md` orientation flow
- [ ] Follow migration guide on a project with a monolithic BACKLOG.md and verify the split produces clean results
- [ ] Confirm `METHODOLOGY_ITEMS` additions score correctly in dashboard output

🤖 Generated with [Claude Code](https://claude.com/claude-code)