### PR TITLE
chore: ignore tools/__pycache__/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 dashboard.html
+tools/__pycache__/


### PR DESCRIPTION
Adds `tools/__pycache__/` to `.gitignore`.

This repo ships `tools/methodology_dashboard.py` (and a copy under `starter-kit/`). Importing the module — e.g. from a test or `python -c "import methodology_dashboard"` — generates a `tools/__pycache__/` bytecode directory, which then shows up as untracked clutter in `git status`. The dashboard already treats `__pycache__` as ignorable noise (it's listed in both `EXCLUDE_DIRS` and `WALK_SKIP`), so git-ignoring the directory is the natural complement.

Scoped to `tools/` deliberately: `bin/sync` and `bin/status` are invoked as top-level scripts (no `.py` extension, not imported), so they don't generate a `bin/__pycache__/`. The scope can be broadened later if Python execution moves outside `tools/`.

One line, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
