### PR TITLE
chore(reuse): add REUSE compliance + license/REUSE README badges

### DIFF
--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,18 @@
+MIT License
+
+Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Iterative Session Methodology
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![REUSE status](https://api.reuse.software/badge/github.com/KJ5HST/methodology)](https://api.reuse.software/info/github.com/KJ5HST/methodology)
+
 A framework for producing high-quality software through structured, self-correcting AI agent sessions. Each session follows a fixed phase sequence, accumulates knowledge, and feeds lessons back into the process. The result: sessions compound — session 40 is dramatically better than session 10, using the same tools on the same type of work.
 
 ## The Problem

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -1,0 +1,12 @@
+version = 1
+
+# Bulk license/copyright declaration for the whole tree (REUSE 3.x).
+# This repository is a documentation framework plus a few standard-library-only
+# scripts; every file is MIT-licensed. Declaring it here — rather than adding an
+# SPDX header to each of the ~50 Markdown documents — keeps the docs clean while
+# still making `reuse lint` pass and the licensing machine-readable per file.
+
+[[annotations]]
+path = "**"
+SPDX-FileCopyrightText = "2025-2026 Terrell Deppe (KJ5HST)"
+SPDX-License-Identifier = "MIT"


### PR DESCRIPTION
## What

Adds two README badges and the metadata that makes one of them substantive:

| Badge | What it is |
|---|---|
| `![License: MIT]` (shields.io) | Restates the license for at-a-glance README scannability. Navigation, not a compliance claim. |
| `![REUSE status]` (FSFE) | The real one. Backed by new `REUSE.toml` + `LICENSES/MIT.txt` so **every file** carries machine-readable, per-file SPDX copyright + license provenance. |

## Why these two (and not the others)

REUSE fits this repo precisely because the framework is adopted **file-by-file** (starter-kit files, workstreams, `SESSION_RUNNER.md`) — a lifted file now stands on its own MIT footing, and the badge is *earned* (only green once `reuse lint` passes), not decorative.

Deliberately skipped **FOSSA / Snyk / OpenSSF Scorecard**: with no dependency manifest (stdlib-only Python) they render trivially green or, in Scorecard's case, undersell a docs repo. Displaying them would signal diligence never exercised.

## How it's built

- **Additive.** `REUSE.toml` declares the whole tree in bulk (`path = "**"`), so **no existing file is edited except the README badge lines** — the ~50 Markdown docs stay header-free.
- **`LICENSES/MIT.txt`** is the canonical SPDX MIT template (via `reuse download MIT`).
- Copyright attributed to `2025-2026 Terrell Deppe (KJ5HST)`, matching `LICENSE`.

## Verification

```
$ reuse lint
* Files with copyright information: 53 / 53
* Files with license information: 53 / 53
Congratulations! Your project is compliant with version 3.3 of the REUSE Specification :-)
```

## Notes for the maintainer

- Badge URLs point at the canonical `KJ5HST/methodology`.
- The **REUSE badge renders green once `REUSE.toml` is on the default branch** (it scans live); before merge it reflects the current default branch. First render may need a one-time prime by visiting the `api.reuse.software/info/...` link.
- No principle, phase, gate, workstream, or FM change. Not a `bin/_manifest.py`-distributed file set, so adopters receive no synced change from this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)