### PR TITLE
Fix SESSION_RUNNER 3C: route project learnings to CLAUDE.md, reserve SESSION_RUNNER table for framework learnings

### DIFF
--- a/HOW_TO_USE.md
+++ b/HOW_TO_USE.md
@@ -760,7 +760,7 @@ The session runner is deliberately short. It fits in a single read. Every line i
 **Phase 3: Close Out** — The automatic close-out protocol. When the deliverable is complete, the agent executes all of these WITHOUT being asked:
 - **3A: Evaluate the previous session's handoff** — Score it 1-10, document what helped, what was missing, what was wrong. This is the compounding mechanism — it creates accountability for handoff quality.
 - **3B: Self-assess** — Compare work to previous sessions' quality bar
-- **3C: Document learnings** — Update workstream prompt and SESSION_RUNNER learnings table
+- **3C: Document learnings** — Update the workstream document; record project learnings in CLAUDE.md → Adaptations → Project-specific Learnings (adopters), or append to the SESSION_RUNNER learnings table (canonical repo dogfooding)
 - **3D: Write handoff notes** — Update SESSION_NOTES.md for the next session. **The agent knows the next session will score these notes**, which changes the quality of what gets written.
 - **3E: Commit** — All changes committed
 - **3F: Report and STOP** — Summary to user including previous session's handoff score, then session is over

--- a/starter-kit/SESSION_RUNNER.md
+++ b/starter-kit/SESSION_RUNNER.md
@@ -166,7 +166,12 @@ Compare your work to the standard set by previous sessions in this workstream:
 
 ### 3C: Document Learnings
 
-Update the workstream document and/or the Learnings table below:
+Capture what this session learned so the next session inherits it. Always update the relevant workstream document for any workstream-level pattern or anti-pattern. Then record session learnings in the right place for your audience:
+
+- **Adopter project** (you copied this `SESSION_RUNNER.md` from the methodology repo): put project learnings in your `CLAUDE.md` → **Project-Specific Methodology Adaptations** → **Project-specific Learnings** subsection. Do NOT edit the "Learnings (added by sessions)" table further down in this file — `SESSION_RUNNER.md` is synced from canonical and must stay byte-identical, or local edits will block future syncs (see BOOTSTRAP, "Customizations Go in CLAUDE.md, Not in Synced Files"). Agents read `CLAUDE.md` at session start, so a learning recorded there is applied on top of the base protocol.
+- **Canonical methodology repo** (you are dogfooding the framework on itself): record framework-level learnings by appending a new row to the "Learnings (added by sessions)" table further down in this file. This repo has no `CLAUDE.md` Adaptations section because the SESSION_RUNNER table is its learnings home; the seed rows there are real framework learnings, not placeholders. Append new rows — do not edit or overwrite existing ones.
+
+Capture, wherever it lands:
 
 - What you did, how you did it, and why
 - Files referenced during this session
@@ -295,7 +300,7 @@ These are documented tendencies. The agent must actively guard against them.
 
 ## Learnings (added by sessions)
 
-*This table starts empty. Each session adds learnings here. Over time, this becomes the project's institutional memory.*
+*These rows are the methodology's own framework learnings, recorded as the canonical repo dogfoods itself — canonical sessions append new rows here (append only; do not edit existing rows). Adopter projects do NOT edit this synced table — record project learnings in `CLAUDE.md` → Project-Specific Methodology Adaptations → Project-specific Learnings instead (see 3C).*
 
 | # | Learning | Source | When to Apply |
 |---|----------|--------|---------------|


### PR DESCRIPTION
Closes #24.

## What

Phase **3C "Document Learnings"** told sessions to *"Update the workstream document and/or the Learnings table below"* — pointing adopters at SESSION_RUNNER's own table. That contradicts `BOOTSTRAP.md`, which marks `SESSION_RUNNER.md` as a synced, byte-identical file ("Customizations Go in CLAUDE.md, Not in Synced Files") and routes project learnings to `CLAUDE.md` → Project-Specific Methodology Adaptations → Project-specific Learnings. See #24 for the full write-up (originally rad-con audit Finding #10).

## The fix — three edits, no stale destination left behind

- **`SESSION_RUNNER.md` 3C** — recomposed to route by audience:
  - *Adopter project* → record learnings in `CLAUDE.md` → Project-Specific Methodology Adaptations → Project-specific Learnings; **do NOT** edit the synced "Learnings (added by sessions)" table.
  - *Canonical methodology repo* (no `CLAUDE.md` Adaptations section) → append framework learnings to the SESSION_RUNNER seed table (append-only).
- **`SESSION_RUNNER.md` Learnings-table caption** — replaced the false *"This table starts empty…"* line (it ships with 6 seed rows) with the same dual-audience framing, so the contradiction doesn't resurface ~120 lines below.
- **`HOW_TO_USE.md:763`** — retargeted the 3C summary to match (kept the `3C` label per that block's 3A–3F convention) so it isn't a stale destination.

## Notes

- The six learning-content bullets and the closing goal line in 3C are unchanged; intent preserved.
- Canonical vocabulary reused verbatim from `BOOTSTRAP.md` (Step 5 heading, "synced from canonical / byte-identical / block future syncs", "Agents read CLAUDE.md at session start") and `CLAUDE_TEMPLATE.md` ("Project-Specific Methodology Adaptations", "Project-specific Learnings"). No invented names; destinations cited by name, not step number.
- Branched from `upstream/main`; the diff is exactly these three edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)