### PR TITLE
docs(tutorials): complete the hands-on tutorial roadmap (T3, T4, T6, T7, T8)

### DIFF
--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -9,8 +9,9 @@ project, with a checkpoint after each step.
 > [worked transcript](T2_worked_transcript.md) of a real session against the sample project), and
 > [T5: Cautionary Use](T5_cautionary.md) — now extended by the roadmap tutorials
 > [T3: The Compounding Loop](T3_compounding_loop.md),
-> [T4: Choosing & Adapting a Workstream](T4_workstreams.md), and
-> [T6: Multi-Session Campaigns](T6_campaigns.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
+> [T4: Choosing & Adapting a Workstream](T4_workstreams.md),
+> [T6: Multi-Session Campaigns](T6_campaigns.md), and
+> [T7: Portfolio & Dashboard Ops](T7_portfolio_dashboard.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
 > [sample project](sample-project/) are in place. The curriculum below shows what's done and what's coming.
 
 ## Why bother?
@@ -28,7 +29,7 @@ sessions, and session N+1 reliably better than session N — is documented, not 
 
 - **One objective per tutorial** — mirrors the methodology's "1 deliverable per session." Each
   tutorial does exactly one thing.
-- **Progressive** — every tutorial names its predecessor, so the chain T1 → T2 → T5 → T3 → T4 → T6 builds on itself.
+- **Progressive** — every tutorial names its predecessor, so the chain T1 → T2 → T5 → T3 → T4 → T6 → T7 builds on itself.
 - **You produce a real artifact** — an installed framework, a saved session doc, a feature you
   shipped, a near-miss you caught. Not read-along.
 - **Cite, don't restate** — tutorials link into [`BOOTSTRAP.md`](../../starter-kit/BOOTSTRAP.md),
@@ -53,11 +54,13 @@ near-misses as its cautionary cases, T3 runs *Session 2* — scoring Session 1's
 building the next feature — to make the compounding loop felt, T4 switches lenses, auditing
 that same CLI and drafting a custom workstream for it instead of forcing the work into Development,
 and T6 carries the repository-wide hardening that audit recommended across a planning →
-execution → consolidation campaign that no single session could produce.
+execution → consolidation campaign that no single session could produce, and T7 zooms out from that
+single project to the whole portfolio — running the dashboard across many repos and letting the risk
+matrix and compliance grid decide where the next session goes.
 
 ## Curriculum
 
-The **core trio (T1 · T2 · T5)** was the first cut; **T3**, **T4**, and **T6** have since landed, and the rest is a roadmap.
+The **core trio (T1 · T2 · T5)** was the first cut; **T3**, **T4**, **T6**, and **T7** have since landed, and the rest is a roadmap.
 
 | # | Tutorial | You'll be able to… | Status |
 |---|----------|--------------------|:-------------:|
@@ -67,7 +70,7 @@ The **core trio (T1 · T2 · T5)** was the first cut; **T3**, **T4**, and **T6**
 | [T3](T3_compounding_loop.md) | The Compounding Loop | Run the handoff + scoring loop and watch session N+1 improve | ✅ **published** |
 | [T4](T4_workstreams.md) | Choosing & Adapting a Workstream | Pick the right workstream; spin up a custom one when none fits | ✅ **published** |
 | [T6](T6_campaigns.md) | Multi-Session Campaigns | Carry one deliverable across many sessions — planning → execution → consolidation, with a checkpoint at each boundary | ✅ **published** |
-| T7 | Portfolio & Dashboard Ops | Run across many projects; read the health dashboard | roadmap |
+| [T7](T7_portfolio_dashboard.md) | Portfolio & Dashboard Ops | Run across many projects; read the health dashboard | ✅ **published** |
 | T8 | Keeping Adopters Current | Use `bin/sync` / `bin/status` to stay in step with the canonical repo | roadmap |
 
 ## Writing a tutorial

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -8,8 +8,9 @@ project, with a checkpoint after each step.
 > [T2: Your First Session, End-to-End](T2_first_session.md) (with a
 > [worked transcript](T2_worked_transcript.md) of a real session against the sample project), and
 > [T5: Cautionary Use](T5_cautionary.md) — now extended by the roadmap tutorials
-> [T3: The Compounding Loop](T3_compounding_loop.md) and
-> [T4: Choosing & Adapting a Workstream](T4_workstreams.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
+> [T3: The Compounding Loop](T3_compounding_loop.md),
+> [T4: Choosing & Adapting a Workstream](T4_workstreams.md), and
+> [T6: Multi-Session Campaigns](T6_campaigns.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
 > [sample project](sample-project/) are in place. The curriculum below shows what's done and what's coming.
 
 ## Why bother?
@@ -27,7 +28,7 @@ sessions, and session N+1 reliably better than session N — is documented, not 
 
 - **One objective per tutorial** — mirrors the methodology's "1 deliverable per session." Each
   tutorial does exactly one thing.
-- **Progressive** — every tutorial names its predecessor, so the chain T1 → T2 → T5 → T3 → T4 builds on itself.
+- **Progressive** — every tutorial names its predecessor, so the chain T1 → T2 → T5 → T3 → T4 → T6 builds on itself.
 - **You produce a real artifact** — an installed framework, a saved session doc, a feature you
   shipped, a near-miss you caught. Not read-along.
 - **Cite, don't restate** — tutorials link into [`BOOTSTRAP.md`](../../starter-kit/BOOTSTRAP.md),
@@ -49,12 +50,14 @@ Choose a single track for a given run (do one, then the other if you like — no
 One running example threads the series: T1 installs the framework onto the sample project, T2
 runs the first session (building one todo-CLI feature), T5 uses that same session's
 near-misses as its cautionary cases, T3 runs *Session 2* — scoring Session 1's handoff and
-building the next feature — to make the compounding loop felt, and T4 switches lenses, auditing
-that same CLI and drafting a custom workstream for it instead of forcing the work into Development.
+building the next feature — to make the compounding loop felt, T4 switches lenses, auditing
+that same CLI and drafting a custom workstream for it instead of forcing the work into Development,
+and T6 carries the repository-wide hardening that audit recommended across a planning →
+execution → consolidation campaign that no single session could produce.
 
 ## Curriculum
 
-The **core trio (T1 · T2 · T5)** was the first cut; **T3** and **T4** have since landed, and the rest is a roadmap.
+The **core trio (T1 · T2 · T5)** was the first cut; **T3**, **T4**, and **T6** have since landed, and the rest is a roadmap.
 
 | # | Tutorial | You'll be able to… | Status |
 |---|----------|--------------------|:-------------:|
@@ -63,7 +66,7 @@ The **core trio (T1 · T2 · T5)** was the first cut; **T3** and **T4** have sin
 | [T5](T5_cautionary.md) | Cautionary Use | Read the gates, the 26 failure modes, "1 and done", the vertical-slice gates, and the Plan-Mode exit trap — and know when the methodology is too heavy | ✅ **published** |
 | [T3](T3_compounding_loop.md) | The Compounding Loop | Run the handoff + scoring loop and watch session N+1 improve | ✅ **published** |
 | [T4](T4_workstreams.md) | Choosing & Adapting a Workstream | Pick the right workstream; spin up a custom one when none fits | ✅ **published** |
-| T6 | Multi-Session Campaigns | Carry one deliverable across many sessions | roadmap |
+| [T6](T6_campaigns.md) | Multi-Session Campaigns | Carry one deliverable across many sessions — planning → execution → consolidation, with a checkpoint at each boundary | ✅ **published** |
 | T7 | Portfolio & Dashboard Ops | Run across many projects; read the health dashboard | roadmap |
 | T8 | Keeping Adopters Current | Use `bin/sync` / `bin/status` to stay in step with the canonical repo | roadmap |
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -7,8 +7,9 @@ project, with a checkpoint after each step.
 > **Status:** The **core trio is published** — [T1: Setup & First Bootstrap](T1_setup.md),
 > [T2: Your First Session, End-to-End](T2_first_session.md) (with a
 > [worked transcript](T2_worked_transcript.md) of a real session against the sample project), and
-> [T5: Cautionary Use](T5_cautionary.md) — now extended by the first roadmap tutorial,
-> [T3: The Compounding Loop](T3_compounding_loop.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
+> [T5: Cautionary Use](T5_cautionary.md) — now extended by the roadmap tutorials
+> [T3: The Compounding Loop](T3_compounding_loop.md) and
+> [T4: Choosing & Adapting a Workstream](T4_workstreams.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
 > [sample project](sample-project/) are in place. The curriculum below shows what's done and what's coming.
 
 ## Why bother?
@@ -26,7 +27,7 @@ sessions, and session N+1 reliably better than session N — is documented, not 
 
 - **One objective per tutorial** — mirrors the methodology's "1 deliverable per session." Each
   tutorial does exactly one thing.
-- **Progressive** — T1 → T2 → T5 build on each other, and T3 builds on T2; every tutorial names its predecessor.
+- **Progressive** — every tutorial names its predecessor, so the chain T1 → T2 → T5 → T3 → T4 builds on itself.
 - **You produce a real artifact** — an installed framework, a saved session doc, a feature you
   shipped, a near-miss you caught. Not read-along.
 - **Cite, don't restate** — tutorials link into [`BOOTSTRAP.md`](../../starter-kit/BOOTSTRAP.md),
@@ -47,12 +48,13 @@ Choose a single track for a given run (do one, then the other if you like — no
 
 One running example threads the series: T1 installs the framework onto the sample project, T2
 runs the first session (building one todo-CLI feature), T5 uses that same session's
-near-misses as its cautionary cases, and T3 runs *Session 2* — scoring Session 1's handoff and
-building the next feature — to make the compounding loop felt, not just described.
+near-misses as its cautionary cases, T3 runs *Session 2* — scoring Session 1's handoff and
+building the next feature — to make the compounding loop felt, and T4 switches lenses, auditing
+that same CLI and drafting a custom workstream for it instead of forcing the work into Development.
 
 ## Curriculum
 
-The **core trio (T1 · T2 · T5)** was the first cut; **T3** has since landed, and the rest is a roadmap.
+The **core trio (T1 · T2 · T5)** was the first cut; **T3** and **T4** have since landed, and the rest is a roadmap.
 
 | # | Tutorial | You'll be able to… | Status |
 |---|----------|--------------------|:-------------:|
@@ -60,7 +62,7 @@ The **core trio (T1 · T2 · T5)** was the first cut; **T3** has since landed, a
 | [T2](T2_first_session.md) | Your First Session, End-to-End | Run one full 6-phase pass to one deliverable — with Phase 0 Orient and the Present gate front and center | ✅ **published** |
 | [T5](T5_cautionary.md) | Cautionary Use | Read the gates, the 26 failure modes, "1 and done", the vertical-slice gates, and the Plan-Mode exit trap — and know when the methodology is too heavy | ✅ **published** |
 | [T3](T3_compounding_loop.md) | The Compounding Loop | Run the handoff + scoring loop and watch session N+1 improve | ✅ **published** |
-| T4 | Choosing & Adapting a Workstream | Pick the right workstream; spin up a custom one | roadmap |
+| [T4](T4_workstreams.md) | Choosing & Adapting a Workstream | Pick the right workstream; spin up a custom one when none fits | ✅ **published** |
 | T6 | Multi-Session Campaigns | Carry one deliverable across many sessions | roadmap |
 | T7 | Portfolio & Dashboard Ops | Run across many projects; read the health dashboard | roadmap |
 | T8 | Keeping Adopters Current | Use `bin/sync` / `bin/status` to stay in step with the canonical repo | roadmap |

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -7,7 +7,8 @@ project, with a checkpoint after each step.
 > **Status:** The **core trio is published** — [T1: Setup & First Bootstrap](T1_setup.md),
 > [T2: Your First Session, End-to-End](T2_first_session.md) (with a
 > [worked transcript](T2_worked_transcript.md) of a real session against the sample project), and
-> [T5: Cautionary Use](T5_cautionary.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
+> [T5: Cautionary Use](T5_cautionary.md) — now extended by the first roadmap tutorial,
+> [T3: The Compounding Loop](T3_compounding_loop.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
 > [sample project](sample-project/) are in place. The curriculum below shows what's done and what's coming.
 
 ## Why bother?
@@ -25,7 +26,7 @@ sessions, and session N+1 reliably better than session N — is documented, not 
 
 - **One objective per tutorial** — mirrors the methodology's "1 deliverable per session." Each
   tutorial does exactly one thing.
-- **Progressive** — T1 → T2 → T5 build on each other; every tutorial names its predecessor.
+- **Progressive** — T1 → T2 → T5 build on each other, and T3 builds on T2; every tutorial names its predecessor.
 - **You produce a real artifact** — an installed framework, a saved session doc, a feature you
   shipped, a near-miss you caught. Not read-along.
 - **Cite, don't restate** — tutorials link into [`BOOTSTRAP.md`](../../starter-kit/BOOTSTRAP.md),
@@ -44,20 +45,21 @@ Choose a single track for a given run (do one, then the other if you like — no
   with a real test suite and a [backlog](sample-project/BACKLOG.md)) and follow the steps
   step-for-step in a throwaway sandbox.
 
-One running example threads the core trio: T1 installs the framework onto the sample project, T2
-runs the first session (building one todo-CLI feature), and T5 uses that same session's
-near-misses as its cautionary cases.
+One running example threads the series: T1 installs the framework onto the sample project, T2
+runs the first session (building one todo-CLI feature), T5 uses that same session's
+near-misses as its cautionary cases, and T3 runs *Session 2* — scoring Session 1's handoff and
+building the next feature — to make the compounding loop felt, not just described.
 
 ## Curriculum
 
-The **core trio (T1 · T2 · T5)** is the first cut; the rest is a roadmap.
+The **core trio (T1 · T2 · T5)** was the first cut; **T3** has since landed, and the rest is a roadmap.
 
-| # | Tutorial | You'll be able to… | In first cut? |
+| # | Tutorial | You'll be able to… | Status |
 |---|----------|--------------------|:-------------:|
 | [T1](T1_setup.md) | Setup & First Bootstrap | Install the framework into a project: root files, `CLAUDE.md` protocol block, task tracking, dashboard | ✅ **published** |
 | [T2](T2_first_session.md) | Your First Session, End-to-End | Run one full 6-phase pass to one deliverable — with Phase 0 Orient and the Present gate front and center | ✅ **published** |
 | [T5](T5_cautionary.md) | Cautionary Use | Read the gates, the 26 failure modes, "1 and done", the vertical-slice gates, and the Plan-Mode exit trap — and know when the methodology is too heavy | ✅ **published** |
-| T3 | The Compounding Loop | Run the handoff + scoring loop and watch session N+1 improve | roadmap |
+| [T3](T3_compounding_loop.md) | The Compounding Loop | Run the handoff + scoring loop and watch session N+1 improve | ✅ **published** |
 | T4 | Choosing & Adapting a Workstream | Pick the right workstream; spin up a custom one | roadmap |
 | T6 | Multi-Session Campaigns | Carry one deliverable across many sessions | roadmap |
 | T7 | Portfolio & Dashboard Ops | Run across many projects; read the health dashboard | roadmap |

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -4,15 +4,10 @@ A hands-on, progressive learning track for the Iterative Session Methodology. Th
 docs *define* the framework — this one makes you *do* it, one thing at a time, against a real
 project, with a checkpoint after each step.
 
-> **Status:** The **core trio is published** — [T1: Setup & First Bootstrap](T1_setup.md),
-> [T2: Your First Session, End-to-End](T2_first_session.md) (with a
-> [worked transcript](T2_worked_transcript.md) of a real session against the sample project), and
-> [T5: Cautionary Use](T5_cautionary.md) — now extended by the roadmap tutorials
-> [T3: The Compounding Loop](T3_compounding_loop.md),
-> [T4: Choosing & Adapting a Workstream](T4_workstreams.md),
-> [T6: Multi-Session Campaigns](T6_campaigns.md), and
-> [T7: Portfolio & Dashboard Ops](T7_portfolio_dashboard.md). The [tutorial template](TUTORIAL_TEMPLATE.md) and
-> [sample project](sample-project/) are in place. The curriculum below shows what's done and what's coming.
+> **The track is eight tutorials, T1 through T8.** Alongside them: a
+> [worked transcript](T2_worked_transcript.md) of a real session against the sample project, a reusable
+> [tutorial template](TUTORIAL_TEMPLATE.md), and a bundled [sample project](sample-project/) to practice on.
+> New here? Start at [T1](T1_setup.md) and follow the [curriculum](#curriculum) in order.
 
 ## Why bother?
 
@@ -29,7 +24,7 @@ sessions, and session N+1 reliably better than session N — is documented, not 
 
 - **One objective per tutorial** — mirrors the methodology's "1 deliverable per session." Each
   tutorial does exactly one thing.
-- **Progressive** — every tutorial names its predecessor, so the chain T1 → T2 → T5 → T3 → T4 → T6 → T7 builds on itself.
+- **Progressive** — every tutorial names its predecessor, so the chain T1 → T2 → T5 → T3 → T4 → T6 → T7 → T8 builds on itself.
 - **You produce a real artifact** — an installed framework, a saved session doc, a feature you
   shipped, a near-miss you caught. Not read-along.
 - **Cite, don't restate** — tutorials link into [`BOOTSTRAP.md`](../../starter-kit/BOOTSTRAP.md),
@@ -54,24 +49,26 @@ near-misses as its cautionary cases, T3 runs *Session 2* — scoring Session 1's
 building the next feature — to make the compounding loop felt, T4 switches lenses, auditing
 that same CLI and drafting a custom workstream for it instead of forcing the work into Development,
 and T6 carries the repository-wide hardening that audit recommended across a planning →
-execution → consolidation campaign that no single session could produce, and T7 zooms out from that
+execution → consolidation campaign that no single session could produce, T7 zooms out from that
 single project to the whole portfolio — running the dashboard across many repos and letting the risk
-matrix and compliance grid decide where the next session goes.
+matrix and compliance grid decide where the next session goes — and T8 keeps the framework itself
+current, running `bin/status`/`bin/sync` to absorb a new canonical release without losing the
+project's customizations.
 
 ## Curriculum
 
-The **core trio (T1 · T2 · T5)** was the first cut; **T3**, **T4**, **T6**, and **T7** have since landed, and the rest is a roadmap.
+Eight tutorials, listed in series order. Each does one thing and names the next.
 
-| # | Tutorial | You'll be able to… | Status |
-|---|----------|--------------------|:-------------:|
-| [T1](T1_setup.md) | Setup & First Bootstrap | Install the framework into a project: root files, `CLAUDE.md` protocol block, task tracking, dashboard | ✅ **published** |
-| [T2](T2_first_session.md) | Your First Session, End-to-End | Run one full 6-phase pass to one deliverable — with Phase 0 Orient and the Present gate front and center | ✅ **published** |
-| [T5](T5_cautionary.md) | Cautionary Use | Read the gates, the 26 failure modes, "1 and done", the vertical-slice gates, and the Plan-Mode exit trap — and know when the methodology is too heavy | ✅ **published** |
-| [T3](T3_compounding_loop.md) | The Compounding Loop | Run the handoff + scoring loop and watch session N+1 improve | ✅ **published** |
-| [T4](T4_workstreams.md) | Choosing & Adapting a Workstream | Pick the right workstream; spin up a custom one when none fits | ✅ **published** |
-| [T6](T6_campaigns.md) | Multi-Session Campaigns | Carry one deliverable across many sessions — planning → execution → consolidation, with a checkpoint at each boundary | ✅ **published** |
-| [T7](T7_portfolio_dashboard.md) | Portfolio & Dashboard Ops | Run across many projects; read the health dashboard | ✅ **published** |
-| T8 | Keeping Adopters Current | Use `bin/sync` / `bin/status` to stay in step with the canonical repo | roadmap |
+| # | Tutorial | You'll be able to… |
+|---|----------|--------------------|
+| [T1](T1_setup.md) | Setup & First Bootstrap | Install the framework into a project: root files, `CLAUDE.md` protocol block, task tracking, dashboard |
+| [T2](T2_first_session.md) | Your First Session, End-to-End | Run one full 6-phase pass to one deliverable — with Phase 0 Orient and the Present gate front and center |
+| [T5](T5_cautionary.md) | Cautionary Use | Read the gates, the 26 failure modes, "1 and done", the vertical-slice gates, and the Plan-Mode exit trap — and know when the methodology is too heavy |
+| [T3](T3_compounding_loop.md) | The Compounding Loop | Run the handoff + scoring loop and watch session N+1 improve |
+| [T4](T4_workstreams.md) | Choosing & Adapting a Workstream | Pick the right workstream; spin up a custom one when none fits |
+| [T6](T6_campaigns.md) | Multi-Session Campaigns | Carry one deliverable across many sessions — planning → execution → consolidation, with a checkpoint at each boundary |
+| [T7](T7_portfolio_dashboard.md) | Portfolio & Dashboard Ops | Run across many projects; read the health dashboard |
+| [T8](T8_keeping_current.md) | Keeping Adopters Current | Use `bin/status` / `bin/sync` to stay in step with the canonical repo without losing customizations |
 
 ## Writing a tutorial
 

--- a/docs/tutorials/T3_compounding_loop.md
+++ b/docs/tutorials/T3_compounding_loop.md
@@ -1,0 +1,108 @@
+# Tutorial 3: The Compounding Loop
+
+> **Objective:** Run the handoff-and-scoring loop across two sessions — *score* your predecessor's handoff and *write* one you know will be scored — and feel why session N+1 starts faster than session N when the handoff is good.
+> **Prerequisites:** [Tutorial 2: Your First Session, End-to-End](T2_first_session.md) — you need the **Session 1 handoff** it produced (the one that named **F2** as next and scored itself 9/10); that handoff is the raw material this tutorial scores. Ideally you've also read [Tutorial 5: Cautionary Use](T5_cautionary.md). New here? Start at the [series index](README.md).
+> **Time:** ~25 minutes
+> **What you'll produce:** Backlog item **F2 — `todo rm <id>`** shipped as *Session 2*, plus the **scored handoff chain** on disk — a 1–10 evaluation of Session 1's handoff (with evidence) and Session 2's own handoff to Session 3, written to be scored in turn.
+> **Track:** Pick one and stick with it for this pass —
+> **A** (your own repo): run your *second* real session, scoring the handoff your Tutorial 2 session left; that run is your reference.
+> **B** ([sample project](sample-project/)): run Session 2 on the sample, building **F2 — `todo rm <id>`**, the item your Tutorial 2 handoff pointed at.
+
+## Why this matters
+
+Tutorial 2 had you run one session well. But one good session is just a good session — the methodology's actual payoff is **compounding**, and compounding lives entirely in the seam *between* sessions. The mechanism is small and bidirectional: each session opens by scoring its predecessor's handoff, and closes by writing a handoff it knows will be scored. That two-sided pressure is what turns a sequence of isolated sessions into a chain where each one starts ahead of the last. It is not theory — it is the single change the framework credits with its longest clean streak:
+
+- [Principle 8: Handoff Accountability](../../ITERATIVE_METHODOLOGY.md#8-handoff-accountability) — "the primary mechanism that makes sessions compound."
+- [The Self-Improvement Loop](../../ITERATIVE_METHODOLOGY.md#the-self-improvement-loop) and its [between-sessions detail](../../ITERATIVE_METHODOLOGY.md#between-sessions-the-handoff-accountability-loop) — the outgoing/incoming loop, end to end.
+- [`HOW_TO_USE.md` §What the Session Runner Contains](../../HOW_TO_USE.md#what-the-session-runner-contains) — the evidence: the handoff loop "added around Session 34 … correlated with 14 consecutive clean deliveries."
+
+This tutorial does not restate Principle 8 or the close-out steps — they live in the [flight manual](../../ITERATIVE_METHODOLOGY.md) and the [cockpit checklist](../../starter-kit/SESSION_RUNNER.md#phase-3-close-out), one source of truth. It makes you *run both sides of the loop once* and watch the head start arrive.
+
+## Before you start
+
+You need your **completed Tutorial 2 run** — the project where Session 1 shipped F1 and left a handoff. Track B: that means F1 is in (12 tests green) and your `SESSION_NOTES.md` holds the Session 1 handoff that named **F2** as next, listed the key files with line numbers, and flagged the gotcha *"core stays I/O-free."* If you're picking up cold, re-read that handoff in the [worked transcript](T2_worked_transcript.md#3d--handoff-notes) — it is exactly what Session 2 will score.
+
+```sh
+# Track B, from your sandbox copy of the sample project:
+python -m pytest                       # expect: 12 passed  (F1 shipped in Tutorial 2)
+sed -n '/What Session 1 Did/,/Self-assessment/p' SESSION_NOTES.md   # the handoff you'll score
+```
+
+**Checkpoint:** Tests are green at 12, and you can see Session 1's handoff in `SESSION_NOTES.md` — it names F2, the key files, and the I/O-free gotcha. You're about to start a *fresh* session (Session 2) against that handoff.
+
+## Steps
+
+Each step is one move of the loop. The first and last steps — orienting *from* the handoff and writing the *next* one — are the whole point; the build in the middle is Tutorial 2's lesson, run again, faster. Don't skip ahead.
+
+### 1. Open Session 2 and orient — read the handoff, don't re-discover
+
+Start a brand-new session. Phase 0 runs as always — but this time there *is* a predecessor, so the orientation reads Session 1's handoff in `SESSION_NOTES.md` and absorbs it: F1 is done, the next item is **F2**, the relevant code is at `todo.py:57`/`:103`/`:127`, and the standing gotcha is *core stays I/O-free*.
+
+**Expected result:** The orientation report says, in effect, *"Session 2. Predecessor shipped F1 and handed off F2 with key files and one gotcha; baseline 12 passed."* — and then stops for a task, exactly as in Tutorial 2.
+**Checkpoint:** The agent oriented *from the handoff* — it already knows what's next and where the code lives, without re-reading the whole codebase. **That head start is the compounding.** (Had Session 1 written *"Done. Pick next from backlog,"* you'd be re-discovering all of it right now — that's [FM #15](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).)
+
+### 2. Give the one task the handoff teed up — and watch it go faster
+
+Hand over **F2 — `todo rm <id>`** (Track A: the item *your* Tutorial 2 handoff named). The session claims itself (Phase 1B stub) and runs the same six phases you learned in Tutorial 2 — but Research is shorter, because the handoff already told it the shape: reuse the **I/O-free-core / I/O-shell split** (a pure `remove_todo` + a `cmd_rm` shell + one `rm` subparser), and settle the open question the handoff flagged (ids are *not* renumbered after a delete — next id stays `max(remaining)+1`, consistent with `test_add_reuses_max_id_plus_one_after_gaps`).
+
+```sh
+# Track B — the build runs as in Tutorial 2 (test-first, full suite each time); counts are illustrative:
+python -m pytest test_rm.py -q   # red:  4 failed  (rm is an invalid choice, remove_todo missing)
+# …agent applies remove_todo + cmd_rm + the rm subparser to todo.py…
+python -m pytest -q              # green: 16 passed (12 prior + 4 new) — no regression
+python3 todo.py --file demo.json rm 1   # runtime smoke test: -> removed #1: …
+```
+
+**Expected result:** A plan that *cites the predecessor's gotcha as an input* and reuses the F1 pattern instead of re-deriving it; F2 shipped test-first, the original 12 tests still green, runtime-verified.
+**Checkpoint:** You can point at where Session 2 stood on Session 1's shoulders — the core/shell split came from the handoff, not from fresh analysis. (The full phase-by-phase mechanics are Tutorial 2's lesson and its [worked transcript](T2_worked_transcript.md); here you're watching them cost less.)
+
+### 3. Close out — Phase 3A FIRST: score Session 1's handoff (1–10)
+
+Now the close-out, and its *first* step is the one Session 1 had to skip (it had no predecessor): **[3A — Evaluate the Previous Session's Handoff](../../starter-kit/SESSION_RUNNER.md#3a-evaluate-the-previous-sessions-handoff).** Score Session 1's handoff against the [six minimum requirements](../../starter-kit/SESSION_RUNNER.md#minimum-handoff-requirements-all-mandatory) — did it give key files with line numbers? gotchas? a specific, actionable next step? — and write the verdict to `SESSION_NOTES.md` under a **"Session 1 Handoff Evaluation (by Session 2)"** heading, with *specific evidence*, not a vibe.
+
+```markdown
+### Session 1 Handoff Evaluation (by Session 2)
+**Score: 9/10.** What helped: named F2 as the exact next item; key files with line
+numbers (todo.py:57/103/127) meant zero re-discovery; the "core stays I/O-free"
+gotcha pre-decided F2's structure. What was missing: no note on the id-reuse policy
+decision (I had to make the call this session). ROI: saved ~one research cycle.
+```
+
+**Expected result:** A written 1–10 score with concrete "what helped / what was missing" evidence — the predecessor can see precisely why.
+**Checkpoint:** `SESSION_NOTES.md` now holds a *numbered* evaluation of Session 1 with specifics, written *before* you self-assess. Skipping this — "my self-assessment is enough" — is [FM #10 (skip handoff evaluation)](../../starter-kit/SESSION_RUNNER.md#known-failure-modes); the evaluation *is* the compounding mechanism, which is why [3A comes first](../../starter-kit/SESSION_RUNNER.md#phase-3-close-out).
+
+### 4. Write Session 2's handoff — knowing Session 3 will score it
+
+Now you're on the *other* side of the loop. Write Session 2's handoff to all [six minimum requirements](../../starter-kit/SESSION_RUNNER.md#3d-write-handoff-notes): current state, what was done + commit, **F3 (`undo`) as the specific next item**, key files with the new line numbers, the id-reuse decision as a gotcha, and a self-assessment score. Write the notes you'd want to *receive* — the ones you just gave Session 1 a 9 for.
+
+**Expected result:** A full handoff that names F3, the key files (`remove_todo`/`cmd_rm` and their lines), the id-reuse gotcha, and a self-score — meeting every minimum requirement.
+**Checkpoint:** Re-read your handoff against the score you just handed out. A handoff like *"Done. Pick next from backlog"* would earn the ≤4/10 you'd refuse to write — that's [FM #15 (minimal handoff)](../../starter-kit/SESSION_RUNNER.md#known-failure-modes). You wrote one that would earn a 9.
+
+### 5. Confirm both sides of the loop are on disk
+
+The loop is real only if it's *written down*. Check that this session left both halves: the evaluation it owed its predecessor, and the handoff it owes its successor.
+
+```sh
+grep -n "Handoff Evaluation (by Session 2)" SESSION_NOTES.md   # incoming: you -> Session 1
+grep -n "What's next.*F3"                  SESSION_NOTES.md     # outgoing: you -> Session 3
+```
+
+**Expected result:** Both lines are present; F2 is shipped, tested, and runtime-verified; the session stopped at one deliverable.
+**Checkpoint:** `SESSION_NOTES.md` carries an *incoming* evaluation and an *outgoing* handoff. The yardstick you held Session 1 to is the one Session 3 will hold to you — that bidirectional pressure ([Principle 8](../../ITERATIVE_METHODOLOGY.md#8-handoff-accountability)) is what makes the chain improve instead of drift.
+
+## Common mistakes
+
+Cite the failure mode by number; link the list, don't paste it.
+(Full list: [Known Failure Modes](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).)
+
+- **Skipping the predecessor evaluation.** Self-assessing feels like enough, and scoring the last session feels like extra work — so 3A gets dropped. This is **FM #10 (skip handoff evaluation)**; the countermeasure is that [3A runs *first* in close-out](../../starter-kit/SESSION_RUNNER.md#phase-3-close-out) — the evaluation is the compounding mechanism, not paperwork after it.
+- **Writing a handoff you'd score ≤4.** *"Done. Pick next from backlog"* is technically a handoff and functionally useless — the next session starts blind. That's **FM #15 (minimal handoff)**; the countermeasure is the [six minimum requirements](../../starter-kit/SESSION_RUNNER.md#minimum-handoff-requirements-all-mandatory). Write notes that would earn a 9 or 10.
+- **Scoring without evidence.** "Looked fine, 9/10" gives your predecessor nothing to act on, and the feedback loop quietly stops improving anything — see [`HOW_TO_USE.md` "The self-improvement loop isn't improving anything."](../../HOW_TO_USE.md#the-self-improvement-loop-isnt-improving-anything). The score creates accountability; the *specific evidence* creates the improvement. (And inflated scores that hide drift are how a 9/10 chain slides toward 1/10 — [protocol erosion, FM #17](../../starter-kit/SESSION_RUNNER.md#known-failure-modes); watch the trend in [Degradation Detection](../../starter-kit/SESSION_RUNNER.md#degradation-detection).)
+
+## You produced
+
+Session 2, complete: **F2 — `todo rm <id>`** shipped and runtime-verified, *and* a scored handoff chain on disk — a 1–10 evaluation of Session 1's handoff with concrete evidence, and Session 2's own handoff to Session 3 written to the six minimum requirements. You have now run **both sides of the loop**: you graded the session before you and set up the session after you, against the same yardstick. The point was never this one feature — it's that the score is a ratchet. Session 3 inherits a better starting line because you wrote it one, exactly as Session 1 wrote one for you.
+
+## Next
+
+→ The next roadmap stop is **T4 — Choosing & Adapting a Workstream** (pick the right workstream for the work in front of you; spin up a custom one when none fits) — see the [curriculum](README.md#curriculum) for what's landed. For now, run a real *Session 2* on a project you actually return to: the loop only compounds on work you repeat, and you only trust the ratchet once you've felt your own past handoff give you a head start.

--- a/docs/tutorials/T3_compounding_loop.md
+++ b/docs/tutorials/T3_compounding_loop.md
@@ -105,4 +105,4 @@ Session 2, complete: **F2 — `todo rm <id>`** shipped and runtime-verified, *an
 
 ## Next
 
-→ The next roadmap stop is **T4 — Choosing & Adapting a Workstream** (pick the right workstream for the work in front of you; spin up a custom one when none fits) — see the [curriculum](README.md#curriculum) for what's landed. For now, run a real *Session 2* on a project you actually return to: the loop only compounds on work you repeat, and you only trust the ratchet once you've felt your own past handoff give you a head start.
+→ **[Tutorial 4: Choosing & Adapting a Workstream](T4_workstreams.md)** — pick the right workstream for the work in front of you, and spin up a custom one when none fits. For now, run a real *Session 2* on a project you actually return to: the loop only compounds on work you repeat, and you only trust the ratchet once you've felt your own past handoff give you a head start.

--- a/docs/tutorials/T4_workstreams.md
+++ b/docs/tutorials/T4_workstreams.md
@@ -131,4 +131,4 @@ A recorded workstream selection — the Audit lens chosen by matching the task t
 
 ## Next
 
-→ The next roadmap stop is **T6 — Multi-Session Campaigns** (carry one deliverable — like the repo-wide hardening your audit just recommended — across many sessions without losing the thread) — see the [curriculum](README.md#curriculum) for what's landed. For now, do it for real: name the workstream your *own* last session was in, and the next time a task doesn't fit, draft the lens before you start instead of forcing the work into Development.
+→ **[Tutorial 6: Multi-Session Campaigns](T6_campaigns.md)** — carry one deliverable, like the repo-wide hardening your audit just recommended, across many sessions without losing the thread. For now, do it for real: name the workstream your *own* last session was in, and the next time a task doesn't fit, draft the lens before you start instead of forcing the work into Development.

--- a/docs/tutorials/T4_workstreams.md
+++ b/docs/tutorials/T4_workstreams.md
@@ -1,0 +1,134 @@
+# Tutorial 4: Choosing & Adapting a Workstream
+
+> **Objective:** Match the task in front of you to the right workstream — Design, Architecture, Development, Audit, or Research-Documentation — and, when none of them fits, spin up a custom one from the template instead of forcing a bad fit.
+> **Prerequisites:** [Tutorial 3: The Compounding Loop](T3_compounding_loop.md) — you've now run two sessions (Tutorial 2 shipped F1, Tutorial 3 shipped F2), and both were *the same kind of work* without you ever naming it. This tutorial names it. New here? Start at the [series index](README.md).
+> **Time:** ~25 minutes
+> **What you'll produce:** A recorded **workstream selection** for a real task (the choice, plus the two or three things it changes about Phase 2 and Phase 3), and a new `*_WORKSTREAM.md` file you create from the template for a task no shipped workstream covered.
+> **Track:** Pick one and stick with it for this pass —
+> **A** (your own repo): name the workstream your last two real sessions were in, then choose one consciously for your next task.
+> **B** ([sample project](sample-project/)): run an *Audit* session on the todo CLI you've been building, then draft a custom *Release* workstream for it.
+
+## Why this matters
+
+For two sessions you've been running the **Development workstream** — implementing features — and you never had to say so, because Development is the unstated default. That works right up until the task in front of you *isn't* feature work: an audit, a design pass, a release. Reach for the only lens you've used and an audit quietly turns into "while I'm here, let me just fix it," and a design session ships untested code. The workstream is the methodology's domain-specific lens: the *same* 9 principles, 6 phases, and 12 gates, with only Phase 2, Phase 3, scope validation, verification, and the reference tables specialized to the work. Choosing the right one — or building one when none fits — is a skill, not a default.
+
+- [Adapting to Your Domain](../../ITERATIVE_METHODOLOGY.md#adapting-to-your-domain) — workstreams are domain-specific adaptations; the phases and gates don't change, only the five things listed there.
+- [`HOW_TO_USE.md` §Workstreams](../../HOW_TO_USE.md#workstreams) — "the workstream is where knowledge compounds." Session 1 invents the patterns; Session 5 applies them automatically.
+- [Workstreams (README)](../../README.md#workstreams) — the five shipped lenses and what each is best for, at a glance.
+
+This tutorial does not restate the phases, the workstream catalog, or the failure-mode list — they live in the [flight manual](../../ITERATIVE_METHODOLOGY.md), the [README](../../README.md#workstreams), and the [cockpit checklist](../../starter-kit/SESSION_RUNNER.md). It makes you *make the selection decision once*, feel a workstream change the work, and *build one* when the catalog runs out.
+
+## Before you start
+
+You need the project from the earlier tutorials, with two Development sessions behind it. Track B: the sample todo CLI where Tutorial 2 shipped F1 and Tutorial 3 shipped F2.
+
+```sh
+# Track B, from your sandbox copy of the sample project:
+python -m pytest        # expect: green (16 passed if you built F2 in Tutorial 3)
+ls docs/methodology/workstreams/   # the shipped workstreams, installed by bin/sync in Tutorial 1
+```
+
+**Checkpoint:** Tests are green, and you can see the shipped workstream files — `DESIGN_`, `ARCHITECTURE_`, `DEVELOPMENT_`, `AUDIT_`, `RESEARCH_DOCUMENTATION_`, and the blank `TEMPLATE_WORKSTREAM.md` — under `docs/methodology/workstreams/`. (Tutorial 1's `bin/sync` put them there; they're the catalog you're about to choose from.)
+
+## Steps
+
+Each step is one action. Steps 1–3 are the *choosing* skill; Step 4 is the *adapting* skill; Step 5 makes the choice persist. Don't skip ahead.
+
+### 1. Name the workstream you've already been using
+
+Open [`DEVELOPMENT_WORKSTREAM.md`](../../workstreams/DEVELOPMENT_WORKSTREAM.md#when-to-use) and read its **When to Use**: *"implementing a series of related features … running a bug fix campaign … any development work where the same type of task repeats with variation."* That is exactly what Tutorial 2 and Tutorial 3 were. You were in the Development workstream the whole time — it's just the default you never had to declare.
+
+**Expected result:** You can point at the Development workstream's *When to Use* and see your last two sessions described in it.
+**Checkpoint:** You know the word **workstream**, that you've been operating in Development, and that [four other lenses](../../README.md#workstreams) exist for work that isn't feature implementation.
+
+### 2. Match a new task to a workstream — read the *When to Use*, don't default
+
+A new priority arrives: **before sharing the todo CLI more widely, review it for correctness and edge-case bugs.** Nothing new ships — so this is *not* Development. At [Phase 1](../../starter-kit/SESSION_RUNNER.md#phase-1-receive-task), the session runner asks "which workstream governs this work?" Answer it by reading each lens's *When to Use* and matching, instead of reaching for the one you know:
+
+| Lens | *When to Use* says… | Fit? |
+|------|---------------------|:----:|
+| Design | UI layouts, visual hierarchy | no |
+| Architecture | systems, APIs, data models | no |
+| Development | *implement* features / run a bug-fix campaign | no — you're *finding*, not fixing |
+| **Audit** | *"auditing a codebase for a specific class of issue (security, performance, **correctness**, style)"* | **yes** |
+| Research-Documentation | cited papers, regulatory analyses | no |
+
+→ **Audit workstream.** Record the choice and its one-line rationale (the *When to Use* clause it matched) in your session notes or `CONTEXT.md`.
+
+**Expected result:** A written selection — *"This session → Audit workstream, because the task is finding a class of issue (correctness), not implementing."*
+**Checkpoint:** You chose by matching the task to a workstream's [*When to Use*](../../workstreams/AUDIT_WORKSTREAM.md#when-to-use), not by defaulting to Development. Reaching for Development on every task — and then "just fixing" what you find — is **FM #12 (workstream transfer amnesia)**; you just avoided it by choosing deliberately.
+
+### 3. Run the session in that lens — same gates, different Phase 2 and Phase 3
+
+The workstream changes nothing about the gates; it changes the *domain work inside them*. For Audit versus the Development you ran in Tutorial 2:
+
+- **Phase 2** is *define audit criteria + inventory scope* (a criteria table and a coverage list), not *study requirements + read the code you'll modify*.
+- **Phase 3** produces an [**audit report**](../../workstreams/AUDIT_WORKSTREAM.md#the-audit-report) — severity, location, evidence, recommendation — **not code.**
+- **Verification** is *coverage* ("examined N of M") plus every finding carrying evidence, not "tests still green / no regression."
+- The default **reasoning tier** shifts too: an audit mutates nothing, but a *missed* finding is costly, so scale depth to the cost of a miss ([Matching Reasoning Effort to Stakes](../../ITERATIVE_METHODOLOGY.md#matching-reasoning-effort-to-stakes)).
+
+Do the small real version: write a two-row criteria table and a scope list for `todo.py`, read it against them, and you'll surface the project's known rough edges as *findings* — **B1** (`add` accepts empty/whitespace text) and **B2** (no confirmation before overwriting the data file), each with a `file:line` and a recommendation. The discipline that makes this an Audit and not a Development session: **you file them; you do not fix them.** Fixing is a separate Development session that the audit *recommends* — patching B1 inline here is the very scope creep [Tutorial 5](T5_cautionary.md) warned about, and the Development reflex **FM #12** predicts you'll feel.
+
+```markdown
+### Finding #1: `add` accepts empty text  — Severity: Moderate — todo.py:44
+Evidence: `add_todo("")` creates a blank task; no validation (see NOTE in todo.py).
+Recommendation: reject empty/whitespace in a *future Development session* (own test).
+```
+
+**Expected result:** A short findings report (B1, B2) with locations and recommendations — and **zero code changed**; the suite is still green because an audit doesn't touch code.
+**Checkpoint:** Your deliverable is a *report*, not a diff. You found the bugs the workstream's way — surfaced with evidence and handed off — instead of the Development way of patching them on sight.
+
+### 4. When none fits: spin up a custom workstream from the template
+
+A different task is coming: **cut a tagged `v0.1` release** of the todo CLI — update the changelog, bump the version, tag it, smoke-test the packaged artifact. Walk the catalog again: not Design, not Architecture, not Audit, not Research-Documentation — and not Development either (you're not implementing a feature or running a bug campaign). None fits. [Phase 1](../../starter-kit/SESSION_RUNNER.md#phase-1-receive-task) names this case directly — *"if no workstream document exists for the task type, follow the master framework"* — and when the work is the kind you'll repeat, the methodology's move is to build the missing lens first rather than force the task into a workstream it doesn't belong to.
+
+The methodology's stance is *adapt, don't force*. Follow [`HOW_TO_USE.md` §Creating a Custom Workstream](../../HOW_TO_USE.md#creating-a-custom-workstream): copy the [blank template](../../workstreams/TEMPLATE_WORKSTREAM.md), fill the sections that earn their place, and delete the optional ones it marks as deletable.
+
+```sh
+# in your installed project (adopter layout):
+cp docs/methodology/workstreams/TEMPLATE_WORKSTREAM.md \
+   docs/methodology/workstreams/RELEASE_WORKSTREAM.md
+# fill: When to Use + Phase 2 (Research) + Phase 3 (Create); delete the optional sections you don't need
+```
+
+Filled in, the bones look like this — a thin lens, not a fork of the framework:
+
+```markdown
+# Release Workstream
+## When to Use
+- Cutting a tagged, versioned release of a tool or library
+- Publishing a packaged artifact (wheel, binary, image) from a known-good commit
+## Phase 2: Research (Release-Specific)
+- Inventory what ships: changelog entries since the last tag, version string, artifacts
+- Verify the build equivalent is green at the exact commit being tagged
+## Phase 3: Create (Release-Specific)
+- The deliverable is the release checklist: version bumped, CHANGELOG updated,
+  tag created, packaged artifact smoke-tested from a clean checkout
+```
+
+**Expected result:** A real `RELEASE_WORKSTREAM.md` with at least *When to Use* + Phase 2 + Phase 3 filled, that a future session could pick up and run.
+**Checkpoint:** The file exists and reads like the shipped workstreams — same shape, your domain — and it specializes Phase 2/3 only; it does **not** rewrite the phases or gates ([Adapting to Your Domain](../../ITERATIVE_METHODOLOGY.md#adapting-to-your-domain) lists the five things a workstream may change, and the gates aren't among them). It lives beside the shipped lenses in `docs/methodology/workstreams/`; because it isn't in the [distribution manifest](../../bin/_manifest.py), `bin/sync` will never overwrite it — it's yours.
+
+### 5. Record the workstream — and notice you've found a campaign
+
+The selection is only real if it persists. Note the active workstream in your handoff (the [Tutorial 3](T3_compounding_loop.md) discipline) so the next session inherits the choice instead of re-deciding. Then look at what the audit actually recommended: fix B1, fix B2, and run the [7-dimension audit](../../workstreams/AUDIT_WORKSTREAM.md) across the whole CLI. That is more than one session's work — which is precisely the signal [Phase 1's campaign check](../../starter-kit/SESSION_RUNNER.md#phase-1-receive-task) exists to catch.
+
+**Expected result:** Your handoff names the active workstream and flags whether the remaining work is a single session or a [multi-session campaign](../../ITERATIVE_METHODOLOGY.md#multi-session-campaigns).
+**Checkpoint:** A future session can read which workstream is active without re-deciding, and you've spotted that the audit's full recommendation is a campaign — exactly where the next tutorial picks up.
+
+## Common mistakes
+
+Cite the failure mode by number; link the list, don't paste it.
+(Full list: [Known Failure Modes](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).)
+
+- **Carrying one workstream's reflexes into another.** You ran two Development sessions, switch to an Audit, and "just fix" B1 the moment you see it — the Development habit fires in the wrong lens. That's **FM #12 (workstream transfer amnesia)**, and the act of fixing mid-audit is also **FM #8 (redesign during implementation)** and **FM #2 (keep going)**. The countermeasure: when you switch workstreams, consciously re-read the new lens's Phase 2–3 and [re-apply the close-out checklist](../../starter-kit/SESSION_RUNNER.md#phase-3-close-out) — discipline doesn't auto-transfer.
+- **Forcing a poor-fit task into the nearest lens.** Jamming the release into Development because it's familiar produces a session with the wrong Phase 2 and the wrong verification. The methodology's answer is to [adapt the template](../../HOW_TO_USE.md#creating-a-custom-workstream), not to mislabel the work.
+- **Building a custom workstream that re-forks the framework.** A new workstream specializes Phase 2, Phase 3, scope validation, verification, and the reference tables — *only* those ([Adapting to Your Domain](../../ITERATIVE_METHODOLOGY.md#adapting-to-your-domain)). If your `*_WORKSTREAM.md` rewrites the phases, renumbers the gates, or invents its own close-out, it has stopped being a lens and become a fork that will drift from canonical.
+
+## You produced
+
+A recorded workstream selection — the Audit lens chosen by matching the task to its *When to Use*, with the rationale on disk — and a short audit report that *found* the CLI's rough edges instead of patching them. And a real custom `RELEASE_WORKSTREAM.md`, built from the template for work the catalog didn't cover, that specializes only Phase 2 and Phase 3 and leaves the gates untouched. You can now answer the Phase 1 question — *which workstream governs this work?* — for any task, and build the answer when it doesn't exist yet. The audit's full recommendation turned out to be bigger than one session, which is the thread the next tutorial pulls.
+
+## Next
+
+→ The next roadmap stop is **T6 — Multi-Session Campaigns** (carry one deliverable — like the repo-wide hardening your audit just recommended — across many sessions without losing the thread) — see the [curriculum](README.md#curriculum) for what's landed. For now, do it for real: name the workstream your *own* last session was in, and the next time a task doesn't fit, draft the lens before you start instead of forcing the work into Development.

--- a/docs/tutorials/T5_cautionary.md
+++ b/docs/tutorials/T5_cautionary.md
@@ -87,4 +87,6 @@ Two near-misses you caught on purpose — recorded in `SESSION_NOTES.md` as gate
 
 ## Next
 
-That's the **core trio (T1 · T2 · T5)** — installed, run once for real, and stress-tested. From here the [curriculum](README.md#curriculum) maps the roadmap: **T3 — The Compounding Loop** (run the handoff-and-scoring loop across sessions and watch session N+1 beat session N) is the natural continuation when it lands. For now, take the use/don't-use judgment from Step 5 to a real project — the methodology earns its keep on the work you'd otherwise repeat without learning from.
+That's the **core trio (T1 · T2 · T5)** — installed, run once for real, and stress-tested. The natural continuation is now live:
+
+→ **[Tutorial 3: The Compounding Loop](T3_compounding_loop.md)** — run the handoff-and-scoring loop across sessions and watch session N+1 beat session N. (See the [curriculum](README.md#curriculum) for the full roadmap.) And take the use/don't-use judgment from Step 5 to a real project — the methodology earns its keep on the work you'd otherwise repeat without learning from.

--- a/docs/tutorials/T5_cautionary.md
+++ b/docs/tutorials/T5_cautionary.md
@@ -87,6 +87,6 @@ Two near-misses you caught on purpose — recorded in `SESSION_NOTES.md` as gate
 
 ## Next
 
-That's the **core trio (T1 · T2 · T5)** — installed, run once for real, and stress-tested. The natural continuation is now live:
+You've now installed the framework, run one real session, and stress-tested the gates. Next in the track:
 
-→ **[Tutorial 3: The Compounding Loop](T3_compounding_loop.md)** — run the handoff-and-scoring loop across sessions and watch session N+1 beat session N. (See the [curriculum](README.md#curriculum) for the full roadmap.) And take the use/don't-use judgment from Step 5 to a real project — the methodology earns its keep on the work you'd otherwise repeat without learning from.
+→ **[Tutorial 3: The Compounding Loop](T3_compounding_loop.md)** — run the handoff-and-scoring loop across sessions and watch session N+1 beat session N. (See the [curriculum](README.md#curriculum) for the full track.) And take the use/don't-use judgment from Step 5 to a real project — the methodology earns its keep on the work you'd otherwise repeat without learning from.

--- a/docs/tutorials/T6_campaigns.md
+++ b/docs/tutorials/T6_campaigns.md
@@ -146,4 +146,4 @@ A complete pass through a multi-session campaign in miniature: a real `CAMPAIGN.
 
 ## Next
 
-→ The next roadmap stop is **T7 — Portfolio & Dashboard Ops** (run the methodology across many projects at once and read the health dashboard) — see the [curriculum](README.md#curriculum) for what's landed. For now, do it for real on Track A: take a deliverable you already suspect is too big for one session, run *only* its planning session, and let the `CAMPAIGN.md` — not a heroic marathon — be where the work gets organized.
+→ **[Tutorial 7: Portfolio & Dashboard Ops](T7_portfolio_dashboard.md)** — zoom out from one project to many: run the health dashboard across your whole portfolio and let the risk matrix decide where the next session goes. For now, do it for real on Track A: take a deliverable you already suspect is too big for one session, run *only* its planning session, and let the `CAMPAIGN.md` — not a heroic marathon — be where the work gets organized.

--- a/docs/tutorials/T6_campaigns.md
+++ b/docs/tutorials/T6_campaigns.md
@@ -1,0 +1,149 @@
+# Tutorial 6: Multi-Session Campaigns
+
+> **Objective:** Recognize when a deliverable is too big for one session even after correct decomposition, and carry it across many sessions using the **planning → execution → consolidation** sequence — with a checkpoint deliverable at every boundary — without losing the thread.
+> **Prerequisites:** [Tutorial 4: Choosing & Adapting a Workstream](T4_workstreams.md) — its Audit session ended by recommending *fix B1, fix B2, and run the 7-dimension audit across the whole CLI*, and noticed that recommendation is "more than one session's work." That recommendation is the campaign this tutorial runs. New here? Start at the [series index](README.md).
+> **Time:** ~30 minutes (this is the heaviest concept in the series — it coordinates *across* sessions, not within one).
+> **What you'll produce:** A real `CAMPAIGN.md` (the planning-session output), one execution-session **unit deliverable** committed as a checkpoint, and a partial `REPORT.md` (the consolidation output) — the three campaign session types, run once each in miniature — plus the recognition skill: the three-part test that tells you a campaign is the right tool *before* you stand one up.
+> **Track:** Pick one and stick with it for this pass —
+> **A** (your own repo): take a deliverable you've already discovered is too big for one session — a repo-wide audit, a hardening pass, an inherited-codebase familiarization — and run its planning session for real.
+> **B** ([sample project](sample-project/)): run the **repository-wide hardening audit** of the todo CLI that Tutorial 4's audit recommended.
+
+## Why this matters
+
+Every tutorial so far lived *inside* one session — Phase 0 to close-out, one deliverable, stop. But some deliverables don't fit one session even when you decompose them correctly: paper-wide claim verification across hundreds of citations, security hardening across dozens of endpoints, familiarization with an inherited 40-module codebase. The six phases bound a single session and [Principle 9](../../ITERATIVE_METHODOLOGY.md#9-session-scope-bounding) bounds what one session may *produce*; coordinating many sessions toward a single deliverable operates at a different scale entirely. Forcing that work into one session is not heroic — it is the failure the campaign layer exists to prevent: the second half gets less rigor than the first, there's no resumability when it crashes, and "1 and done" is violated by a deliverable that was secretly dozens of micro-deliverables fused together.
+
+- [§Multi-Session Campaigns](../../ITERATIVE_METHODOLOGY.md#multi-session-campaigns) — what a campaign is, and the crucial distinction: a campaign is **not** a workstream (workstreams adapt the phases to a domain; campaigns sequence sessions toward one deliverable *within* a workstream).
+- [When to write or invoke a campaign](../../ITERATIVE_METHODOLOGY.md#when-to-write-or-invoke-a-campaign) — the three-part test, and just as important, when **not** to reach for one.
+- [Phase 1's multi-session campaign check](../../starter-kit/SESSION_RUNNER.md#phase-1-receive-task) — the gate that catches campaign-shaped work at the start of a session, which is exactly what Tutorial 4 tripped.
+
+This tutorial does not restate the campaign template, the session sequence, or the anti-pattern list — they live in [§Multi-Session Campaigns](../../ITERATIVE_METHODOLOGY.md#multi-session-campaigns), the [blank template](../../workstreams/TEMPLATE_CAMPAIGN.md), and the realized [`INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md`](../../workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md). It makes you *run the three session types once* on a deliberately small deliverable, so you feel the session boundaries that keep a long campaign from collapsing into one mega-session.
+
+> **A note on scale — read this before you start.** The todo CLI is tiny; a real hardening audit of it would fit in one or two sessions, and the three-part test below would tell you **not** to stand up a campaign for it. We use it anyway, the same way the whole series uses a toy: to rehearse the *structure* safely. So this tutorial **telescopes** what must, in real life, be **separate sessions** — you'll walk planning, one execution unit, and consolidation in a single sitting to see the whole arc. The lesson is precisely that they are separate sessions; Step 4 is where that boundary becomes the point.
+
+## Before you start
+
+You need the project from Tutorial 4, with the audit's findings on disk. Track B: the sample todo CLI where Tutorials 2–3 shipped F1 and F2 and Tutorial 4 ran an audit that filed **B1** (`add` accepts empty/whitespace text) and **B2** (no confirmation before overwriting the data file) without fixing them.
+
+```sh
+# Track B, from your sandbox copy of the sample project:
+python -m pytest        # expect: 16 passed  (F1 + F2 shipped; the Tutorial 4 audit changed no code)
+ls docs/methodology/workstreams/   # the catalog, incl. *_CAMPAIGN.md templates installed by bin/sync in Tutorial 1
+```
+
+**Checkpoint:** Tests are green at 16, your Tutorial 4 audit report (B1, B2 with `file:line` and recommendations) is on disk, and you can see the campaign templates — `TEMPLATE_CAMPAIGN.md`, `INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md`, `RESEARCH_EXHAUSTIVE_VERIFICATION_CAMPAIGN.md` — beside the workstreams. (Tutorial 1's `bin/sync` put them there; they're the templates you're about to use.)
+
+## Steps
+
+Each step is one move of the campaign. Steps 1–2 are the *recognition and planning* skill, Step 3 is one *execution* unit, Step 4 is the boundary that keeps the campaign honest, and Step 5 *consolidates*. Don't skip ahead.
+
+### 1. Apply the three-part test — is this actually a campaign?
+
+Tutorial 4 ended by noticing the audit recommended more than one session's work. "A lot to do" is not the trigger, though — the trigger is a specific three-part test. Open [When to write or invoke a campaign](../../ITERATIVE_METHODOLOGY.md#when-to-write-or-invoke-a-campaign) and check that **all three** hold:
+
+| # | The condition | Does the hardening audit meet it? |
+|---|---------------|-----------------------------------|
+| 1 | Can't be produced in one session even under correct decomposition | On a real codebase, yes — a 7-dimension sweep plus per-finding evidence across many files is dozens of micro-deliverables. *On this toy, honestly no* — which is the teaching point. |
+| 2 | The shape is, or will be, repeatable | Yes — "audit every dimension, file findings with evidence, consolidate into a prioritized backlog" recurs on every codebase you inherit or harden. |
+| 3 | Cross-session coordination (shared schema, checkpoint deliverables, calibration) is load-bearing for quality | Yes — without a locked finding schema, units don't merge; without checkpoints, a crash restarts the run. |
+
+The same section names when **not** to: the work fits in one session, the deliverable is genuinely one-off, or the right artifact is a *new workstream* (which was Tutorial 4's lesson — don't confuse the two). For the toy, condition 1 fails, so the honest answer on a real project this size is "not a campaign." We proceed anyway *as a rehearsal*, with that flag raised — manufacturing campaign ceremony for one-session work is its own waste, the inverse of the mistake this tutorial mostly guards against.
+
+**Expected result:** A written verdict — *"All three conditions hold at real scale (1 only because the toy is small); shape is the Audit-extending hardening campaign; proceeding as a structural rehearsal."*
+**Checkpoint:** You can name which of the three conditions hold and which is borderline, and you didn't reach for a campaign merely because "there's a lot to do." Recognition first, ceremony second.
+
+### 2. Run the planning session — produce `CAMPAIGN.md` (no findings yet, no fixes)
+
+Session 1 of any campaign is a **planning session** ([§Session Types](../../ITERATIVE_METHODOLOGY.md#session-types) — heavy Phase 2, and its Phase 3 deliverable is *the plan itself*, not work product). The campaign extends the Audit workstream, exactly as the realized [`INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md`](../../workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md) does — its per-module audit primitive is what this campaign scales repository-wide. Copy the [blank template](../../workstreams/TEMPLATE_CAMPAIGN.md) and fill the load-bearing decisions:
+
+- **Choose the scoping unit.** One execution session per **audit dimension** — for code, the [Audit workstream's *When to Use*](../../workstreams/AUDIT_WORKSTREAM.md#when-to-use) frames these as *classes of issue* (*"security, performance, correctness, style"* — the same clause Tutorial 4 matched). Here the campaign picks its own — *correctness · input-validation · data-safety · error-handling* — the axis that splits cleanly and merges cleanly for this CLI.
+- **Lock the deliverable contract.** One per-finding schema, used by every unit, fixed *now*: `| # | dimension | location | severity | evidence | recommendation |`, with a closed status vocabulary. Schema drift across units is what forces consolidation rework.
+- **Set exit criteria.** A unit is done when its dimension is examined across every function in `todo.py` and every finding carries evidence; the campaign halts (not pauses — halts) on a systemic finding or a stakeholder direction change.
+
+```sh
+# in your installed project (adopter layout):
+mkdir -p docs/hardening-campaign/units
+cp docs/methodology/workstreams/TEMPLATE_CAMPAIGN.md docs/hardening-campaign/CAMPAIGN.md
+# fill: mode, the dimension list as the unit map, the locked per-finding schema, exit criteria
+```
+
+The bones of a filled `CAMPAIGN.md` — a thin coordination contract, not a fork of the framework:
+
+```markdown
+# Todo-CLI Hardening Campaign  (extends AUDIT_WORKSTREAM.md)
+Unit map (one execution session each): correctness · input-validation · data-safety · error-handling
+Per-finding schema (LOCKED): | # | dimension | location | severity | evidence | recommendation |
+Exit criteria: every dimension examined across all of todo.py; every finding has evidence.
+Consolidation deliverable: REPORT.md — prioritized remediation backlog feeding Development sessions.
+```
+
+Then **stop and get approval.** Stakeholder sign-off on `CAMPAIGN.md` is the campaign's second-highest-leverage gate (after each execution session's own implement gate) — a bad plan multiplies its cost across every unit. Because planning a campaign is the decision every later session inherits, this session runs at your agent's **deepest reasoning tier** ([Matching Reasoning Effort to Stakes](../../ITERATIVE_METHODOLOGY.md#matching-reasoning-effort-to-stakes) — high compounding cost ⇒ reason hard up front).
+
+**Expected result:** A real `CAMPAIGN.md` with the unit map, the locked schema, and exit criteria — and **zero code and zero findings produced**; planning sessions plan.
+**Checkpoint:** The plan exists and reads like the realized campaign templates — it specializes the session *sequence*, not the phases or gates. No `todo.py` was touched, no finding was filed; that's the next session's job.
+
+### 3. Run one execution session — one unit, committed as a checkpoint
+
+Session 2 is the first **execution session**, and it runs the full Audit pattern on **exactly one unit**. Pick the *input-validation* dimension. Pre-Flight reads `CAMPAIGN.md` first; the [Phase 1B stub](../../starter-kit/SESSION_RUNNER.md#1b-claim-the-session-mandatory) names the unit in progress (`unit: input-validation`) so a crash is detectable. Examine every function in `todo.py` against that one dimension, and file findings into the locked schema — `B1` resurfaces here with evidence, alongside any sibling the dimension turns up. Write the unit deliverable and **commit it before close-out** — the unit file *is* the checkpoint ([Resumability](../../workstreams/TEMPLATE_CAMPAIGN.md#resumability)).
+
+```markdown
+<!-- docs/hardening-campaign/units/input-validation.md -->
+| # | dimension        | location    | severity | evidence                                   | recommendation                     |
+|---|------------------|-------------|----------|--------------------------------------------|------------------------------------|
+| 1 | input-validation | todo.py:44  | moderate | `add_todo("")` creates a blank task (B1)   | reject empty/whitespace (own session) |
+| 2 | input-validation | todo.py:75  | low      | `cmd_add` forwards `args.text` unchecked   | validate at the core, not the shell   |
+```
+
+```sh
+python -m pytest                 # expect: still 16 passed — an audit unit changes no code
+git add docs/hardening-campaign/units/input-validation.md && git commit -m "campaign(hardening): input-validation unit"
+```
+
+Note what this unit is and isn't: it **files** findings, it does **not fix** them — the same Audit-vs-Development discipline Tutorial 4 taught (you found B1; you didn't patch it). The actual fixes are follow-on *Development* sessions that the campaign's consolidation backlog will feed — they live **outside** the campaign, exactly as the inherited-codebase campaign's backlog [feeds Development sessions](../../workstreams/INHERITED_CODEBASE_FAMILIARIZATION_CAMPAIGN.md). And notice how much of the prior series is still live here: this is still a six-phase session (Tutorial 2), it still scores its predecessor and hands off the next unit (Tutorial 3), and it's still governed by a consciously chosen workstream (Tutorial 4).
+
+**Expected result:** One committed `units/input-validation.md` with evidence-bearing rows in the locked schema; suite still green at 16; the handoff names **the next unit** (`data-safety`, which will pick up B2) as the specific next step.
+**Checkpoint:** Your deliverable is one unit's findings, on disk and committed, in the schema the plan locked. A future session — or a recovery after a crash — can read `CAMPAIGN.md`, see which units have files, and resume from the first one that doesn't. That checkpoint-and-resume property is the whole reason this is a campaign and not one long session.
+
+### 4. Stop at one unit — the per-unit boundary is the campaign's "1 and done"
+
+You finished `input-validation` fast and you can feel it: *"data-safety is right there, let me just knock out B2 too, and maybe start error-handling."* That pull is the one-session attempt re-emerging *inside* the campaign — and it is the same failure the campaign existed to prevent, now wearing a "vertical slice" costume. Two different units bundled into one session is **FM #26 (mega-session masquerading as a vertical slice)**; the "just keep going" that drives it is **FM #2 (keep going)**. The campaign's per-unit boundary is "1 and done" at campaign scale: one unit per session, then close out. Resist it, and the campaign stays resumable and uniformly rigorous; ignore it, and the second unit gets the thin reasoning the campaign was designed to avoid.
+
+**Expected result:** You closed out after one unit — `input-validation` only — even though the next unit looked cheap.
+**Checkpoint:** Exactly one new unit file exists, and your handoff (not a second commit of work) is what carries `data-safety` forward. If you'd bundled two units, the [Degradation Detection](../../starter-kit/SESSION_RUNNER.md#degradation-detection) row "two unrelated capabilities in one session → FM #26" would be firing.
+
+### 5. Consolidate — merge, find the cross-unit pattern, write the backlog
+
+Skip ahead now to the campaign's **consolidation session** (Session N+2). In real life it runs only after every execution unit is done; here you'll write a *partial* one over your single unit, which is itself a discipline — *do not synthesize coverage you did not produce.* The consolidation session **does not re-do per-unit work**: it aggregates the unit files, surfaces patterns visible only at campaign scale, and writes a prioritized remediation backlog as `REPORT.md`. The pattern the toy actually exposes once you line the findings up: **B1** (core trusts un-validated text) and **B2** (core overwrites the store without confirmation) are the *same* underlying weakness — *the core trusts its inputs and its filesystem blindly* — a finding no single unit could see.
+
+```markdown
+<!-- docs/hardening-campaign/REPORT.md (partial — 1 of 4 units complete) -->
+## Coverage
+input-validation: complete (2 findings). data-safety / correctness / error-handling: pending.
+## Cross-unit pattern
+The core layer trusts its inputs and its filesystem without guarding either (B1, and B2 once data-safety runs).
+## Remediation backlog (feeds Development sessions, ordered by severity)
+1. Validate todo text at the core (B1) — own session, own test.
+2. Confirm-before-overwrite for the store (B2) — own session.
+```
+
+The temptation here mirrors Step 4's: while merging you'll spot a fix and want to apply it. That's **consolidation creep** — log it in the backlog and keep merging; fixing during consolidation is per-unit work in the wrong session.
+
+**Expected result:** A `REPORT.md` that states honest partial coverage, names the cross-unit pattern, and lists an ordered remediation backlog — and changes no code.
+**Checkpoint:** You've now produced all three campaign deliverables — `CAMPAIGN.md`, one `units/*.md`, and a partial `REPORT.md` — and the report's backlog is the bridge back to ordinary Development sessions. The campaign is resumable from its first pending unit, and nothing was fixed inside it.
+
+## Common mistakes
+
+Cite the failure mode by number; link the list, don't paste it.
+(Full list: [Known Failure Modes](../../starter-kit/SESSION_RUNNER.md#known-failure-modes); campaign-specific anti-patterns live in [`TEMPLATE_CAMPAIGN.md` §Anti-Patterns](../../workstreams/TEMPLATE_CAMPAIGN.md#anti-patterns).)
+
+- **The one-session attempt.** Running the whole campaign — every dimension, all the findings — in a single session. The back half gets thinner reasoning than the front, and a crash restarts everything. This is the **one-session attempt** anti-pattern, and inside a session it surfaces as **FM #26 (mega-session)** and **FM #2 (keep going)**; the countermeasure is the per-unit boundary you held in Step 4.
+- **Manufacturing a campaign for one-session work.** The inverse mistake — standing up `CAMPAIGN.md`, units, and a consolidation session for work that fits in one sitting. The [three-part test](../../ITERATIVE_METHODOLOGY.md#when-to-write-or-invoke-a-campaign) exists to stop both directions; if condition 1 fails, the right answer is a normal session (or, if the work is a new *kind* of task, the [custom workstream from Tutorial 4](T4_workstreams.md)), not campaign ceremony.
+- **Skipping the planning session.** Jumping straight to filing findings without a locked schema in `CAMPAIGN.md`. Units written to different shapes don't merge, and the consolidation session pays for it in rework — the **skip-the-planning-session** anti-pattern. The countermeasure is Step 2's locked deliverable contract, approved before any unit runs.
+- **Consolidation creep.** Doing per-unit work in the consolidation session because you noticed a problem while merging. Stop, log it as a backlog item, return to merging — the **cross-unit consolidation creep** anti-pattern from Step 5.
+
+## You produced
+
+A complete pass through a multi-session campaign in miniature: a real `CAMPAIGN.md` whose plan locks the unit map and the per-finding schema, one committed execution unit (`units/input-validation.md`) that filed evidence without fixing anything, and a partial `REPORT.md` that surfaced a cross-unit pattern and handed a prioritized backlog to ordinary Development sessions. More durably, you have the **recognition skill** — the three-part test that tells you, before you build any of it, whether the deliverable in front of you is genuinely campaign-shaped or just large. You ran the three session types, felt the per-unit boundary that keeps a long campaign uniformly rigorous and resumable, and saw how a campaign sequences sessions *toward* a deliverable that no single session could produce — while every session inside it still ran the same six phases, the same handoff loop, and the same gates you've practiced since Tutorial 2.
+
+## Next
+
+→ The next roadmap stop is **T7 — Portfolio & Dashboard Ops** (run the methodology across many projects at once and read the health dashboard) — see the [curriculum](README.md#curriculum) for what's landed. For now, do it for real on Track A: take a deliverable you already suspect is too big for one session, run *only* its planning session, and let the `CAMPAIGN.md` — not a heroic marathon — be where the work gets organized.

--- a/docs/tutorials/T7_portfolio_dashboard.md
+++ b/docs/tutorials/T7_portfolio_dashboard.md
@@ -1,0 +1,110 @@
+# Tutorial 7: Portfolio & Dashboard Ops
+
+> **Objective:** Zoom out from one project to many — run the health dashboard in **portfolio mode** across every repo at once, read the risk matrix and the methodology-compliance grid, and turn the picture into a single decision: *where your next session goes.*
+> **Prerequisites:** [Tutorial 6: Multi-Session Campaigns](T6_campaigns.md) — you've now run a full arc on **one** project (install in T1, sessions in T2–T3, an audit and a custom workstream in T4, a campaign in T6). This tutorial is the first to operate *above* a single project. New here? Start at the [series index](README.md).
+> **Time:** ~20 minutes
+> **What you'll produce:** A generated **portfolio `dashboard.html`** covering two or more projects, and a one-line, evidence-backed allocation decision — *"next session → project X, because dimension Y is red,"* or the equally valid *"leave project Z alone; it shouldn't run the methodology at all."*
+> **Track:** Pick one and stick with it for this pass —
+> **A** (your own repos): point the scanner at the parent directory above the projects you actually maintain and read your real portfolio.
+> **B** ([sample project](sample-project/)): stand up a two-repo portfolio — your Tutorial 1–6 sample (high compliance) beside a bare, un-adopted second repo (zero compliance) — and let the contrast drive the decision.
+
+## Why this matters
+
+Every tutorial so far lived *inside* one project — install it, run sessions in it, audit it, run a campaign across it. But the people who get the most from this methodology run it across a *portfolio*: a dozen repos in different states of health, only some of which should even be using the framework. At that scale "which project needs me next?" stops being answerable from memory. The [methodology dashboard](../../README.md#methodology-dashboard) exists to answer it — it *"turns methodology compliance into a visible, measurable signal"* across every repo at once, so you spend scarce session capacity where it pays off instead of where it's top of mind.
+
+- [§Methodology Dashboard](../../README.md#methodology-dashboard) — what the scanner is and its **two auto-detected modes** (per-project vs. portfolio); the seven metric dimensions and the five weighted health scores.
+- [Dashboard Overview](../../README.md#dashboard-overview) and [Project Detail View](../../README.md#project-detail-view) — the portfolio summary, the risk matrix, the compliance table, and what expanding a single project card shows.
+- [When to Use / When Not to Use](../../README.md#when-to-use--when-not-to-use) and [When to Use This Methodology](../../ITERATIVE_METHODOLOGY.md#when-to-use-this-methodology) — because the dashboard surfaces *candidates*, and deciding which ones deserve the methodology (and which emphatically don't) is the actual skill.
+
+This tutorial does not restate the dashboard's metrics, scoring formula, or risk thresholds — they live in [§Methodology Dashboard](../../README.md#methodology-dashboard), one source of truth. It makes you *run portfolio mode once* and convert the picture into one allocation decision, the move every single-project tutorial has been building toward.
+
+## Before you start
+
+In [Tutorial 1](T1_setup.md#5-generate-the-dashboard) you ran `methodology_dashboard.py` from *inside* your project — that's **single-project mode**, and it scored that one repo. Portfolio mode is the same scanner with the same command; the only thing that changes is **where the script sits**: in the parent directory *above* your repos, where it auto-detects that it isn't itself in a git repo and scans the siblings instead. To see a portfolio you need at least two sibling git repos.
+
+```sh
+# Track B — from the parent directory that holds your Tutorial 1–6 sample (e.g. ~ if the sample is ~/todo-practice):
+ls todo-practice/SESSION_RUNNER.md          # your adopted sample is here, a git repo with high compliance
+# create a second project that has NOT adopted the methodology, beside the first:
+mkdir throwaway-script && ( cd throwaway-script && git init -q && \
+  printf 'print("hi")\n' > main.py && git add . && git commit -qm "init" )
+cp todo-practice/methodology_dashboard.py .  # T1's bin/sync put the scanner at the sample root; lift a copy up one level
+```
+
+**Checkpoint:** Your parent directory holds **two or more sibling git repos** and a copy of `methodology_dashboard.py`, and the parent directory is **not itself a git repo** (run `ls .git` here and expect "No such file" — that's what makes the scanner pick portfolio mode). Track B: you can see `todo-practice/`, `throwaway-script/`, and `methodology_dashboard.py` side by side.
+
+## Steps
+
+Each step is one action. Steps 1–2 *generate* the portfolio view, Step 3 *reads* it, Step 4 turns it into the one decision that is the deliverable, and Step 5 makes the score something you steer by over time. Don't skip ahead.
+
+### 1. Confirm the portfolio shape — two projects in two different states
+
+The teaching contrast is the point, so look before you run. Your sample project has been through six tutorials: it has `SESSION_RUNNER.md`, `SAFEGUARDS.md`, `SESSION_NOTES.md`, `BACKLOG.md`, `CHANGELOG.md`, `ROADMAP.md`, and `docs/methodology/` — the kind of files the [methodology-compliance checklist](../../README.md#methodology-dashboard) scores, plus a green test suite and a history of real commits. The throwaway repo has one file and one commit and *none* of that. One repo is the methodology working as designed; the other is a project that has never heard of it.
+
+**Expected result:** You can state, before running anything, that the sample should score high on compliance and *clearly lower risk* than the throwaway — though even the adopted sample isn't spotless (it ships no CI, an honest medium flag) — while the throwaway is the reverse on every dimension.
+**Checkpoint:** You know which repo is the "adopted" one and which is the "cold" one — so when the dashboard agrees with you, you'll trust it, and when it surprises you, you'll look closer.
+
+### 2. Run portfolio mode — one command, the whole portfolio
+
+From the parent directory, run the exact command from Tutorial 1 — only the *location* differs:
+
+```sh
+python3 methodology_dashboard.py        # same command as T1 §5; run from the PARENT dir → portfolio mode
+```
+
+Because the working directory isn't a git repo, the scanner [auto-detects portfolio mode](../../README.md#methodology-dashboard), discovers every sibling git repo, scores each, and aggregates them. It prints a color-coded portfolio summary to the terminal and writes a single self-contained `dashboard.html` (the same generated artifact you `.gitignore`d in T1 — leave it open and it auto-refreshes every 60 seconds).
+
+**Expected result:** The terminal lists **two projects**, each with a health score out of 100, a worst-risk level, and an activity state — *not* a single-project readout. `dashboard.html` is written and opens.
+**Checkpoint:** The terminal summary shows ≥2 projects and a portfolio-level health line. If it shows only one, the scanner picked single-project mode — you're running it from inside a repo; move up to the non-git parent and re-run.
+
+### 3. Read the risk matrix and the compliance grid — find where attention is owed
+
+Open `dashboard.html` and read it top-down, the way it's meant to be read ([Dashboard Overview](../../README.md#dashboard-overview)): the portfolio summary bar, then the **risk matrix** (projects bucketed critical / high / medium / low / healthy), then the **methodology-compliance table** (each project's checklist and percentage). Expand the throwaway repo's card ([Project Detail View](../../README.md#project-detail-view)) to see *which* dimensions are red — you'll find 0% methodology compliance, no tests, no CI, no README.
+
+| | Your sample (adopted) | The throwaway (cold) |
+|---|---|---|
+| Methodology compliance | high — the checklist is satisfied | **0%** — none of the files exist |
+| Testing | a real, green suite | none |
+| Risk bucket | **medium** — one honest `No CI/CD` flag, far healthier than the cold repo | **high** — 0% methodology, no tests, no CI |
+
+Notice the sample isn't spotless — its worst risk is **medium**, not healthy: it ships no CI workflow, and the card will show a couple of other honest gaps. That's the dashboard working as intended — it surfaces a real shortfall even in your well-tended project, which is exactly why you read the *named dimensions* rather than a single color.
+
+**Expected result:** You can name each project's health/100, its worst-risk bucket, and its compliance %, and point at the specific red dimensions on the cold repo's card.
+**Checkpoint:** You can say *why* the dashboard ranks one repo riskier than the other in terms of named dimensions — not "it looks worse," but "0% methodology, zero tests, no CI." The dashboard turned a vibe into evidence.
+
+### 4. Turn the picture into ONE decision — and don't adopt everywhere it shows red
+
+The dashboard is a decision *input*, not a trophy. Its output for you is a single sentence: which project gets your next session, and why. But here is the judgment the red doesn't make for you — **a project scoring 0% compliance is not automatically a project that needs the methodology.** If the throwaway is a one-off script you'll run twice and delete, its 0% is the *correct* score and the right next action is *nothing*: forcing the framework onto one-off, trivial, or exploratory work is the inverse waste the canonical guidance warns against ([README §When to Use / When Not to Use](../../README.md#when-to-use--when-not-to-use); [§When to Use This Methodology](../../ITERATIVE_METHODOLOGY.md#when-to-use-this-methodology)). So the decision has two honest forms:
+
+- *"Next session → bootstrap the throwaway (run [Tutorial 1](T1_setup.md) on it), because it's real, repeated work sitting at high risk and 0% compliance."* — the dashboard found a genuine gap.
+- *"No methodology for the throwaway — it's a one-off; 0% is the right score and the dashboard is working."* — the dashboard found a non-problem, and you said so.
+
+Reading the dashboard to reach this is cheap and fully reversible — the **lighter default** the [Matching Reasoning Effort to Stakes](../../ITERATIVE_METHODOLOGY.md#matching-reasoning-effort-to-stakes) rule reserves for low-blast-radius work. The deep reasoning belongs to the session this decision *sends you into* — especially if the dashboard points at work big enough to need the [campaign](T6_campaigns.md) you ran in Tutorial 6, whose planning session runs at your deepest tier.
+
+**Expected result:** One written sentence naming a project, a dashboard dimension as its evidence, and a When-to-Use verdict — either "bootstrap it" or "leave it."
+**Checkpoint:** Your decision cites a *named dimension* (compliance %, risk bucket, activity) and reflects a deliberate When-to-Use call. If your instinct was "adopt the methodology on every repo that showed red," you just caught yourself — that's the mistake Step 4 exists to prevent.
+
+### 5. Keep the score honest over time — re-run, and watch it move for the right reason
+
+A health score is longitudinal, not a one-time readout. If your decision was "bootstrap the throwaway," do it and re-run the scanner: its methodology dimension climbs off zero as the real files arrive, exactly as your sample's did across T1–T6. That moving compliance line — backed by sessions actually run — is the portfolio-scale cousin of the handoff ratchet from [Tutorial 3](T3_compounding_loop.md). What it is *not* is a number to inflate: the compliance dimension scores the *presence* of files, so you could bump it by touching empty `SESSION_RUNNER.md` stubs without running a single disciplined session. That's a vanity metric that hides drift — watch the [trend](../../starter-kit/SESSION_RUNNER.md#degradation-detection), not the snapshot.
+
+**Expected result:** You understand the compliance score as a signal you act on across sessions, and you can distinguish an honest rise (sessions run; files that exist because they're used) from a gamed one (empty stubs created to move the number).
+**Checkpoint:** You can describe what would make a project's methodology score rise *honestly* versus *dishonestly* — and you'd trust only the first.
+
+## Common mistakes
+
+Cite the failure mode by number; link the list, don't paste it.
+(Full list: [Known Failure Modes](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).)
+
+- **Mistaking a high compliance score for a well-run project.** The methodology dimension scores file *presence* — `SESSION_RUNNER.md`, `SAFEGUARDS.md`, `SESSION_NOTES.md`, `BACKLOG.md`, `docs/methodology/`. You can satisfy the checklist with empty stubs and never run a disciplined session: the score is necessary, not sufficient. A number you *maintain* in place of a discipline you *practice* is exactly how a 9/10 chain slides to 1/10 — **FM #17 (protocol erosion)**; the countermeasure is to read the [trend](../../starter-kit/SESSION_RUNNER.md#degradation-detection), not a single green snapshot.
+- **Adopting the methodology everywhere the dashboard shows red.** A one-off or throwaway repo *should* score 0% — that's the scanner working, not a backlog item. Forcing the framework onto work it doesn't fit produces ceremony with no payoff; the canonical guidance names exactly when **not** to adopt ([README §When to Use / When Not to Use](../../README.md#when-to-use--when-not-to-use), [§When to Use This Methodology](../../ITERATIVE_METHODOLOGY.md#when-to-use-this-methodology)).
+- **Confusing single-project and portfolio mode.** Run the scanner inside a repo and it scores that one project (and its submodules); run it from the parent directory above your repos and it scores them as a portfolio. If you expected the whole portfolio and got one project — or the reverse — check where the script is sitting; the [two modes are auto-detected by location](../../README.md#methodology-dashboard).
+- **Generating the dashboard and never acting on it.** A health report you read and forget is a vanity metric. The deliverable of a portfolio pass is a *decision* — which project gets the next session, or the explicit verdict that one shouldn't — not the HTML file.
+
+## You produced
+
+A real portfolio: a generated `dashboard.html` scoring two or more projects at once, and a one-line allocation decision backed by a named dimension — *"next session → X because Y,"* or the deliberate *"leave Z alone."* You ran the same scanner from Tutorial 1 in its other mode, read the risk matrix and the methodology-compliance grid, and — just as importantly — refused to adopt the framework on a repo that didn't warrant it. Methodology compliance is no longer a feeling about your projects; it's a measurable signal you steer the whole portfolio by, and you know the difference between a score that rose because the work got better and one that rose because someone gamed the checklist.
+
+## Next
+
+→ The next roadmap stop is **T8 — Keeping Adopters Current** (use `bin/sync` / `bin/status` to stay in step with the canonical repo) — see the [curriculum](README.md#curriculum) for what's landed. The dashboard tells you *where* to spend a session; `bin/sync` keeps the framework those projects run on *current*. For now, do it for real on Track A: point the scanner at the parent directory above your real repos and let the risk matrix — not your memory of which project felt neglected — choose your next session.

--- a/docs/tutorials/T7_portfolio_dashboard.md
+++ b/docs/tutorials/T7_portfolio_dashboard.md
@@ -107,4 +107,4 @@ A real portfolio: a generated `dashboard.html` scoring two or more projects at o
 
 ## Next
 
-→ The next roadmap stop is **T8 — Keeping Adopters Current** (use `bin/sync` / `bin/status` to stay in step with the canonical repo) — see the [curriculum](README.md#curriculum) for what's landed. The dashboard tells you *where* to spend a session; `bin/sync` keeps the framework those projects run on *current*. For now, do it for real on Track A: point the scanner at the parent directory above your real repos and let the risk matrix — not your memory of which project felt neglected — choose your next session.
+→ **[Tutorial 8: Keeping Adopters Current](T8_keeping_current.md)** — the dashboard tells you *where* to spend a session; `bin/status`/`bin/sync` keep the framework those projects run on *current* as the canonical repo evolves. Before you move on, do this one for real on Track A: point the scanner at the parent directory above your real repos and let the risk matrix — not your memory of which project felt neglected — choose your next session.

--- a/docs/tutorials/T8_keeping_current.md
+++ b/docs/tutorials/T8_keeping_current.md
@@ -1,0 +1,187 @@
+# Tutorial 8: Keeping Adopters Current
+
+> **Objective:** Keep an installed project in step with the canonical methodology as it evolves — read drift with **`bin/status`**, apply updates with **`bin/sync`**, and absorb a new release *without losing your project-specific customizations.*
+> **Prerequisites:** [Tutorial 7: Portfolio & Dashboard Ops](T7_portfolio_dashboard.md) — you've installed the framework (T1), run sessions and a campaign on one project (T2–T6), and zoomed out to the whole portfolio (T7). This is the **final** tutorial: it keeps everything the previous seven built *current.* You need a local `methodology/` checkout (Track B learners already have one — the sample came from it). New here? Start at the [series index](README.md).
+> **Time:** ~20 minutes
+> **What you'll produce:** An adopter project whose `bin/status` reads **`current` / `present` across the whole corpus** — reached the honest way: you detected real drift, previewed and applied the update, and handled a file you'd *locally modified* by relocating the edit into `CLAUDE.md` instead of force-overwriting it.
+> **Track:** Pick one and stick with it for this pass —
+> **A** (your own repo): a project you installed the framework into earlier (its files may genuinely be behind by now). Point the commands at your sibling `../methodology/` checkout.
+> **B** ([sample project](sample-project/)): the todo-CLI you bootstrapped in [Tutorial 1](T1_setup.md). Set `METH` to the methodology checkout it came from, as you did in T1, and run the commands against it.
+
+## Why this matters
+
+The framework you installed in Tutorial 1 is not frozen — it ships releases. Every release since v2.5 changed files *beyond* the original three that the old sync tool tracked, so adopters who synced "by the book" could **silently fall behind while the tool still reported `current`** — false confidence about whether you're running the latest discipline. The [v2.8 distribution work](../../README.md#whats-new-in-v28) closed exactly that gap: `bin/sync` and `bin/status` now cover the **full corpus** over a single shared manifest, so "am I current?" stops being a guess and becomes a per-file answer you can read.
+
+- [§What's New in v2.8](../../README.md#whats-new-in-v28) — the corpus-wide `bin/sync`/`bin/status`, the `seed` disposition, and the false-confidence gap this closes.
+- [`BOOTSTRAP.md` §Updating an existing project](../../starter-kit/BOOTSTRAP.md#updating-an-existing-project) — the canonical update workflow (`bin/status` → `bin/sync`) and the manual fallback.
+- [`BOOTSTRAP.md` §Step 5 — Customizations go in CLAUDE.md, not in synced files](../../starter-kit/BOOTSTRAP.md#step-5-customizations-go-in-claudemd-not-in-synced-files) — the customization seam that makes staying current friction-free *forever*.
+
+This tutorial does not restate what each file is, how disposition is decided, or the exact distribution list — that lives once in [`bin/_manifest.py`](../../bin/_manifest.py) and the docs above. It makes you *run the update loop once* and survive the one move that breaks it: editing a synced file in place.
+
+## Before you start
+
+You need the same local `methodology/` checkout your project was installed from — `bin/sync`/`bin/status` are scripts on disk there; they read canonical content from that checkout (`source: local`). Track B: set `METH` to it exactly as in [Tutorial 1](T1_setup.md), e.g. `METH=~/Development/methodology`. Track A: if you kept the portfolio layout (your project a sibling of the checkout), the relative `../methodology/` form works.
+
+```sh
+# Track B — confirm the checkout and that your sample was installed from it:
+ls "$METH"/bin/sync                 # the tool exists on disk
+ls SESSION_RUNNER.md docs/methodology/ITERATIVE_METHODOLOGY.md   # T1 put the corpus here
+```
+
+**Checkpoint:** `"$METH"/bin/sync` (or `../methodology/bin/sync`) exists, and your project already has `SESSION_RUNNER.md` at its root and `docs/methodology/` populated from Tutorial 1. If not, run [Tutorial 1](T1_setup.md) first — there's nothing to keep current until something is installed.
+
+## Steps
+
+Each step is one action. Step 1 *reads* state, Step 2 makes drift visible, Step 3 is the update loop, Step 4 is the one trap that breaks it, and Step 5 makes it a habit across the portfolio. Don't skip ahead.
+
+### 1. See exactly where you stand — `bin/status` (it writes nothing)
+
+`bin/status` is the read-only audit: it compares every distributed file in your project against the canonical checkout and prints one row per file. Run it from inside your project:
+
+```sh
+"$METH"/bin/status .          # Track B — $METH is your methodology checkout
+../methodology/bin/status .   # Track A — a sibling checkout
+```
+
+Right after a clean Tutorial-1 install, every row is `current` (TRACKED files match canonical) or `present` (SEED files exist):
+
+```
+source: local (/Users/you/Development/methodology)
+Project  File                                       Disposition  Status
+adopter  SESSION_RUNNER.md                          tracked      current
+adopter  SAFEGUARDS.md                              tracked      current
+adopter  RECOMMENDED_SKILLS.md                      tracked      current
+…
+adopter  SESSION_NOTES.md                           seed         present
+adopter  CHANGELOG.md                               seed         present
+adopter  ROADMAP.md                                 seed         present
+adopter  docs/methodology/ITERATIVE_METHODOLOGY.md  tracked      current
+…
+```
+
+The two **dispositions** are the whole model ([`bin/_manifest.py`](../../bin/_manifest.py)): **TRACKED** files are canonical-owned — `bin/sync` keeps them current and `bin/status` can report `current` / `N versions behind` / `locally modified` / `missing`. **SEED** files (`SESSION_NOTES.md`, `CHANGELOG.md`, `ROADMAP.md`) are *yours* after first creation — `bin/status` reports only `present` / `absent`, and an absent seed is **not** drift.
+
+**Expected result:** A per-file table, every TRACKED row `current` and every SEED row `present` — and your working tree is byte-for-byte unchanged (status never writes).
+**Checkpoint:** You can point at any row and say which disposition it is and what its status word means — and you confirm status changed *nothing* (`git status` in your project shows no new modifications from running it).
+
+### 2. Make real drift visible — simulate "I installed before the last release"
+
+In real life drift appears when the canonical repo ships a release after you installed. To *see* it now without waiting, roll one TRACKED file back to an earlier release tag — you're pretending you installed at v2.8 while the checkout has since moved to v2.9 — and delete a seed to show the contrast:
+
+```sh
+git -C "$METH" show v2.8:starter-kit/SESSION_RUNNER.md > SESSION_RUNNER.md   # pretend this was installed at v2.8
+rm CHANGELOG.md                                                              # pretend a seed was never committed
+"$METH"/bin/status .
+```
+
+```
+adopter  SESSION_RUNNER.md  tracked  1 version behind
+adopter  CHANGELOG.md        seed     absent
+```
+
+`bin/status` names the gap precisely: `SESSION_RUNNER.md` is **1 version behind** (v2.9 added a reasoning-effort line your v2.8 copy is missing — that's the exact content you'd be running without), and `CHANGELOG.md` is **absent**. `N versions behind` counts how many distinct committed versions of that file lie between yours and canonical, so your own number may differ from the `1` above. The seed's `absent` is reported but is *not* a defect to chase — it's a file you own.
+
+**Expected result:** Status flips the rolled-back file to `N versions behind` and the deleted seed to `absent`; everything else stays `current` / `present`.
+**Checkpoint:** You can state *which* file is behind and by how much from the report alone — the "am I current?" guess is now an evidence-backed answer. That conversion is the false-confidence gap [v2.8](../../README.md#whats-new-in-v28) closed.
+
+### 3. Bring it current — preview first, then sync
+
+The update loop is **status → dry-run → sync → status**. Look before you leap with `--dry-run` (writes nothing — it only prints intent), then apply:
+
+```sh
+"$METH"/bin/sync . --dry-run     # preview: 'would write' / 'would create', nothing touched
+"$METH"/bin/sync .               # apply
+"$METH"/bin/status .             # confirm
+```
+
+The dry run shows intent; the real run reports `updated` for the file that drifted and `created` for the re-seeded one — and every file that was already current reports `unchanged`, so sync only ever touches what actually moved:
+
+```
+  version: v2.9
+  files:
+    SESSION_RUNNER.md: updated
+    CHANGELOG.md: created
+    …                 (every other file: unchanged)
+```
+
+The `version:` line is `git describe --tags` of your checkout, so it reads whatever release you're on. After sync, status returns every row to `current` / `present`. (SEED note: sync re-creates a seed *only when it's absent* — an existing seed is never clobbered, even with `--force`, because once it exists it's yours.)
+
+**Expected result:** `--dry-run` changes nothing; the real run writes only the drifted/absent files; the follow-up status is all `current` / `present` again.
+**Checkpoint:** Your project is current, and you reached it by previewing first — you never overwrote a file without seeing the intent. You've run the whole loop once.
+
+### 4. The one trap — customizations don't go in synced files
+
+Now the move that breaks everything. Say you want this project to always run its linter in Phase 5, so you edit `SESSION_RUNNER.md` directly. The next sync refuses:
+
+```sh
+# (you appended a custom note to SESSION_RUNNER.md)
+"$METH"/bin/sync .
+```
+
+```
+  ERROR: the following files have local modifications that don't match
+  any canonical or historical version and would be overwritten:
+    SESSION_RUNNER.md
+
+  The recommended pattern (see plan §3.2) is to move per-project
+  customizations into CLAUDE.md's 'Project-Specific Methodology
+  Adaptations' section, keeping synced files byte-identical to canonical.
+
+  To proceed anyway and overwrite local changes, pass --force.
+```
+
+Sync **exits non-zero and writes nothing** — it will not silently eat an edit it doesn't recognize (`bin/status` labels the same file `locally modified`). The tempting fix is `--force`, and used *first* it is the wrong one: it discards your edit **and** leaves you forking the shared procedure every release — that is **FM #17 (protocol erosion)** wearing a convenience flag, the exact slow-drip that slides a 9/10 chain to 1/10 ([Known Failure Modes](../../starter-kit/SESSION_RUNNER.md#known-failure-modes)). The right fix is the **customization seam**: move the rule into `CLAUDE.md`'s *Project-Specific Methodology Adaptations* section, then restore the file to canonical and re-sync clean ([`BOOTSTRAP.md` §Step 5](../../starter-kit/BOOTSTRAP.md#step-5-customizations-go-in-claudemd-not-in-synced-files); [§Troubleshooting](../../starter-kit/BOOTSTRAP.md#troubleshooting)):
+
+```sh
+# 1. record the linter rule in CLAUDE.md → "Project-Specific Methodology Adaptations"
+# 2. now that the intent is safe, discard the orphaned in-file edit and take canonical:
+"$METH"/bin/sync . --force        # safe HERE — the customization already lives in CLAUDE.md
+"$METH"/bin/status .              # SESSION_RUNNER.md → current
+```
+
+`--force` is dangerous only when it runs *before* you've relocated the edit; once the intent lives in `CLAUDE.md` — which every session already reads — discarding the in-file copy loses nothing. Your customization survives, the synced file stays byte-identical to canonical, and the next release applies without a single conflict.
+
+**Expected result:** Sync refuses the unrecognized edit (exit non-zero, no write); after you move the rule to `CLAUDE.md` and re-sync, `SESSION_RUNNER.md` is `current` and your customization is intact in `CLAUDE.md`.
+**Checkpoint:** Your project is current *and* still does the project-specific thing you wanted — because the customization lives in the file built to hold it, not in the file built to be replaced. If your instinct in Step 4 was to reach straight for `--force`, you just learned why the seam exists.
+
+### 5. Make it routine — and keep the checkout itself fresh
+
+Two habits turn this into maintenance you don't think about:
+
+- **Audit the portfolio before a work session.** `bin/status` takes many paths and shell-expands globs, so one command reports drift across every project — the [Tutorial 7](T7_portfolio_dashboard.md) portfolio cousin: the dashboard tells you *where* the next session goes; `bin/status` tells you whether the framework that project runs on is itself current first.
+
+  ```sh
+  "$METH"/bin/status ~/projects/*     # one row per file, per project
+  ```
+
+- **Pull the checkout before you trust "current."** `status`/`sync` compare against your **local** checkout (`source: local`), so `current` means "current with whatever your checkout holds" — a stale checkout reports green against an old canonical. Update the checkout first, or compare against GitHub directly ([`BOOTSTRAP.md` §Updating](../../starter-kit/BOOTSTRAP.md#updating-an-existing-project)):
+
+  ```sh
+  git -C "$METH" pull                 # bring the checkout to the latest release, THEN status/sync
+  "$METH"/bin/status . --source=github   # or: compare straight against canonical on GitHub (needs gh CLI)
+  ```
+
+Keeping current is cheap and fully reversible — the **lighter default** the [Matching Reasoning Effort to Stakes](../../ITERATIVE_METHODOLOGY.md#matching-reasoning-effort-to-stakes) rule reserves for low-blast-radius work. The deep reasoning belongs to the sessions this maintenance *protects*, not to the sync itself.
+
+**Expected result:** You can audit every project's drift in one command and you know why a fresh checkout (or `--source=github`) must precede trusting a `current`.
+**Checkpoint:** You can describe the full update loop — pull the checkout, `bin/status` the project(s), `bin/sync` what drifted, relocate any in-file customizations to `CLAUDE.md` — without re-reading this page.
+
+## Common mistakes
+
+Cite the failure mode by number; link the list, don't paste it.
+(Full list: [Known Failure Modes](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).)
+
+- **Editing a synced file in place — then forcing past the refusal.** A direct edit to `SESSION_RUNNER.md` / `SAFEGUARDS.md` / any TRACKED file becomes drift that blocks the next update; reaching for `--force` *before* relocating the edit discards your work and keeps you forking the shared procedure release after release. That's **FM #17 (protocol erosion)** — improvement-by-subtraction-or-fork during a session. The countermeasure is the customization seam: project additions live in `CLAUDE.md`'s Adaptations section, synced files stay byte-identical to canonical ([`BOOTSTRAP.md` §Step 5](../../starter-kit/BOOTSTRAP.md#step-5-customizations-go-in-claudemd-not-in-synced-files)).
+- **Trusting memory that you're current instead of running `bin/status`.** "I synced a while ago, I'm probably fine" is exactly the false confidence the v2.8 work existed to kill — the old tool tracked three files and reported `current` while the rest of the corpus silently fell behind. Read the per-file report, don't assume ([§What's New in v2.8](../../README.md#whats-new-in-v28)).
+- **Syncing from a stale checkout.** `status`/`sync` compare against your local `methodology/` checkout, so `current` against a checkout you never `git pull` isn't current against canonical. Pull the checkout first, or pass `--source=github` to compare against the live repo.
+- **Chasing an `absent` seed as if it were drift.** `SESSION_NOTES.md` / `CHANGELOG.md` / `ROADMAP.md` are adopter-owned; `absent` is a legitimate state, not a defect. Sync will re-seed a missing one, but you never *have* to — they're yours, not canonical's.
+
+## You produced
+
+An installed project whose `bin/status` reads `current` / `present` across all 21 distributed files — reached honestly. You ran the read-only audit, manufactured real drift and watched status name it to the file, previewed with `--dry-run` and applied with `bin/sync`, and — the move that matters — handled a file you'd locally modified by relocating the edit into `CLAUDE.md` rather than force-overwriting it. Staying current is no longer a hope; it's a loop you can run on one project or the whole portfolio, and you know the one trap that turns "friction-free forever" into "merge conflict every release."
+
+That closes the series. Tutorial 1 installed the framework; Tutorials 2–6 ran it on one project through sessions, a custom workstream, and a campaign; Tutorial 7 zoomed out to the portfolio; and Tutorial 8 keeps all of it current as the canonical methodology itself evolves.
+
+## Next
+
+→ **You've finished the track.** There's no Tutorial 9 — T8 was the final roadmap stop, and the [curriculum](README.md#curriculum) is complete. The real next step isn't another lesson: point [`bin/status`](../../starter-kit/BOOTSTRAP.md#updating-an-existing-project) at your actual projects, bring the drifted ones current, and go run a real session — with [Phase 0 Orient](T2_first_session.md), the [Present gate](T5_cautionary.md), and the [handoff ratchet](T3_compounding_loop.md) now muscle memory. Loop back to the [series index](README.md) any time you want to re-run a lesson on a new project.


### PR DESCRIPTION
## What

Completes the **hands-on tutorial roadmap** in `docs/tutorials/`. The core trio (T1/T2/T5) shipped in #38 / v2.9; this PR adds the five remaining lessons and closes the T1→T8 chain:

| Tutorial | Teaches |
|----------|---------|
| **T3 — The Compounding Loop** | Run *both sides* of the handoff-accountability loop once: score Session 1's handoff (1–10, with evidence), build the next feature faster because the handoff teed it up, then write a handoff knowing Session 3 will score it. |
| **T4 — Choosing & Adapting a Workstream** | Pick the right workstream by matching the task to each lens's *When to Use*; the running CLI becomes an Audit session that *surfaces* B1/B2 as findings (not fixes); spin up a custom `RELEASE_WORKSTREAM.md` from the template when none fits. |
| **T6 — Multi-Session Campaigns** | Run the three campaign session types — planning → one execution unit → consolidation — in miniature, carrying the repo-wide hardening T4's audit recommended; teaches the "is this *actually* a campaign?" recognition test first. |
| **T7 — Portfolio & Dashboard Ops** | First lesson *above* one project: run `methodology_dashboard.py` in portfolio mode across a two-repo portfolio, read the risk matrix + compliance grid, and turn it into one evidence-backed "where the next session goes" decision — including *not* adopting the framework on a repo that doesn't warrant it. |
| **T8 — Keeping Adopters Current** | The `bin/status` → `bin/sync` update loop, and the one trap that breaks it (editing a synced file in place → relocate the edit to `CLAUDE.md`, tied to FM #17). Every tool output reproduced live. |

Plus `docs/tutorials/README.md` recomposed to **current-state** (single complete T1–T8 track; dropped the "core trio / first cut / roadmap" framing and the now-uniform Status column), and `T5_cautionary.md`'s footer recomposed to match.

## Why

One good session is just a good session — the methodology's payoff is **compounding**, and that lives in the seams between sessions, across workstreams, across a campaign, and across a portfolio. The tutorials make each of those seams *felt* on a single running example: T1 installs the framework on the bundled `sample-project/`, T2 runs Session 1, and T3→T8 thread the same todo-CLI through the compounding loop, a workstream switch, a campaign, the portfolio dashboard, and staying current. They **cite, don't restate** — every principle, phase, gate, FM, and workstream is linked to its canonical home, never forked.

## Conventions honored

- **Canonical-only learning aid** — `docs/tutorials/` is deliberately **not** in the `bin/_manifest.py` distribution corpus; adopters don't receive it via `bin/sync`. The distributed-file pointer to it uses an absolute GitHub URL (v2.8 link-topology convention); intra-tutorial `../../` links resolve in the canonical repo layout.
- No principle / phase / gate / workstream / FM changes; **FM count stays 26**.

## Verification

Deterministic gates, all green on the final branch:

- `bin/check-links` OK (78 relative links across 20 distributed files resolve in the simulated adopter tree)
- `bin/tests.sh` — 51/51
- sample-project `pytest` — 7/7 (F1/F2 deliberately implemented *by the learner* in T2/T3)
- `bin/sync --dry-run` excludes `docs/tutorials/` (non-distribution invariant holds)
- All **91** cross-boundary `#anchors` resolve to a real heading (GitHub-slug check)

Each tutorial had its own pre-commit adversarial review (5–6 lenses, default-to-refuted). Before marking this PR ready, a final adversarial workflow re-reviewed the **accumulated set as one unit** (semantic citation correctness · cite-don't-restate · current-state coherence · reproducible tool-output claims). It confirmed **one** should-fix defect — T5's footer was the sole surviving "core trio … is now live" outlier after T8's recompose — now fixed in the final commit; zero blockers, no anchor/link/factual breakage.

## Notes for the reviewer

Built incrementally on one branch per the agreed one-branch roadmap plan; commits are append-only (T3 → T4 → T6 → T7 → T8 → footer fix), each independently reviewed. Strict horizontal "1 and done" framing of the tutorial structure is preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
