### PR TITLE
feat: complete v2.6 skill-citation discipline

### DIFF
--- a/ITERATIVE_METHODOLOGY.md
+++ b/ITERATIVE_METHODOLOGY.md
@@ -370,6 +370,8 @@ The canonical index is [`starter-kit/RECOMMENDED_SKILLS.md`](starter-kit/RECOMME
 
 Inline pointers in this document and in the workstream files reference skills by their slash-command name (`/verify`, `/grill-me`, `/code-review`) without re-describing them. To learn what a skill does, run it or read its `SKILL.md` at the source URL listed in the index. **When a recommended skill is unavailable in your environment, the methodology's own rules** (the phase body, the failure mode, the anti-pattern) **remain the operative guidance.** The citation is a recommendation, not a hard dependency.
 
+**A skill is not a phase.** A recommended skill that pulls a session across a hard gate — e.g., `/to-issues` followed immediately by `/tdd`, or any skill that produces an artifact and then continues to the next artifact in the same session — is failure mode #2 (keep-going) wearing a tool costume. **Close out first.** The methodology recommends skills as sharper instruments for specific phases; it does not authorize them to compress two sessions into one. This applies whether the skill appears in [`starter-kit/RECOMMENDED_SKILLS.md`](starter-kit/RECOMMENDED_SKILLS.md) or the adopter installed it independently — the methodology's gates bind every session, regardless of which tools are loaded.
+
 ---
 
 ## The Session Runner

--- a/starter-kit/BOOTSTRAP.md
+++ b/starter-kit/BOOTSTRAP.md
@@ -174,6 +174,8 @@ for every session. It tells you what to read, when to stop, and how to close out
 3. **Auto-close** — When done: evaluate previous handoff, self-assess, document learnings, write handoff notes, commit, report, STOP.
 ```
 
+**Claude Code helper.** If you don't yet have a `CLAUDE.md`, running `/init` (Claude Code built-in) scaffolds one from the project's existing structure; then paste the SESSION PROTOCOL block above into the result. If you already have a `CLAUDE.md`, skip `/init` and paste the block directly. See [`RECOMMENDED_SKILLS.md`](RECOMMENDED_SKILLS.md).
+
 ---
 
 ## Step 5: Customizations Go in CLAUDE.md, Not in Synced Files

--- a/starter-kit/RECOMMENDED_SKILLS.md
+++ b/starter-kit/RECOMMENDED_SKILLS.md
@@ -53,6 +53,31 @@ Repo HEAD at verification: `b8be62ffacb0` (2026-05-20).
 
 ---
 
+## Skills not recommended (and why)
+
+This index is a *vetted snapshot* of skills the methodology actively cites at specific phases or workstreams. Skills not listed in the tables above are either out of scope for the methodology's content, adequately covered by existing methodology discipline at higher rigor, or architecturally incompatible with the methodology's session-arc model.
+
+The entries below name skills considered during the v2.6 audit (or surfaced after) that were *deliberately* not cited, with a one-line rationale each. This subsection exists to (a) close the door on future re-litigation and (b) make the audit decisions discoverable from this index rather than only from the underlying [`docs/audits/2026-05-02-mattpocock-skills-evaluation.md`](../docs/audits/2026-05-02-mattpocock-skills-evaluation.md).
+
+**See also: [`ITERATIVE_METHODOLOGY.md`](../ITERATIVE_METHODOLOGY.md) §Recommended Skills — "A skill is not a phase."** A recommended skill that pulls a session across a hard gate is failure mode #2 wearing a tool costume. That principle applies to *every* skill, recommended or not — including the ones below if an adopter installs them independently.
+
+| Skill | Source | Why not cited |
+|---|---|---|
+| `/loop`, `/schedule` | Claude Code built-ins | Orchestration, not engineering. The methodology's phases are sequential and gated; loop/schedule belong above the session, not inside it. |
+| `/to-issues` | Pocock (`engineering/to-issues`) | Covered by Learning #30 (table-first, decisions batch, parallel creation, cross-reference verification). The methodology version is materially more rigorous. |
+| `/to-prd` | Pocock (`engineering/to-prd`) | Covered by Planning Sessions discipline. `/to-prd` synthesizes what's been discussed; methodology's planning sessions require grep-verified evidence inventories (per FM #19, plan-mode bypass). |
+| `/tdd` | Pocock (`engineering/tdd`) | The vertical-slicing framing is incorporated as FM #25; the red-green-refactor workflow is left to adopter preference. |
+| `/handoff` | Pocock (`productivity/handoff`) | Targets ephemeral single-arc compaction to OS temp; methodology requires repo-versioned cross-session handoff notes scored by the next session (Phase 3D). Different scope, not a substitute. |
+| `/caveman` | Pocock (`productivity/caveman`) | Stylistic compression; the methodology's length discipline (Learning #34: ≤150 lines for handoffs) addresses token reduction without changing voice. |
+| `/zoom-out` | Pocock (`engineering/zoom-out`) | Covered better by Learnings #28/#29 (Plan-subagent architecture surveys with file:line citations). |
+| `/write-a-skill` | Pocock (`productivity/write-a-skill`) | The methodology doesn't ship its own skills (per the v2.6 principle). Becomes relevant only if that posture changes. |
+| `/prototype` | Pocock (`engineering/prototype`) | Not yet audited (Pocock shipped this after the 2026-05-02 audit). Future-audit candidate. |
+| `/setup-matt-pocock-skills` | Pocock (`engineering/setup-matt-pocock-skills`) | Out of scope — installs Pocock's skills; methodology's `BOOTSTRAP.md` is the equivalent for the methodology framework itself. Different concerns. |
+
+If you encounter a skill that should be added to this section because it was considered and declined, open an issue or PR.
+
+---
+
 ## When a recommended skill is unavailable
 
 The methodology's text remains the operative guidance. The skill is a sharper instrument; the underlying discipline does not depend on it. Examples:

--- a/starter-kit/RECOMMENDED_SKILLS.md
+++ b/starter-kit/RECOMMENDED_SKILLS.md
@@ -50,7 +50,6 @@ Repo HEAD at verification: `b8be62ffacb0` (2026-05-20).
 | `/code-review` | [`workstreams/AUDIT_WORKSTREAM.md`](../workstreams/AUDIT_WORKSTREAM.md) — correctness review |
 | `/review` | [`workstreams/AUDIT_WORKSTREAM.md`](../workstreams/AUDIT_WORKSTREAM.md) — PR review |
 | `/security-review` | [`workstreams/AUDIT_WORKSTREAM.md`](../workstreams/AUDIT_WORKSTREAM.md) — security review |
-| `/fewer-permission-prompts` | [`BOOTSTRAP.md`](BOOTSTRAP.md) — permission setup |
 
 ---
 


### PR DESCRIPTION
# Complete v2.6 skill-citation discipline

Follow-on to #14. Three findings from a post-merge review of v2.6, bundled as a single coherent "complete the citation story" PR.

## What this PR addresses

**1. Aspirational citations in `RECOMMENDED_SKILLS.md` (commit 1).**
The built-ins table listed `/init` as cited at "BOOTSTRAP.md Step 4" and `/fewer-permission-prompts` as cited at "BOOTSTRAP.md — permission setup". Neither was actually cited there (verified via `grep`). Resolves both:
- `/init` gets a one-line Claude Code helper paragraph in BOOTSTRAP Step 4, naming it as the greenfield scaffolder and noting the paste-the-block flow for projects that already have a `CLAUDE.md`
- `/fewer-permission-prompts` is dropped from the index. It's a Claude Code productivity tweak (transcript scan + settings.json allowlist) that doesn't map to any methodology discipline — no natural citation site. The skill remains usable; the methodology just doesn't actively cite it.

**2. "A skill is not a phase" caveat (commit 2).**
PR #14 defends against skill-induced FM #2 erosion *silently* — by omitting gate-crossing skills (`/to-issues`, `/tdd`, `/to-prd`) from RECOMMENDED_SKILLS.md. The audit doc explicitly justifies each omission.

The gap: adopters who install Pocock's skill set independently (e.g., via `/plugin marketplace`) still have access to those skills and may use them without the FM #2 caveat. Silent omission from the index doesn't reach those adopters.

Adds an explicit principle paragraph to `ITERATIVE_METHODOLOGY.md` §Recommended Skills naming the failure mode and the rule. The paragraph applies whether the skill is in the index or installed externally — the methodology's gates bind every session regardless of loaded tools.

**3. "Skills not recommended (and why)" subsection (commit 3).**
Surfaces the audit-doc's keep/drop decisions from the 339-line evaluation into the index itself. Ten-row table covering:
- The v2.6 audit's REJECT/OUT-OF-SCOPE rationale: `/to-issues`, `/to-prd`, `/tdd`-as-workflow, `/caveman`, `/zoom-out`, `/write-a-skill`, `/setup-matt-pocock-skills`
- Claude Code built-ins that are orchestration-not-engineering: `/loop`, `/schedule`
- Pocock's two post-audit additions with appropriately hedged rationale: `/handoff`, `/prototype`

Placement: between the two skill tables and the "When a recommended skill is unavailable" graceful-degradation section. Narrative flow: skills cited → skills not cited and why → what to do when a cited skill is missing → future-audit candidates.

Opens with a back-reference to the "A skill is not a phase" principle from commit 2 so adopters who land in this subsection understand the FM #2 caveat applies to any skill — recommended or not.

## Scope

- 3 commits, +30/-1 across 3 files (`BOOTSTRAP.md`, `ITERATIVE_METHODOLOGY.md`, `RECOMMENDED_SKILLS.md`)
- No principle, phase, gate, workstream, FM, or session-type changes
- No FM renumbering
- Backward compatible — addition-only behavior changes

## Provenance

Findings from a post-merge review at [`docs/planning/pr14-review.md`](https://github.com/rmsharp/methodology/blob/main/docs/planning/pr14-review.md) on the rmsharp fork — analysis happened in parallel with your own self-review (which caught complementary issues; see PR #14's pre-merge fix commits and post-merge `7154759`).

The "skill is not a phase" framing and the "skills not recommended" section pattern were both originally drafted on the rmsharp fork PR #6 sketch from 2026-05-02; lightly edited and generalized here.

## Items not in scope (filed as separate issues)

- Phase 2.5 → Phase 2B naming (consistency with Phase 1B precedent) — #15
- CONTEXT_TEMPLATE auto-memory coupling (agent-independence) — #16
- Workstream citation pattern convention (AUDIT vs DEV vs ARCH inconsistency) — #17

## Test plan

- [ ] Read `BOOTSTRAP.md` Step 4 and confirm the `/init` paragraph accurately describes the skill (greenfield scaffolder, not for projects with existing CLAUDE.md)
- [ ] Read `ITERATIVE_METHODOLOGY.md` §Recommended Skills end-to-end and confirm the new paragraph reinforces (does not erode) FM #2
- [ ] Spot-check the "Skills not recommended" table against the audit doc — each rationale should match the audit's REJECT or OUT-OF-SCOPE reasoning where applicable
- [ ] Confirm `/handoff` and `/prototype` rationales (post-audit additions) are defensible
