### PR TITLE
docs: generalize the reasoning-tier recommendation into a cross-cutting convention

### DIFF
--- a/ITERATIVE_METHODOLOGY.md
+++ b/ITERATIVE_METHODOLOGY.md
@@ -382,6 +382,18 @@ Inline pointers in this document and in the workstream files reference skills by
 
 ---
 
+## Matching Reasoning Effort to Stakes
+
+> **Match reasoning effort to the stakes, not the task label.**
+>
+> Set your agent's reasoning depth by the work's *blast radius × irreversibility × compounding cost* — the same risk lens the methodology already uses to size a vertical slice (Principle 9) and to place its hardest gate (Principle 3). High on any axis — wide blast radius (changes ripple across many call sites or readers), low reversibility (migrations, cutovers, published claims, operator-approval boundaries), or high compounding cost (a planning or architecture error every later session inherits) — warrants your agent's deepest-reasoning mode (max-effort, extended-reasoning, or a larger thinking budget, depending on the toolchain). The marginal cost is latency and tokens; the cost of a shallow decision on heavy work is rework that compounds. Set the mode at session start — not after a problem appears.
+
+Cheap, reversible, mechanical work — a one-line fix, a rename the compiler catches, a reversible config tweak — does not need it; a lighter setting is the honest default there. The axis runs both ways.
+
+Methodology owns *when and why* to raise the tier (this rule); your agent owns *how* (the specific effort or model mechanism — see [`RECOMMENDED_SKILLS.md`](../../RECOMMENDED_SKILLS.md) for concrete Claude Code settings). And a higher tier is not a license: like a skill, a deeper-reasoning mode sharpens a phase — it never authorizes skipping orientation, the stub, close-out, or any hard gate, nor widening a session beyond its one declared deliverable (failure mode #17, `SESSION_RUNNER.md` Protocol erosion). Reason harder; stop at the same gates.
+
+---
+
 ## The Session Runner
 
 The 6 phases and 9 principles define WHAT to do and WHY. In practice, they need an **operational wrapper** — a cockpit checklist — that ensures they're actually followed. This is the Session Runner (`SESSION_RUNNER.md` in the project root).

--- a/ITERATIVE_METHODOLOGY.md
+++ b/ITERATIVE_METHODOLOGY.md
@@ -390,7 +390,7 @@ Inline pointers in this document and in the workstream files reference skills by
 
 Cheap, reversible, mechanical work — a one-line fix, a rename the compiler catches, a reversible config tweak — does not need it; a lighter setting is the honest default there. The axis runs both ways.
 
-Methodology owns *when and why* to raise the tier (this rule); your agent owns *how* (the specific effort or model mechanism — see [`RECOMMENDED_SKILLS.md`](../../RECOMMENDED_SKILLS.md) for concrete Claude Code settings). And a higher tier is not a license: like a skill, a deeper-reasoning mode sharpens a phase — it never authorizes skipping orientation, the stub, close-out, or any hard gate, nor widening a session beyond its one declared deliverable (failure mode #17, `SESSION_RUNNER.md` Protocol erosion). Reason harder; stop at the same gates.
+Methodology owns *when and why* to raise the tier (this rule); your agent owns *how* (the specific effort or model mechanism — see [`RECOMMENDED_SKILLS.md`](../../RECOMMENDED_SKILLS.md) for concrete example settings). And a higher tier is not a license: like a skill, a deeper-reasoning mode sharpens a phase — it never authorizes skipping orientation, the stub, close-out, or any hard gate, nor widening a session beyond its one declared deliverable (failure mode #17, `SESSION_RUNNER.md` Protocol erosion). Reason harder; stop at the same gates.
 
 ---
 

--- a/starter-kit/RECOMMENDED_SKILLS.md
+++ b/starter-kit/RECOMMENDED_SKILLS.md
@@ -57,6 +57,23 @@ Repo HEAD at verification: `b8be62ffacb0` (2026-05-20).
 
 ---
 
+## Reasoning Effort
+
+Not a skill — a setting. The methodology owns *when* to raise reasoning effort (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes: tier ∝ blast radius × irreversibility × compounding cost). This index — the recommendation layer — names the concrete Claude Code mechanism that satisfies it. Like the skill SHAs above, these are example settings for one agent; other agents expose the capability under other names, and the model names below are illustrative.
+
+| Work type | Why | Example (Claude Code) |
+|---|---|---|
+| Deep research / regulatory docs | misattribution is irreversible + reputational | `/effort max`, deepest model (e.g. Opus) |
+| Architecture / cross-module refactor | wide blast radius, low reversibility | `/effort high`–`max`, deepest model |
+| Planning sessions | errors compound across every executor session | `/effort high`–`max` |
+| Audits | a missed finding has high downstream cost | `/effort high` |
+| Feature / bugfix campaigns | quality compounds across sessions | `/effort medium`–`high` |
+| Mechanical / reversible edits (rename, config) | cheap to undo | `/effort low`–`medium`, lighter model (e.g. Sonnet/Haiku) |
+
+A higher tier sharpens a phase; it never licenses crossing a gate (failure mode #17).
+
+---
+
 ## Skills not recommended (and why)
 
 This index is a *vetted snapshot* of skills the methodology actively cites at specific phases or workstreams. Skills not listed in the tables above are either out of scope for the methodology's content, adequately covered by existing methodology discipline at higher rigor, or architecturally incompatible with the methodology's session-arc model.

--- a/starter-kit/SESSION_RUNNER.md
+++ b/starter-kit/SESSION_RUNNER.md
@@ -94,6 +94,8 @@ State your understanding back to the user: *"I'm going to [deliverable] followin
 
 **⚠ The plan is the deliverable. Do not start implementing it.** Write the plan document to `docs/planning/`, commit it, close out. Implementation happens in a separate session.
 
+**Set your agent's deepest available reasoning mode at session start** (capability: maximum reasoning depth — e.g. `/effort max` where supported). A plan is low-reversibility and high-compounding: its errors propagate into every executor session that trusts it (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes).
+
 **A plan is a deliverable, not a preamble.** When the session's deliverable is a plan (architecture doc, migration plan, multi-phase implementation plan), additional discipline applies:
 
 #### Evidence-Based Inventory (MANDATORY for deletion/migration/rename plans)
@@ -122,6 +124,7 @@ Without explicit completion criteria, executors don't know when to stop and tend
 
 Before closing out a planning session, verify:
 
+- [ ] Deepest available reasoning mode set at session start
 - [ ] Plan document written with file paths and line numbers
 - [ ] Grep-based inventory completed for all affected symbols (if deletion/migration/rename)
 - [ ] Each phase has explicit completion criteria and verification commands

--- a/workstreams/ARCHITECTURE_WORKSTREAM.md
+++ b/workstreams/ARCHITECTURE_WORKSTREAM.md
@@ -216,6 +216,7 @@ The deletion test is a thought experiment, not a recommendation to actually dele
 - During Phase 2 (Research) when inventorying the existing architecture — flag shallow modules for the design.
 - During refactor planning — the deletion test produces the rationale that goes in the architecture document's "why" section.
 - **Not** during feature implementation. Spotting a shallow module mid-feature is a Mode-Switch trigger (see [`SAFEGUARDS.md`](../../../SAFEGUARDS.md) §The Two-Mode Problem). Commit the feature, note the heuristic finding for a future architecture session, do not refactor inline.
+- Run these heuristics — and the refactor they motivate — at your agent's deepest available reasoning setting. Refactoring an existing module is high blast-radius (changes ripple across call sites) and often hard to reverse once committed; the cost of a shallow analysis compounds across every later session that navigates the result (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes).
 
 For applying these heuristics as a worked session, run `/improve-codebase-architecture`. The methodology owns *the heuristics and when to apply them*; the skill owns *the survey workflow*.
 

--- a/workstreams/AUDIT_WORKSTREAM.md
+++ b/workstreams/AUDIT_WORKSTREAM.md
@@ -31,6 +31,8 @@ The methodology owns *the audit framework* (criteria definition, scope inventory
 
 When a recommended skill is unavailable, the audit framework in this document is the operative discipline — the skill is a sharper instrument, not a hard dependency.
 
+Reasoning effort is the other sharper instrument. An audit mutates nothing (low irreversibility), but a missed finding has high downstream cost and findings compound — so scale reasoning depth to the cost of a missed finding (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes).
+
 ---
 
 ## Phase 2: Research (Audit-Specific)

--- a/workstreams/DESIGN_WORKSTREAM.md
+++ b/workstreams/DESIGN_WORKSTREAM.md
@@ -12,7 +12,7 @@ Use this workstream when designing:
 - Visual hierarchy and interaction flow
 - Profile/theme/configuration variants of the same interface
 
-> Design output is iterative and cheap to revise — lower blast radius than development or research. A lighter reasoning tier is the honest default here; reserve the deepest mode for genuinely irreversible commitments (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes). The axis runs both ways.
+> Design output is iterative and cheap to revise — lower blast radius than development or research. A lighter reasoning tier is the honest default here; reserve the deepest mode for genuinely irreversible commitments (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes).
 
 ---
 

--- a/workstreams/DESIGN_WORKSTREAM.md
+++ b/workstreams/DESIGN_WORKSTREAM.md
@@ -12,6 +12,8 @@ Use this workstream when designing:
 - Visual hierarchy and interaction flow
 - Profile/theme/configuration variants of the same interface
 
+> Design output is iterative and cheap to revise — lower blast radius than development or research. A lighter reasoning tier is the honest default here; reserve the deepest mode for genuinely irreversible commitments (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes). The axis runs both ways.
+
 ---
 
 ## Phase 2: Research (Design-Specific)

--- a/workstreams/DEVELOPMENT_WORKSTREAM.md
+++ b/workstreams/DEVELOPMENT_WORKSTREAM.md
@@ -14,6 +14,8 @@ Use this workstream when:
 
 **Not for one-off fixes.** If it's a single bug with a clear fix, just fix it. This workstream is for campaigns — repeated tasks of the same type where quality compounds.
 
+> Feature and bugfix campaigns mutate code and compound across sessions — heavy work. Default to a deeper reasoning tier (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes).
+
 ---
 
 ## Issue Lifecycle

--- a/workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md
+++ b/workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md
@@ -69,6 +69,8 @@ A single session that attempts to familiarize with a non-trivial inherited codeb
 
 This campaign decomposes the work into a planning session, N execution sessions (one per scoped unit), and a consolidation session — each obeying the methodology's session-scope rules and producing a checkpoint deliverable.
 
+Decomposition answers the within-session degradation above; the work's *stakes* are a separate lever. A confidently wrong mental model of an inherited codebase propagates into every later session that trusts the familiarization record, so this campaign inherits the deepest-reasoning-tier default from its parent Audit workstream (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes): set your agent's deepest-reasoning mode at the start of *each* session.
+
 ---
 
 ## Campaign Structure

--- a/workstreams/RESEARCH_DOCUMENTATION_WORKSTREAM.md
+++ b/workstreams/RESEARCH_DOCUMENTATION_WORKSTREAM.md
@@ -30,7 +30,7 @@ This workstream adapts Phases 2 (Research), 3 (Create), 4 (Present), and 6 (Veri
 
 Sloppy research is worse than valueless — credible-looking citations that fail under scrutiny damage reader trust more than missing citations would. Documentation errors surface as plausible text that passes casual review and only breaks under hostile scrutiny; by then the reputational damage is done.
 
-This workstream benefits materially from your agent's deepest-reasoning mode (max-effort, deep-thinking, or extended-reasoning settings, depending on the toolchain). The marginal cost is latency and tokens; the cost of an undetected misattribution is reputational. Set the mode at session start — not after a problem appears.
+Research documentation is a high-stakes instance of the general rule — *match reasoning effort to the stakes* (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes). A misattribution is effectively irreversible once published and its cost compounds across every reader who trusts it, so this workstream sits at the top of the tier: set your agent's deepest-reasoning mode at session start — not after a problem appears.
 
 The same logic applies to a human author working without an agent: the chapters of this workstream that demand the most attention are claim-source mapping, framing-language distinctions, and dedup logic across parallel work streams. Slow down on those. Speed elsewhere is fine.
 

--- a/workstreams/RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md
+++ b/workstreams/RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md
@@ -9,6 +9,8 @@ The campaign is explicitly **bidirectional**:
 
 Both modes share the same campaign shape (planning → per-unit work → consolidation) because both run into the same wall: a non-trivial paper or repository contains hundreds of claims, and verifying them in a single session degrades reasoning quality long before it exhausts raw context.
 
+That degradation is a *within-session* problem the campaign solves by decomposition; the work's *stakes* are a separate axis with a separate lever. Paper-wide claim verification is irreversible once published and compounds across every reader, so this campaign sits at the top of the reasoning tier inherited from its parent workstream (`ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes): set your agent's deepest-reasoning mode at the start of *each* session — decomposing the work does not lower its stakes.
+
 This is a **campaign**, not a workstream. It does not replace the Research Documentation workstream; it prescribes a campaign structure for a specific deliverable: a complete, primary-source-anchored claim record.
 
 ---

--- a/workstreams/TEMPLATE_WORKSTREAM.md
+++ b/workstreams/TEMPLATE_WORKSTREAM.md
@@ -25,6 +25,12 @@ When a recommended skill is unavailable, the discipline in this document is the 
 
 ---
 
+## Recommended Reasoning Tier *(optional — set this domain's default)*
+
+One line keying this workstream's default reasoning tier to its blast radius × irreversibility × compounding cost, citing `ITERATIVE_METHODOLOGY.md` §Matching Reasoning Effort to Stakes. Heavy / irreversible / compounding → deepest mode; cheap / reversible / mechanical → lighter. Delete if the domain's tier is unremarkable.
+
+---
+
 ## Phase 2: Research ([Domain]-Specific)
 
 ### Step 1: Study the [Requirements/Domain/Problem]


### PR DESCRIPTION
## Summary

The methodology recommends a deepest-reasoning tier for **research documentation only** (`RESEARCH_DOCUMENTATION_WORKSTREAM.md` §Recommended Operating Mode), yet the same risk applies to all heavy work — refactoring, planning, audits. This PR generalizes that single-domain recommendation into a **cross-cutting convention**, alongside phases, principles, workstreams, and skills (the same shape v2.6 used for the skill-recommendation layer).

**The rule:** *match reasoning effort to the stakes, not the task label* — reasoning tier ∝ **blast radius × irreversibility × compounding cost**. This is not a new axis: every multiplicand already lives in the framework's vocabulary (blast radius → SAFEGUARDS Blast Radius Limits; irreversibility → Vertical Slice recoverability ceiling / Principle 3's hardest gate; compounding → Principle 4). It's the *same* risk lens the methodology already uses to size a slice and place its hardest gate, applied to "how hard to reason."

## What changed (11 files, +50/−1)

**Spine**
- `ITERATIVE_METHODOLOGY.md` — **new `## Matching Reasoning Effort to Stakes`** section (maxim + prose), a sibling cross-cutting section after §Recommended Skills. Capability-framed (agent-independent); contains the inverse case (lighter is the honest default for cheap/reversible work) and an anti-erosion clause that cross-references FM #17.
- `RESEARCH_DOCUMENTATION_WORKSTREAM.md` — §Recommended Operating Mode **recomposed** as a high-stakes *instance* of the general rule (not the sole home); capability gloss relocated to the core to avoid duplication-drift.
- `RECOMMENDED_SKILLS.md` — **new `## Reasoning Effort`** section (a setting, not a skill) with concrete `/effort` examples — the brand-coupled recommendation layer.

**Cited surfaces** (each cites the rule by section name and adds only domain-specific rationale)
- `ARCHITECTURE_WORKSTREAM.md` (refactoring = high blast radius), `DEVELOPMENT_WORKSTREAM.md` (campaigns compound), `AUDIT_WORKSTREAM.md` (missed-finding cost) — the heavy workstreams.
- `DESIGN_WORKSTREAM.md` — **inverse** note (lighter tier is the default; keeps the axis honest).
- `SESSION_RUNNER.md` — §Planning Sessions umbrella sentence + a Planning Session Checklist item.
- `TEMPLATE_WORKSTREAM.md` — optional `## Recommended Reasoning Tier` scaffold for new workstreams.
- `RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md`, `INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md` — inheritance cites (see Scope below).

## Design constraints honored

- **Agent-independence** — the core names the *capability* ("deepest-reasoning mode: max-effort, extended-reasoning, or a larger thinking budget, depending on the toolchain"), no brand token; concrete `/effort`/model examples live only in the brand-coupled layer (`RECOMMENDED_SKILLS.md`, plus a capability-first "where supported" example in `SESSION_RUNNER.md`).
- **No renumbering** — cross-cutting section, **not** a 10th principle. "9 principles, 6 phases, 12 quality gates" and the FM count (26) are unchanged; no FM/phase/gate touched.
- **Cite-don't-restate** — the rule is stated once (core); every other surface cites it by name.
- **Anti-erosion** — a higher tier sharpens a phase; it never licenses skipping orientation, the stub, close-out, or any hard gate, nor widening a session beyond its one declared deliverable (cross-references FM #17). *Reason harder; stop at the same gates.*
- **Cross-reference convention** — name-based cites (`§Matching Reasoning Effort to Stakes`) avoid the v2.8 #33 link-topology paradox; the one new relative link matches the file's existing adopter-depth (`../../`).

## Verification

- **8-lens adversarial review** (stale-prose / xref-resolution / count-invariants / agent-independence / anti-erosion / cite-don't-restate / render / completeness-critic). It caught and I fixed two defects: a stray brand token in the core (agent-independence) and a verbatim tagline echo (duplication) — commit `0bdf5cd`.
- `bin/check-links` OK and **`bin/tests.sh` 51/51 passing** at every commit boundary.
- All 10 citing files reference the exact destination heading; load-bearing count claims re-grepped and unchanged.

## Scope

The completeness critic flagged that the two **campaign** files extend the exact workstreams that gained cites (RESEARCH_EXHAUSTIVE → Research Documentation; INHERITED_CODEBASE → Audit), with direct precedent — v2.5's render-dependency discipline was propagated into RESEARCH_EXHAUSTIVE "so the campaign inherits the discipline." They are included here, each explicitly separating the two axes (**decomposition** answers within-session degradation; **tier** answers stakes) so the cite does not conflate them. **Deliberately excluded:** a tier column on the SESSION_RUNNER session-type table (would over-claim a tier for all 8 rows).

## Process

- Independent deliverable — **not** bundled with the tutorials PR #38.
- Branched off `upstream/main` (v2.8) for a clean diff; the planning doc is fork-only.
- **Version + "What's New" are yours to assign.** Suggested framing: a **minor** release (adds a content convention alongside phases/principles/workstreams/skills, like v2.6 did for skills) — but defer to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)