### PR TITLE
B1 Phase 3: expand bin/sync to the full Option-B corpus (shared bin/_manifest.py)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 dashboard.html
 tools/__pycache__/
+bin/__pycache__/

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ Each phase is gated. You cannot enter the next phase until the current one is co
 ../methodology/bin/sync your-project/ --source=github  # or: pull from GitHub (needs gh CLI)
 ```
 
-This copies `SESSION_RUNNER.md`, `SAFEGUARDS.md`, and `methodology_dashboard.py` into the target. See [`starter-kit/BOOTSTRAP.md`](starter-kit/BOOTSTRAP.md) for the difference between committed and ignored modes.
+This copies the full methodology corpus into the target: the operating files (`SESSION_RUNNER.md`, `SAFEGUARDS.md`, `RECOMMENDED_SKILLS.md`, `CONTEXT_TEMPLATE.md`, `CLAUDE_TEMPLATE.md`, `BOOTSTRAP.md`, `methodology_dashboard.py`) to the project root, and the framework (`ITERATIVE_METHODOLOGY.md`, `HOW_TO_USE.md`, `workstreams/`) to `docs/methodology/`. These are kept current on every run. `SESSION_NOTES.md`, `CHANGELOG.md`, and `ROADMAP.md` are *seeded* at the root only when absent — once they exist they are yours and `bin/sync` never overwrites them. See [`starter-kit/BOOTSTRAP.md`](starter-kit/BOOTSTRAP.md) for the difference between committed and ignored modes.
 
 **Option B — manual:**
 
-Copy `starter-kit/SESSION_RUNNER.md`, `starter-kit/SAFEGUARDS.md`, `starter-kit/SESSION_NOTES.md`, `starter-kit/CHANGELOG.md`, and `starter-kit/ROADMAP.md` to your project root. Copy the framework files (`ITERATIVE_METHODOLOGY.md`, `HOW_TO_USE.md`, `workstreams/`) to `docs/methodology/`.
+Copy the starter-kit root-files to your project root — `SESSION_RUNNER.md`, `SAFEGUARDS.md`, `RECOMMENDED_SKILLS.md`, `CONTEXT_TEMPLATE.md`, `CLAUDE_TEMPLATE.md`, `BOOTSTRAP.md`, `methodology_dashboard.py`, plus `SESSION_NOTES.md`, `CHANGELOG.md`, and `ROADMAP.md` as starting points you then own. Copy the framework files (`ITERATIVE_METHODOLOGY.md`, `HOW_TO_USE.md`) and `workstreams/` to `docs/methodology/`. (Option A's `bin/sync` does all of this in one command.)
 
 ### 2. Tell Claude to use it
 

--- a/bin/_manifest.py
+++ b/bin/_manifest.py
@@ -1,0 +1,70 @@
+"""Distribution manifest — the single source of truth for what the methodology
+ships into an adopter project, where each file lands, and how sync treats it.
+
+Imported by bin/sync, bin/check-links (and bin/status from Phase 4 on) so the
+mapping is defined exactly once (B1 plan Decision 5; Ousterhout deepening — the
+three scripts previously each carried their own copy of the file list).
+
+Each entry is ``(src, dest, disposition)``:
+  * ``src``         path relative to the canonical methodology repo root.
+  * ``dest``        path relative to the ADOPTER project root (README Option B
+                    layout: starter-kit root-files at the project root, the
+                    framework under docs/methodology/). Cross-references inside
+                    distributed files are authored for this layout — see
+                    bin/check-links and B1 plan section 4 ("link-topology paradox").
+  * ``disposition`` how sync reconciles the dest (see below).
+
+Dispositions:
+  TRACKED  canonical owns it; sync keeps it current and the existing
+           drift / --force / upgrade machinery applies. Overwrites toward
+           canonical (never silently clobbering unrecognized local edits).
+  SEED     adopter owns it after first creation; sync writes it ONLY when the
+           dest is absent and never overwrites it afterward (B1 plan Decision 2a).
+
+Adopter-owned *instances* (CONTEXT.md, CLAUDE.md, BACKLOG.md, …) are deliberately
+NOT listed: the template ships under a different name (CONTEXT_TEMPLATE.md →
+TRACKED), and the instance simply never appears as a dest, so it can never be a
+sync target — no special-case guard needed (B1 plan Decision 2).
+
+Python 3 stdlib only; data-only module (no imports, no side effects).
+"""
+
+TRACKED = "tracked"
+SEED = "seed"
+
+DISTRIBUTION = [
+    # starter-kit root-files -> adopter project root
+    ("starter-kit/SESSION_RUNNER.md", "SESSION_RUNNER.md", TRACKED),
+    ("starter-kit/SAFEGUARDS.md", "SAFEGUARDS.md", TRACKED),
+    ("starter-kit/RECOMMENDED_SKILLS.md", "RECOMMENDED_SKILLS.md", TRACKED),
+    ("starter-kit/CONTEXT_TEMPLATE.md", "CONTEXT_TEMPLATE.md", TRACKED),
+    ("starter-kit/CLAUDE_TEMPLATE.md", "CLAUDE_TEMPLATE.md", TRACKED),
+    ("starter-kit/BOOTSTRAP.md", "BOOTSTRAP.md", TRACKED),
+    ("starter-kit/methodology_dashboard.py", "methodology_dashboard.py", TRACKED),
+    # seed-once root-files: created if absent, then adopter-owned (never clobbered)
+    ("starter-kit/SESSION_NOTES.md", "SESSION_NOTES.md", SEED),
+    ("starter-kit/CHANGELOG.md", "CHANGELOG.md", SEED),
+    ("starter-kit/ROADMAP.md", "ROADMAP.md", SEED),
+    # framework docs -> docs/methodology/
+    ("ITERATIVE_METHODOLOGY.md", "docs/methodology/ITERATIVE_METHODOLOGY.md", TRACKED),
+    ("HOW_TO_USE.md", "docs/methodology/HOW_TO_USE.md", TRACKED),
+    # workstreams + campaigns + templates -> docs/methodology/workstreams/
+    ("workstreams/DESIGN_WORKSTREAM.md",
+     "docs/methodology/workstreams/DESIGN_WORKSTREAM.md", TRACKED),
+    ("workstreams/ARCHITECTURE_WORKSTREAM.md",
+     "docs/methodology/workstreams/ARCHITECTURE_WORKSTREAM.md", TRACKED),
+    ("workstreams/DEVELOPMENT_WORKSTREAM.md",
+     "docs/methodology/workstreams/DEVELOPMENT_WORKSTREAM.md", TRACKED),
+    ("workstreams/AUDIT_WORKSTREAM.md",
+     "docs/methodology/workstreams/AUDIT_WORKSTREAM.md", TRACKED),
+    ("workstreams/RESEARCH_DOCUMENTATION_WORKSTREAM.md",
+     "docs/methodology/workstreams/RESEARCH_DOCUMENTATION_WORKSTREAM.md", TRACKED),
+    ("workstreams/TEMPLATE_WORKSTREAM.md",
+     "docs/methodology/workstreams/TEMPLATE_WORKSTREAM.md", TRACKED),
+    ("workstreams/RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md",
+     "docs/methodology/workstreams/RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md", TRACKED),
+    ("workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md",
+     "docs/methodology/workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md", TRACKED),
+    ("workstreams/TEMPLATE_CAMPAIGN.md",
+     "docs/methodology/workstreams/TEMPLATE_CAMPAIGN.md", TRACKED),
+]

--- a/bin/check-links
+++ b/bin/check-links
@@ -60,11 +60,18 @@ def is_external(target):
     return target.startswith(("http://", "https://", "mailto:", "#"))
 
 
-def materialize(tree):
+def materialize_distribution(tree):
+    """Copy every distributed file to its adopter destination (simulated tree)."""
     for src, dest, _disp in DISTRIBUTION:
         dpath = os.path.join(tree, dest)
         os.makedirs(os.path.dirname(dpath) or tree, exist_ok=True)
         shutil.copyfile(os.path.join(REPO, src), dpath)
+
+
+def materialize_adopter_local(tree):
+    """Create the placeholder files an adopter owns (instances, overflow valves,
+    template placeholders) so links to them resolve. Left untouched if present —
+    safe to call on a real (e.g. sync-produced) tree."""
     for rel in ADOPTER_LOCAL_FILES:
         ppath = os.path.join(tree, rel)
         os.makedirs(os.path.dirname(ppath) or tree, exist_ok=True)
@@ -78,6 +85,11 @@ def check(tree):
     md_files = [(s, d) for s, d, _disp in DISTRIBUTION if d.endswith(".md")]
     for _src, dest in md_files:
         dpath = os.path.join(tree, dest)
+        if not os.path.exists(dpath):
+            # In --tree mode a distributed file may be absent if sync failed to
+            # write it; report rather than crash.
+            failures.append((dest, 0, "<distributed file missing from tree>"))
+            continue
         ddir = os.path.dirname(dpath)
         with open(dpath, encoding="utf-8") as fh:
             for lineno, line in enumerate(fh, 1):
@@ -103,16 +115,44 @@ def check(tree):
 
 
 def main():
-    tree = tempfile.mkdtemp(prefix="methodology-adopter-tree-")
-    try:
-        materialize(tree)
+    argv = sys.argv[1:]
+    if argv and argv[0] in ("-h", "--help"):
+        print("usage: check-links [--tree <adopter-project-dir>]\n"
+              "  (no args)      validate a freshly simulated adopter tree\n"
+              "  --tree <dir>   validate an existing tree, e.g. one bin/sync produced")
+        return 0
+
+    tree_arg = None
+    if argv:
+        if argv[0] == "--tree" and len(argv) == 2:
+            tree_arg = argv[1]
+        else:
+            print("usage: check-links [--tree <adopter-project-dir>]", file=sys.stderr)
+            return 2
+
+    if tree_arg:
+        # Validate a real, caller-owned tree (e.g. bin/sync output). The
+        # distribution is already present; only add the adopter-created
+        # placeholders, and never delete the caller's tree.
+        tree = os.path.abspath(tree_arg)
+        if not os.path.isdir(tree):
+            print("check-links: --tree path is not a directory: %s" % tree, file=sys.stderr)
+            return 2
+        materialize_adopter_local(tree)
         checked, failures, n_files = check(tree)
-    finally:
-        shutil.rmtree(tree, ignore_errors=True)
+        where = "the tree at %s" % tree
+    else:
+        tree = tempfile.mkdtemp(prefix="methodology-adopter-tree-")
+        try:
+            materialize_distribution(tree)
+            materialize_adopter_local(tree)
+            checked, failures, n_files = check(tree)
+        finally:
+            shutil.rmtree(tree, ignore_errors=True)
+        where = "the simulated adopter tree"
 
     if failures:
-        print("check-links: FAIL — %d dangling link(s) in the simulated "
-              "adopter tree:" % len(failures))
+        print("check-links: FAIL — %d dangling link(s) in %s:" % (len(failures), where))
         for dest, lineno, target in failures:
             print("  %s:%d  ->  %s" % (dest, lineno, target))
         print("\nDistributed files author cross-references for the ADOPTER "
@@ -120,7 +160,7 @@ def main():
         return 1
 
     print("check-links: OK — %d relative link(s) across %d distributed markdown "
-          "files resolve in the simulated adopter tree." % (checked, n_files))
+          "files resolve in %s." % (checked, n_files, where))
     return 0
 
 

--- a/bin/check-links
+++ b/bin/check-links
@@ -12,12 +12,9 @@ materializes a simulated adopter tree (each distributable copied to its adopter
 destination, plus the files an adopter creates locally) and asserts every
 relative link in every distributed markdown file resolves to an existing file.
 
-Part of B1 / issue #32, Phase 2 (link reconciliation).
-
-NOTE (Phase 2 -> Phase 3 hand-off): the DISTRIBUTION mapping below is inlined
-here for Phase 2. Phase 3 extracts it to bin/_manifest.py as the single source of
-truth shared with bin/sync and bin/status (plan Decision 5). Until then, keep the
-two in sync.
+Part of B1 / issue #32 (Phase 2 added this checker; Phase 3 moved the
+DISTRIBUTION map to bin/_manifest.py — the single source of truth now shared with
+bin/sync, plan Decision 5).
 
 Usage:  ./bin/check-links            # run from anywhere
 Exit:   0 = all relative links resolve; 1 = one or more dangling links.
@@ -29,43 +26,10 @@ import shutil
 import sys
 import tempfile
 
-REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from _manifest import DISTRIBUTION  # noqa: E402  (bin/ is on sys.path above)
 
-# (source path relative to canonical repo root, destination relative to adopter
-# project root). Mirrors README Option B plus the two files B1 gives a home
-# (RECOMMENDED_SKILLS.md, CONTEXT_TEMPLATE.md -> adopter root, plan Decision 1).
-DISTRIBUTION = [
-    ("starter-kit/SESSION_RUNNER.md", "SESSION_RUNNER.md"),
-    ("starter-kit/SAFEGUARDS.md", "SAFEGUARDS.md"),
-    ("starter-kit/RECOMMENDED_SKILLS.md", "RECOMMENDED_SKILLS.md"),
-    ("starter-kit/CONTEXT_TEMPLATE.md", "CONTEXT_TEMPLATE.md"),
-    ("starter-kit/CLAUDE_TEMPLATE.md", "CLAUDE_TEMPLATE.md"),
-    ("starter-kit/SESSION_NOTES.md", "SESSION_NOTES.md"),
-    ("starter-kit/CHANGELOG.md", "CHANGELOG.md"),
-    ("starter-kit/ROADMAP.md", "ROADMAP.md"),
-    ("starter-kit/BOOTSTRAP.md", "BOOTSTRAP.md"),
-    ("starter-kit/methodology_dashboard.py", "methodology_dashboard.py"),
-    ("ITERATIVE_METHODOLOGY.md", "docs/methodology/ITERATIVE_METHODOLOGY.md"),
-    ("HOW_TO_USE.md", "docs/methodology/HOW_TO_USE.md"),
-    ("workstreams/DESIGN_WORKSTREAM.md",
-     "docs/methodology/workstreams/DESIGN_WORKSTREAM.md"),
-    ("workstreams/ARCHITECTURE_WORKSTREAM.md",
-     "docs/methodology/workstreams/ARCHITECTURE_WORKSTREAM.md"),
-    ("workstreams/DEVELOPMENT_WORKSTREAM.md",
-     "docs/methodology/workstreams/DEVELOPMENT_WORKSTREAM.md"),
-    ("workstreams/AUDIT_WORKSTREAM.md",
-     "docs/methodology/workstreams/AUDIT_WORKSTREAM.md"),
-    ("workstreams/RESEARCH_DOCUMENTATION_WORKSTREAM.md",
-     "docs/methodology/workstreams/RESEARCH_DOCUMENTATION_WORKSTREAM.md"),
-    ("workstreams/TEMPLATE_WORKSTREAM.md",
-     "docs/methodology/workstreams/TEMPLATE_WORKSTREAM.md"),
-    ("workstreams/RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md",
-     "docs/methodology/workstreams/RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md"),
-    ("workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md",
-     "docs/methodology/workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md"),
-    ("workstreams/TEMPLATE_CAMPAIGN.md",
-     "docs/methodology/workstreams/TEMPLATE_CAMPAIGN.md"),
-]
+REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Legitimate link targets that are NOT part of the distribution: files an adopter
 # creates locally (instances / overflow valves) and intentional template
@@ -97,7 +61,7 @@ def is_external(target):
 
 
 def materialize(tree):
-    for src, dest in DISTRIBUTION:
+    for src, dest, _disp in DISTRIBUTION:
         dpath = os.path.join(tree, dest)
         os.makedirs(os.path.dirname(dpath) or tree, exist_ok=True)
         shutil.copyfile(os.path.join(REPO, src), dpath)
@@ -111,7 +75,7 @@ def materialize(tree):
 def check(tree):
     failures = []
     checked = 0
-    md_files = [(s, d) for s, d in DISTRIBUTION if d.endswith(".md")]
+    md_files = [(s, d) for s, d, _disp in DISTRIBUTION if d.endswith(".md")]
     for _src, dest in md_files:
         dpath = os.path.join(tree, dest)
         ddir = os.path.dirname(dpath)

--- a/bin/sync
+++ b/bin/sync
@@ -11,9 +11,15 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _manifest import DISTRIBUTION, TRACKED, SEED  # noqa: E402  (bin/ on sys.path)
+
 REPO = "KJ5HST/methodology"
-SYNC_FILES = ("SESSION_RUNNER.md", "SAFEGUARDS.md", "methodology_dashboard.py")
-IGNORE_ENTRIES = tuple(f"/{name}" for name in SYNC_FILES)
+# Only TRACKED dests are gitignored (ignore mode) and checked for accidental git
+# tracking. SEED files become adopter-owned after first creation and are meant to
+# be committed, so they are deliberately excluded from both.
+TRACKED_DESTS = tuple(dest for _src, dest, disp in DISTRIBUTION if disp == TRACKED)
+IGNORE_ENTRIES = tuple(f"/{dest}" for dest in TRACKED_DESTS)
 
 
 def script_methodology_root() -> Path:
@@ -42,13 +48,13 @@ def blob_sha(content: bytes) -> str:
     return hashlib.sha1(header + content).hexdigest()
 
 
-def read_local(methodology_root: Path, name: str) -> bytes:
-    return (methodology_root / "starter-kit" / name).read_bytes()
+def read_local(methodology_root: Path, src: str) -> bytes:
+    return (methodology_root / src).read_bytes()
 
 
-def local_history_blobs(methodology_root: Path, name: str) -> set:
+def local_history_blobs(methodology_root: Path, src: str) -> set:
     """Set of blob SHAs this file has had across methodology git history."""
-    path = f"starter-kit/{name}"
+    path = src
     try:
         log = subprocess.run(
             ["git", "-C", str(methodology_root), "log", "--format=%H", "--", path],
@@ -71,16 +77,16 @@ def local_history_blobs(methodology_root: Path, name: str) -> set:
     return blobs
 
 
-def read_github(name: str) -> bytes:
+def read_github(src: str) -> bytes:
     try:
         result = subprocess.run(
-            ["gh", "api", f"repos/{REPO}/contents/starter-kit/{name}"],
+            ["gh", "api", f"repos/{REPO}/contents/{src}"],
             capture_output=True, text=True, check=True,
         )
     except FileNotFoundError:
         sys.exit("error: gh CLI not found; install GitHub CLI or use --source=local")
     except subprocess.CalledProcessError as e:
-        sys.exit(f"error: gh api failed for {name}: {e.stderr.strip() or e.stdout.strip()}\n"
+        sys.exit(f"error: gh api failed for {src}: {e.stderr.strip() or e.stdout.strip()}\n"
                  f"hint: run `gh auth login` or use --source=local")
     payload = json.loads(result.stdout)
     return base64.b64decode(payload["content"])
@@ -128,7 +134,7 @@ def ensure_gitignore_entries(project: Path, dry_run: bool) -> list:
 def currently_tracked(project: Path) -> list:
     try:
         out = subprocess.run(
-            ["git", "-C", str(project), "ls-files", "--error-unmatch", "--", *SYNC_FILES],
+            ["git", "-C", str(project), "ls-files", "--error-unmatch", "--", *TRACKED_DESTS],
             capture_output=True, text=True, check=False,
         )
     except FileNotFoundError:
@@ -148,14 +154,31 @@ def classify_target(target: Path, canonical_content: bytes, history_blobs: set) 
     return "modified"
 
 
-def sync_file(project: Path, name: str, content: bytes, dry_run: bool) -> str:
-    target = project / name
+def sync_file(project: Path, dest: str, content: bytes, dry_run: bool) -> str:
+    target = project / dest
     if target.exists() and target.read_bytes() == content:
         return "unchanged"
     action = "would write" if dry_run else ("updated" if target.exists() else "created")
     if not dry_run:
+        target.parent.mkdir(parents=True, exist_ok=True)
         target.write_bytes(content)
-        if name.endswith(".py"):
+        if dest.endswith(".py"):
+            mode = target.stat().st_mode
+            target.chmod(mode | 0o111)
+    return action
+
+
+def seed_file(project: Path, dest: str, content: bytes, dry_run: bool) -> str:
+    """SEED disposition: write only when the dest is absent; never overwrite an
+    existing file, even with --force (Decision 2a; SEED-ONCE-clobber dragon)."""
+    target = project / dest
+    if target.exists():
+        return "present (seed; left as-is)"
+    action = "would create" if dry_run else "created"
+    if not dry_run:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(content)
+        if dest.endswith(".py"):
             mode = target.stat().st_mode
             target.chmod(mode | 0o111)
     return action
@@ -190,25 +213,28 @@ def main() -> int:
     if args.dry_run:
         print("  (dry-run: no changes will be written)")
 
-    contents = {}
-    classifications = {}
-    for name in SYNC_FILES:
-        if source == "local":
-            content = read_local(methodology_root, name)
-            history = local_history_blobs(methodology_root, name)
-        else:
-            content = read_github(name)
-            history = set()  # history walk not implemented for github source
-        contents[name] = content
-        classifications[name] = classify_target(project / name, content, history)
+    entries = []  # (src, dest, disposition, content, classification)
+    for src, dest, disp in DISTRIBUTION:
+        content = read_local(methodology_root, src) if source == "local" else read_github(src)
+        target = project / dest
+        if disp == SEED:
+            # SEED files are adopter-owned; classification is only present/missing.
+            cls = "present" if target.exists() else "missing"
+        else:  # TRACKED
+            history = local_history_blobs(methodology_root, src) if source == "local" else set()
+            cls = classify_target(target, content, history)
+        entries.append((src, dest, disp, content, cls))
 
-    blocked = [name for name, cls in classifications.items() if cls == "modified"]
+    # Only TRACKED files can block: SEED files are never overwritten, so they
+    # cannot be "modified" in the drift sense.
+    blocked = [(src, dest) for src, dest, disp, _content, cls in entries
+               if disp == TRACKED and cls == "modified"]
     if blocked and not args.force:
         print("")
         print("  ERROR: the following files have local modifications that don't match")
         print("  any canonical or historical version and would be overwritten:")
-        for name in blocked:
-            print(f"    {name}")
+        for _src, dest in blocked:
+            print(f"    {dest}")
         print("")
         print("  The recommended pattern (see plan §3.2) is to move per-project")
         print("  customizations into CLAUDE.md's 'Project-Specific Methodology")
@@ -216,19 +242,22 @@ def main() -> int:
         print("")
         print("  To proceed anyway and overwrite local changes, pass --force.")
         print("  To inspect the drift first:")
-        for name in blocked:
+        for src, dest in blocked:
             if source == "local":
-                print(f"    diff {project / name} {methodology_root / 'starter-kit' / name}")
+                print(f"    diff {project / dest} {methodology_root / src}")
         return 2
 
     file_results = []
-    for name in SYNC_FILES:
-        result = sync_file(project, name, contents[name], args.dry_run)
-        file_results.append((name, result))
+    for src, dest, disp, content, _cls in entries:
+        if disp == SEED:
+            result = seed_file(project, dest, content, args.dry_run)
+        else:
+            result = sync_file(project, dest, content, args.dry_run)
+        file_results.append((dest, result))
 
     print("  files:")
-    for name, result in file_results:
-        print(f"    {name}: {result}")
+    for dest, result in file_results:
+        print(f"    {dest}: {result}")
 
     if mode == "ignore":
         added = ensure_gitignore_entries(project, args.dry_run)

--- a/bin/tests.sh
+++ b/bin/tests.sh
@@ -131,6 +131,55 @@ else
     fail "check-links: dangling link(s) in adopter layout (see above)"
 fi
 
+echo "== Test 11: sync produces the full manifest tree (faithful, per-file) =="
+P="$(mktemp_project)"
+"$BIN/sync" "$P" --mode=commit >/dev/null
+MANIFEST_OK=1
+COUNT=0
+while IFS='|' read -r src dest disp; do
+    [ -z "$dest" ] && continue
+    COUNT=$((COUNT+1))
+    if [ ! -f "$P/$dest" ]; then MANIFEST_OK=0; echo "    MISSING: $dest"; continue; fi
+    if [ "$disp" = "tracked" ]; then
+        diff -q "$P/$dest" "$METHODOLOGY/$src" >/dev/null || { MANIFEST_OK=0; echo "    DRIFT: $dest"; }
+    fi
+done < <(python3 -c "import sys; sys.path.insert(0, '$BIN'); import _manifest; [print('%s|%s|%s' % (s, d, x)) for s, d, x in _manifest.DISTRIBUTION]")
+[ "$MANIFEST_OK" = "1" ] && pass "all $COUNT manifest files present; tracked files match canonical" || fail "manifest tree incomplete/drifted"
+# subdir dest spot-check (the multi-dir tree, not just root files)
+[ -f "$P/docs/methodology/ITERATIVE_METHODOLOGY.md" ] && pass "framework doc landed under docs/methodology/" || fail "docs/methodology/ doc missing"
+[ -f "$P/docs/methodology/workstreams/AUDIT_WORKSTREAM.md" ] && pass "workstream landed under docs/methodology/workstreams/" || fail "workstreams/ doc missing"
+rm -rf "$P"
+
+echo "== Test 12: seed files created once, never clobbered (even --force) =="
+P="$(mktemp_project)"
+"$BIN/sync" "$P" >/dev/null
+[ -f "$P/SESSION_NOTES.md" ] && pass "seed SESSION_NOTES created when absent" || fail "seed not created"
+echo "ADOPTER LOG ENTRY" > "$P/SESSION_NOTES.md"
+"$BIN/sync" "$P" >/dev/null
+grep -q "ADOPTER LOG ENTRY" "$P/SESSION_NOTES.md" && pass "seed not overwritten on normal sync" || fail "seed overwritten on sync"
+"$BIN/sync" "$P" --force >/dev/null
+grep -q "ADOPTER LOG ENTRY" "$P/SESSION_NOTES.md" && pass "seed not overwritten even with --force" || fail "seed overwritten by --force"
+rm -rf "$P"
+
+echo "== Test 13: adopter-owned instances are never sync targets =="
+P="$(mktemp_project)"
+"$BIN/sync" "$P" >/dev/null
+[ ! -f "$P/CONTEXT.md" ] && pass "sync did not create instance CONTEXT.md" || fail "sync created instance CONTEXT.md"
+[ ! -f "$P/CLAUDE.md" ] && pass "sync did not create instance CLAUDE.md" || fail "sync created instance CLAUDE.md"
+[ -f "$P/CONTEXT_TEMPLATE.md" ] && pass "template CONTEXT_TEMPLATE.md is present" || fail "template CONTEXT_TEMPLATE.md missing"
+rm -rf "$P"
+
+echo "== Test 14: check-links passes against the sync-produced tree =="
+P="$(mktemp_project)"
+"$BIN/sync" "$P" >/dev/null
+if "$BIN/check-links" --tree "$P" >/dev/null 2>&1; then
+    pass "check-links --tree: links resolve in the sync-produced tree"
+else
+    "$BIN/check-links" --tree "$P" 2>&1 | sed 's/^/    /'
+    fail "check-links --tree: dangling link(s) in sync-produced tree"
+fi
+rm -rf "$P"
+
 echo ""
 echo "== Summary: $PASS passed, $FAIL failed =="
 [ "$FAIL" = "0" ]

--- a/starter-kit/BOOTSTRAP.md
+++ b/starter-kit/BOOTSTRAP.md
@@ -35,7 +35,7 @@ your-projects/                        <-- parent directory (portfolio level)
 
 ## Two adoption modes
 
-The methodology supports two ways to keep synced files (`SESSION_RUNNER.md`, `SAFEGUARDS.md`, `methodology_dashboard.py`) in your project:
+The methodology supports two ways to keep the synced files current in your project (`bin/sync` distributes the full corpus — the operating files at your project root and the framework under `docs/methodology/`; see the next section for the complete list):
 
 | Mode | What it means | Best for |
 |------|---------------|----------|
@@ -64,7 +64,7 @@ If you have a local `methodology/` checkout (sibling to your projects), use the 
 ../methodology/bin/sync your-project/ --source=github
 ```
 
-`bin/sync` copies `SESSION_RUNNER.md`, `SAFEGUARDS.md`, and `methodology_dashboard.py` into the target. In `--mode=ignore` it also adds `.gitignore` entries and warns (non-destructively) if any of those files are currently tracked by git.
+`bin/sync` copies the full methodology corpus into the target: the operating files (`SESSION_RUNNER.md`, `SAFEGUARDS.md`, `RECOMMENDED_SKILLS.md`, `CONTEXT_TEMPLATE.md`, `CLAUDE_TEMPLATE.md`, `BOOTSTRAP.md`, `methodology_dashboard.py`) at the project root and the framework (`ITERATIVE_METHODOLOGY.md`, `HOW_TO_USE.md`, `workstreams/`) under `docs/methodology/`, creating subdirectories as needed. `SESSION_NOTES.md`, `CHANGELOG.md`, and `ROADMAP.md` are *seeded* at the root only when absent and are never overwritten afterward — once created they are yours to edit. The complete mapping is defined once in `bin/_manifest.py`. In `--mode=ignore` it also adds `.gitignore` entries for the tracked files (not the seeded ones, which you commit) and warns (non-destructively) if any tracked file is currently tracked by git.
 
 **Drift safety:** `bin/sync` refuses to overwrite a file that has local modifications not matching canonical or any historical version. The recommended pattern is to move per-project customizations into your CLAUDE.md's "Project-Specific Methodology Adaptations" section (see Step 5), then run sync. If you really need to discard local edits, pass `--force`.
 
@@ -99,6 +99,8 @@ From the methodology `starter-kit/` directory:
 | `CHANGELOG.md` | Completed work history — add entries as work is finished |
 | `ROADMAP.md` | Feature inventory and future plans — what's built, what's next |
 | `methodology_dashboard.py` | Health scanner — scores project health and methodology compliance |
+
+This table is the minimum manual set. The **authoritative, complete distribution list** — which also includes `RECOMMENDED_SKILLS.md` and the `CONTEXT_TEMPLATE.md`/`CLAUDE_TEMPLATE.md` templates at the project root, plus the framework under `docs/methodology/` — is defined once in `bin/_manifest.py` and applied by `bin/sync`. Copy those too for the full set; the templates are renamed to `CONTEXT.md`/`CLAUDE.md` (see Step 5).
 
 Run the dashboard once to generate your first report:
 


### PR DESCRIPTION
**Part of #32** (B1 sync-coverage expansion). Phase 3 of 4 — not `Closes`, because Phase 4 (`bin/status` per-file rows) still remains.

## What this does
Expands `bin/sync` from the legacy 3-file scope to the full Option-B corpus (21 files) and introduces a single shared source of truth for the distribution mapping.

### Changes (7 files)
- **`bin/_manifest.py`** *(new, data-only)* — `DISTRIBUTION = [(src, dest, disposition), …]`, 21 entries (18 `tracked`, 3 `seed`); the single source of truth (plan Decision 5). Imported by `bin/sync` and `bin/check-links`.
- **`bin/sync`** — iterates `DISTRIBUTION`; honors dest subdirs (`mkdir -p`); new `seed_file` (write-if-absent, never overwrites — even with `--force`); IGNORE/tracking restricted to `tracked` dests so seed files stay committable. Produces an idempotent 21-file tree.
- **`bin/check-links`** — imports `DISTRIBUTION` (no longer inlined); new `--tree <dir>` mode validates a real, sync-produced tree, not only the simulated one.
- **`bin/tests.sh`** — +4 tests (T11 faithful per-file manifest incl. subdir spot-checks; T12 seed created-once / never-clobbered incl. `--force`; T13 instances never targets; T14 `check-links --tree` on sync output).
- **`README.md` / `starter-kit/BOOTSTRAP.md`** — scope claims updated to the full corpus + seed semantics; BOOTSTRAP points at `bin/_manifest.py` as the authoritative list.
- **`.gitignore`** — ignore `bin/__pycache__/` (Phase 3 makes `bin/` importable via `bin/_manifest.py`, the same situation as v2.6.1's `tools/__pycache__/`).

### Known interim (intentional; resolved in Phase 4)
`bin/sync` now distributes 21 files, but `bin/status` still reports the legacy 3 until Phase 4 imports the shared manifest. Half the false-confidence gap remains — accepted per the plan, since `sync` coverage and `status` reporting are separate capabilities (bundling them would be FM #26).

### Verification
- `./bin/tests.sh` → **39 passed / 0 failed**
- Phase-3-only diff vs `main` = **7 files**
- Rebased cleanly onto current `main` (Phase 2 / #33 already merged)

No CI on this repo and the fork lacks merge rights → operator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
