### PR TITLE
docs(readme): reconcile Tutorials section to current state (full T1–T8 published)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Expand any project card to see health breakdown by dimension, risk factors, git 
 
 ## Tutorials
 
-New to the methodology? The **[tutorials](docs/tutorials/)** are a hands-on, progressive learning track — install the framework, run a real session end to end, and learn where the guardrails catch you. Each lesson has you *do* one thing against a real project (your own repo, or the bundled [sample project](docs/tutorials/sample-project/)), with a checkpoint at every step. The core trio (Setup → First Session → Cautionary Use) is published; see the **[series index](docs/tutorials/)** for the full curriculum.
+New to the methodology? The **[tutorials](docs/tutorials/)** are a hands-on, progressive learning track — install the framework, run a real session end to end, and learn where the guardrails catch you. Each lesson has you *do* one thing against a real project (your own repo, or the bundled [sample project](docs/tutorials/sample-project/)), with a checkpoint at every step. The full track — Setup through Keeping Adopters Current (T1–T8) — is published; see the **[series index](docs/tutorials/)** for the full curriculum.
 
 ## Repository Structure
 


### PR DESCRIPTION
## What

One-line reconciliation of the README **§Tutorials** pointer. It still read *"the core trio (Setup → First Session → Cautionary Use) is published,"* written when only T1/T2/T5 had shipped. The full eight-tutorial track (T1–T8) landed via #40, so this present-tense, user-facing line now under-claims:

```diff
-The core trio (Setup → First Session → Cautionary Use) is published; see the **[series index](docs/tutorials/)** for the full curriculum.
+The full track — Setup through Keeping Adopters Current (T1–T8) — is published; see the **[series index](docs/tutorials/)** for the full curriculum.
```

## Scope

Deliberately just the one **live current-state** line. The **dated** changelog entries — `README` "What's New in v2.9" and the `CLAUDE.md` Versioning bullet ("Roadmap T3/T4/T6/T7/T8 remain") — are left **verbatim by design**: they accurately record what v2.9 shipped, per the v2.7.1 *"a changelog records what shipped at the time"* convention.

No principle, phase, gate, workstream, or failure-mode changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)