### PR TITLE
Resolve #16: generalize CONTEXT_TEMPLATE 'auto-memory' to agent-level memory

### DIFF
--- a/starter-kit/CONTEXT_TEMPLATE.md
+++ b/starter-kit/CONTEXT_TEMPLATE.md
@@ -52,18 +52,18 @@ Project-specific traps that have bitten previous sessions. Mirrors the methodolo
 
 ---
 
-## CONTEXT.md vs auto-memory: when to use which
+## CONTEXT.md vs agent-level memory: when to use which
 
-Methodology supports two complementary persistence layers. They are **additive**, not exclusive.
+Methodology supports two complementary persistence layers. They are **additive**, not exclusive. The second layer — *agent-level memory* — is persistence scoped to the agent across all projects rather than to one repository; agents implement it under different names (Claude Code's auto-memory, Cursor's memories, Cody's preferences), so this template names the capability generically.
 
-| Use **CONTEXT.md** for… | Use **auto-memory** for… |
+| Use **CONTEXT.md** for… | Use **agent-level memory** for… |
 |------------------------|--------------------------|
 | Domain vocabulary a fresh reader needs on a clean clone | Operator preferences and feedback that apply across all projects |
 | Decisions that should travel with the code under version control | Cross-project policy ("no AI coauthorship", "verify CI before close-out") |
 | Constraints that constrain *the project's* design (licensing, hardware, regulation) | The operator's role, expertise, and collaboration style |
 | Things a contributor should learn before opening a PR | Things the agent should remember across many sessions in many repos |
 
-**Practical rule:** if the artifact would be useful to a contributor who only opened *this* repo without operator context, it belongs in CONTEXT.md. If it is about how the operator works, or it applies across repos, it belongs in auto-memory.
+**Practical rule:** if the artifact would be useful to a contributor who only opened *this* repo without operator context, it belongs in CONTEXT.md. If it is about how the operator works, or it applies across repos, it belongs in agent-level memory.
 
 Some content (e.g., a project's licensing policy) reasonably lives in both layers — repeating it across the layers is a feature, not a duplication bug, because the two audiences are different.
 


### PR DESCRIPTION
Resolves #16.

`starter-kit/CONTEXT_TEMPLATE.md` (added in v2.6) named **auto-memory** — a Claude-Code-specific feature — in its "CONTEXT.md vs auto-memory" section. That contradicts the methodology's agent-independence positioning (`README.md`: *"works with any AI coding agent that supports persistent files and session-based interaction"*). Once the template lands in an adopter's repo, `auto-memory` becomes a phantom dependency on one agent.

## Change

Takes **option (a)** from the issue (generalize), with a touch of option (b) (keep a concrete example):

- Section retitled **"CONTEXT.md vs agent-level memory"**; table header and practical-rule prose follow.
- The conceptual contract is now *project-versioned vs agent-scoped persistence* — no named tool.
- One added sentence keeps concrete grounding by naming implementations as **examples**: Claude Code's auto-memory, Cursor's memories, Cody's preferences.

Scope: 1 file, 4 insertions / 4 deletions — within the issue's ≤10-line estimate.

## Verification

`grep -rni 'auto-memory'` across the repo confirms the only surviving tokens are:
- the **frozen** `docs/audits/2026-05-02-mattpocock-skills-evaluation.md` record (left verbatim by design, consistent with the issue #15 convention), and
- the one deliberate example in the new sentence.

No operative doc still hard-codes the Claude-Code-specific name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)