### PR TITLE
B1 Phase 4: expand bin/status to per-file rows over the shared manifest

### DIFF
--- a/bin/_manifest.py
+++ b/bin/_manifest.py
@@ -1,9 +1,9 @@
 """Distribution manifest — the single source of truth for what the methodology
 ships into an adopter project, where each file lands, and how sync treats it.
 
-Imported by bin/sync, bin/check-links (and bin/status from Phase 4 on) so the
-mapping is defined exactly once (B1 plan Decision 5; Ousterhout deepening — the
-three scripts previously each carried their own copy of the file list).
+Imported by bin/sync, bin/status, and bin/check-links so the mapping is defined
+exactly once (B1 plan Decision 5; Ousterhout deepening — the three scripts
+previously each carried their own copy of the file list).
 
 Each entry is ``(src, dest, disposition)``:
   * ``src``         path relative to the canonical methodology repo root.

--- a/bin/status
+++ b/bin/status
@@ -1,7 +1,17 @@
 #!/usr/bin/env python3
 """Report drift of synced methodology files across one or more projects.
 
-Contract: methodology v2.2 plan §4E.
+Emits one row per distributed file (Project · File · Disposition · Status) so the
+full Option-B corpus is visible, not just a fixed three. The distribution set and
+each file's disposition come from the shared bin/_manifest.py (B1 plan Decision 5);
+status previously carried its own three-file copy of the list.
+
+SEED files are adopter-owned: status reports only present/absent for them and never
+flags an absent seed as drift (B1 plan Phase 4 DONE criterion). TRACKED files are
+compared against canonical and may report current / locally modified / N versions
+behind / missing.
+
+Contract: methodology v2.2 plan §4E; B1 plan Phase 4.
 """
 import argparse
 import base64
@@ -11,10 +21,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _manifest import DISTRIBUTION, TRACKED  # noqa: E402  (bin/ on sys.path)
+
 REPO = "KJ5HST/methodology"
-SYNC_FILES = ("SESSION_RUNNER.md", "SAFEGUARDS.md", "methodology_dashboard.py")
-IGNORE_ENTRIES = tuple(f"/{name}" for name in SYNC_FILES)
-COLUMNS = ("SESSION_RUNNER", "SAFEGUARDS", "DASHBOARD")
+HEADERS = ("Project", "File", "Disposition", "Status")
 
 
 def script_methodology_root() -> Path:
@@ -26,40 +37,29 @@ def blob_sha(content: bytes) -> str:
     return hashlib.sha1(header + content).hexdigest()
 
 
-def detect_mode(project: Path) -> str:
-    gitignore = project / ".gitignore"
-    if not gitignore.exists():
-        return "committed"
-    existing = set(line.strip() for line in gitignore.read_text().splitlines())
-    if any(entry in existing for entry in IGNORE_ENTRIES):
-        return "ignored"
-    return "committed"
-
-
 def detect_source(methodology_root: Path) -> str:
     return "local" if (methodology_root / "starter-kit").is_dir() else "github"
 
 
-def local_canonical_sha(methodology_root: Path, name: str) -> str:
-    content = (methodology_root / "starter-kit" / name).read_bytes()
+def local_canonical_sha(methodology_root: Path, src: str) -> str:
+    content = (methodology_root / src).read_bytes()
     return blob_sha(content)
 
 
-def local_history(methodology_root: Path, name: str) -> list:
+def local_history(methodology_root: Path, src: str) -> list:
     """List of (commit_sha, blob_sha) for the file, newest first."""
-    path = f"starter-kit/{name}"
     try:
         log = subprocess.run(
-            ["git", "-C", str(methodology_root), "log", "--format=%H", "--", path],
+            ["git", "-C", str(methodology_root), "log", "--format=%H", "--", src],
             capture_output=True, text=True, check=True,
         ).stdout.strip().splitlines()
-    except subprocess.CalledProcessError:
+    except (FileNotFoundError, subprocess.CalledProcessError):
         return []
     history = []
     for commit in log:
         try:
             tree = subprocess.run(
-                ["git", "-C", str(methodology_root), "ls-tree", commit, "--", path],
+                ["git", "-C", str(methodology_root), "ls-tree", commit, "--", src],
                 capture_output=True, text=True, check=True,
             ).stdout.strip()
         except subprocess.CalledProcessError:
@@ -71,22 +71,23 @@ def local_history(methodology_root: Path, name: str) -> list:
     return history
 
 
-def github_canonical(name: str):
+def github_canonical(src: str):
     try:
         result = subprocess.run(
-            ["gh", "api", f"repos/{REPO}/contents/starter-kit/{name}"],
+            ["gh", "api", f"repos/{REPO}/contents/{src}"],
             capture_output=True, text=True, check=True,
         )
     except FileNotFoundError:
         sys.exit("error: gh CLI not found; install GitHub CLI or use --source=local")
     except subprocess.CalledProcessError as e:
-        sys.exit(f"error: gh api failed for {name}: {e.stderr.strip() or e.stdout.strip()}")
+        sys.exit(f"error: gh api failed for {src}: {e.stderr.strip() or e.stdout.strip()}")
     payload = json.loads(result.stdout)
     return payload["sha"], base64.b64decode(payload["content"])
 
 
-def file_status(project: Path, name: str, canonical_sha: str, history: list) -> str:
-    target = project / name
+def file_status(project: Path, dest: str, canonical_sha: str, history: list) -> str:
+    """Drift state of a TRACKED dest against canonical (and methodology history)."""
+    target = project / dest
     if not target.exists():
         return "missing"
     project_sha = blob_sha(target.read_bytes())
@@ -99,18 +100,20 @@ def file_status(project: Path, name: str, canonical_sha: str, history: list) -> 
     return "locally modified"
 
 
-def render_table(rows: list) -> str:
-    headers = ("Project", "Mode") + COLUMNS
+def seed_status(project: Path, dest: str) -> str:
+    """SEED files are adopter-owned; only existence matters and an absent seed is
+    NOT drift (B1 plan Phase 4 DONE criterion)."""
+    return "present" if (project / dest).exists() else "absent"
+
+
+def render_table(headers: tuple, rows: list) -> str:
     widths = [len(h) for h in headers]
     for row in rows:
         for i, cell in enumerate(row):
             widths[i] = max(widths[i], len(cell))
     def fmt(row):
-        return "  ".join(cell.ljust(widths[i]) for i, cell in enumerate(row))
-    out = [fmt(headers)]
-    for row in rows:
-        out.append(fmt(row))
-    return "\n".join(out)
+        return "  ".join(str(cell).ljust(widths[i]) for i, cell in enumerate(row))
+    return "\n".join([fmt(headers)] + [fmt(row) for row in rows])
 
 
 def main() -> int:
@@ -121,35 +124,39 @@ def main() -> int:
 
     methodology_root = script_methodology_root()
     source = args.source or detect_source(methodology_root)
+    if source == "local" and not (methodology_root / "starter-kit").is_dir():
+        sys.exit(f"error: --source=local but no starter-kit/ at {methodology_root}")
 
+    # Canonical SHA + history are only meaningful for TRACKED files; SEED files are
+    # adopter-owned and never compared against canonical.
     canonical = {}
-    history = {name: [] for name in SYNC_FILES}
-    if source == "local":
-        if not (methodology_root / "starter-kit").is_dir():
-            sys.exit(f"error: --source=local but no starter-kit/ at {methodology_root}")
-        for name in SYNC_FILES:
-            canonical[name] = local_canonical_sha(methodology_root, name)
-            history[name] = local_history(methodology_root, name)
-    else:
-        for name in SYNC_FILES:
-            sha, _ = github_canonical(name)
-            canonical[name] = sha
-            # history-walk not implemented for github source
+    history = {}
+    for src, _dest, disp in DISTRIBUTION:
+        if disp != TRACKED:
+            continue
+        if source == "local":
+            canonical[src] = local_canonical_sha(methodology_root, src)
+            history[src] = local_history(methodology_root, src)
+        else:
+            sha, _ = github_canonical(src)
+            canonical[src] = sha
+            history[src] = []  # history-walk not implemented for github source
 
     rows = []
     for raw in args.paths:
         project = Path(raw).resolve()
         if not project.is_dir():
-            rows.append((raw, "missing-dir", "-", "-", "-"))
+            rows.append((raw, "-", "-", "missing-dir"))
             continue
-        mode = detect_mode(project)
-        cells = [project.name, mode]
-        for name in SYNC_FILES:
-            cells.append(file_status(project, name, canonical[name], history[name]))
-        rows.append(tuple(cells))
+        for src, dest, disp in DISTRIBUTION:
+            if disp == TRACKED:
+                state = file_status(project, dest, canonical[src], history[src])
+            else:  # SEED
+                state = seed_status(project, dest)
+            rows.append((project.name, dest, disp, state))
 
     print(f"source: {source}" + (f" ({methodology_root})" if source == "local" else ""))
-    print(render_table(rows))
+    print(render_table(HEADERS, rows))
     return 0
 
 

--- a/bin/tests.sh
+++ b/bin/tests.sh
@@ -180,6 +180,42 @@ else
 fi
 rm -rf "$P"
 
+echo "== Test 15: status emits per-file rows with a disposition column (Phase 4) =="
+P="$(mktemp_project)"
+"$BIN/sync" "$P" --mode=commit >/dev/null
+OUT="$("$BIN/status" "$P")"
+echo "$OUT" | grep -q "Disposition" && pass "status: Disposition column present" || fail "status: no Disposition column"
+echo "$OUT" | grep -q "tracked" && pass "status: tracked disposition shown" || fail "status: no tracked rows"
+echo "$OUT" | grep -q "seed" && pass "status: seed disposition shown" || fail "status: no seed rows"
+# One data row per manifest entry (full Option-B corpus, not a fixed three)
+EXPECTED="$(python3 -c "import sys; sys.path.insert(0, '$BIN'); import _manifest; print(len(_manifest.DISTRIBUTION))")"
+GOT="$(echo "$OUT" | grep -c "$(basename "$P")")"
+[ "$GOT" = "$EXPECTED" ] && pass "status: one row per manifest file ($GOT == $EXPECTED)" || fail "status: row count $GOT != manifest $EXPECTED"
+# Freshly-synced tree: every tracked file current, nothing flagged as drift
+echo "$OUT" | grep -q "current" && pass "status: fresh tree shows current" || fail "status: fresh tree missing current"
+if echo "$OUT" | grep -Eq "locally modified|versions? behind"; then fail "status: fresh tree shows spurious drift"; else pass "status: fresh tree shows no drift"; fi
+rm -rf "$P"
+
+echo "== Test 16: an absent seed file is reported, never flagged as drift (Phase 4 DONE) =="
+P="$(mktemp_project)"
+"$BIN/sync" "$P" >/dev/null
+rm -f "$P/CHANGELOG.md"   # CHANGELOG.md is a SEED file (adopter-owned)
+SEEDLINE="$("$BIN/status" "$P" | grep "CHANGELOG.md")"
+echo "$SEEDLINE" | grep -q "seed" && pass "status: CHANGELOG shown with seed disposition" || fail "status: CHANGELOG not marked seed"
+echo "$SEEDLINE" | grep -q "absent" && pass "status: absent seed shown as 'absent'" || fail "status: absent seed not 'absent'"
+if echo "$SEEDLINE" | grep -q "missing"; then fail "status: absent seed mislabeled as drift (missing)"; else pass "status: absent seed NOT flagged as drift"; fi
+rm -rf "$P"
+
+echo "== Test 17: a partially-stale tree flags only the stale file (Phase 4) =="
+P="$(mktemp_project)"
+"$BIN/sync" "$P" >/dev/null
+echo "# local edit" >> "$P/SESSION_RUNNER.md"
+OUT="$("$BIN/status" "$P")"
+NMOD="$(echo "$OUT" | grep -c "locally modified")"
+[ "$NMOD" = "1" ] && pass "status: exactly one file locally modified" || fail "status: expected 1 modified, got $NMOD"
+echo "$OUT" | grep "SESSION_RUNNER.md" | grep -q "locally modified" && pass "status: the stale file is SESSION_RUNNER" || fail "status: wrong file flagged stale"
+rm -rf "$P"
+
 echo ""
 echo "== Summary: $PASS passed, $FAIL failed =="
 [ "$FAIL" = "0" ]


### PR DESCRIPTION
**Closes #32.** Final phase of B1 (Phase 2 = #33, Phase 3 = #34, both merged). Plan: [`docs/planning/b1-sync-coverage-expansion-plan.md`](https://github.com/rmsharp/methodology/blob/main/docs/planning/b1-sync-coverage-expansion-plan.md) §6 Phase 4.

## Problem

`bin/status` inspected only the same three files `bin/sync` used to touch, so it reported `current` while adopters silently fell behind on every framework doc outside that set — the **false confidence** issue #32 targets. Phases 2–3 expanded the manifest and `bin/sync`; this phase makes `bin/status` report against the full Option-B corpus.

## What changed

- **Per-file rows.** The fixed three-column table (`SESSION_RUNNER · SAFEGUARDS · DASHBOARD`) becomes one row per distributed file: `Project · File · Disposition · Status` (plan Decision 4). The old per-project `Mode` column is dropped — it's a per-project attribute that would repeat down every file row, and the ratified 4-column layout omits it.
- **Single source of truth.** `bin/status` now imports `DISTRIBUTION`/`TRACKED` from `bin/_manifest.py` (Decision 5) and drops its own `SYNC_FILES`/`COLUMNS`/`detect_mode` copies. All three scripts (`sync`, `status`, `check-links`) now read one manifest.
- **SEED ≠ drift.** SEED files are adopter-owned, so status reports `present`/`absent` only and never compares them against canonical. An absent seed reads `absent`, **not** flagged as drift (Phase 4 DONE criterion). TRACKED files reuse the existing `current` / `locally modified` / `N versions behind` / `missing` logic unchanged.
- **Latent `--source=github` fix.** The canonical fetch hardcoded `starter-kit/{name}`, which 404s on the framework docs and `workstreams/` now in scope. Now uses the full manifest `src` path, mirroring `bin/sync`'s `read_github`. The three-file set never exposed this; expanding scope did.

## Verification

- `./bin/tests.sh` → **50 passed, 0 failed** (was 39). New Tests 15–17 cover: per-file rows + disposition column, one row per manifest entry, fresh tree shows no drift, **absent seed is not flagged as drift**, and a partially-stale tree isolates only the stale file. Tests 1–14 unchanged.
- Manual `--source=local` on a fresh tree → all 21 files `current`/`present`; on a partially-stale tree → `SESSION_RUNNER`=`locally modified`, `AUDIT_WORKSTREAM`=`1 version behind`, absent seed `ROADMAP`=`absent`, everything else `current`.
- Manual `--source=github` → resolves the root framework docs and `workstreams/*` against the API (the path the old code would 404 on).

## Scope

`bin/status` + its tests + a one-line `bin/_manifest.py` docstring tidy (3 files). No principle/phase/gate/workstream change. Out of scope per plan §7: the `--source=github` history walk (still no N-behind for github source) and any canonical-repo restructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)