### PR TITLE
docs(how-to-use): sync close-out docs to the v3.1 FM #27 ledger (FM count 23→27, rows 24–27, T2 refresh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
 
 ---
 
+### 2026-07-08 · [ad hoc] HOW_TO_USE + T2 tutorials: sync close-out docs to the v3.1 FM #27 ledger
+- **Change:** `HOW_TO_USE.md` (a distributed file) and the `docs/tutorials/T2_*` pair predated failure
+  mode #27 and still taught a pre-ledger close-out. Now current: `HOW_TO_USE.md` FM count **23 → 27**
+  (two sites) with compressed rows **24–27** added, and the `CHANGELOG.md` action-ledger recording folded
+  into the 3E close-out step (cited as Failure Mode #27); `T2_first_session.md` + `T2_worked_transcript.md`
+  show the Phase 3F ledger entry, the paired `BACKLOG.md` removal for a `[BL-N]` item, and explicit
+  `git add` staging (so a freshly-seeded, still-untracked ledger is not silently dropped by `git commit -am`).
+  Resolves the pedagogical-refresh half of fork backlog BL-6. Deliberately out of scope, tracked as a
+  BL-6 follow-up: `HOW_TO_USE.md`'s close-out enumeration still lacks the Phase 3E runtime smoke-test step
+  and its 3E/3F lettering lags canonical.
+- **Commit/PR:** this commit — branch `docs/how-to-use-fm27-ledger` → upstream PR (docs-lag correction, no version event).
+- **Session:** BL-6 item 1 · **Verified:** 6-lens adversarial review (4 fidelity findings fixed); 51/51 `bin/tests.sh`; co-staged through `.githooks/pre-commit`.
+
 ### 2026-07-07 · [ad hoc] BOOTSTRAP: add earlier-version→v3.1 adopter migration note (seed CHANGELOG not auto-updated)
 - **Change:** a local v3.0→v3.1 adopter-migration trial (real `bin/sync` against a pristine v3.0 tree)
   confirmed the update path is sound — **8 tracked files upgrade with no `--force`**, drift guard intact —

--- a/HOW_TO_USE.md
+++ b/HOW_TO_USE.md
@@ -762,14 +762,14 @@ The session runner is deliberately short. It fits in a single read. Every line i
 - **3B: Self-assess** — Compare work to previous sessions' quality bar
 - **3C: Document learnings** — Update the workstream document; record project learnings in CLAUDE.md → Adaptations → Project-specific Learnings (adopters), or append to the SESSION_RUNNER learnings table (canonical repo dogfooding)
 - **3D: Write handoff notes** — Update SESSION_NOTES.md for the next session. **The agent knows the next session will score these notes**, which changes the quality of what gets written.
-- **3E: Commit** — All changes committed
+- **3E: Commit** — All changes committed. **Record the action ledger:** append one dated, source-tagged entry per action to `CHANGELOG.md` and co-stage it with the commit (Failure Mode #27) — the durable answer to "what was done here, ever?", distinct from the session-overwritten handoff notes.
 - **3F: Report and STOP** — Summary to user including previous session's handoff score, then session is over
 
 The close-out is the most important innovation. Before the session runner, close-out was manual — the user had to explicitly tell the agent to self-assess, update the prompt, and stop. The agent's natural tendency is to finish the deliverable and immediately start the next one (Failure Mode #2). Making close-out automatic and mandatory means the self-improvement loop runs every session, not just the sessions where the user remembers to ask for it.
 
 The **handoff accountability loop** (steps 3A and 3D) is what makes sessions compound. Without it, handoff notes are perfunctory. With it — knowing the next session will score you, and having scored your predecessor — handoff notes include gotchas, file references with line numbers, and explicit warnings about traps. This single change (added around Session 34) correlated with 14 consecutive clean deliveries.
 
-**Known Failure Modes** — A table of 23 documented agent tendencies with specific countermeasures. This table exists because agents exhibit predictable failure patterns:
+**Known Failure Modes** — A table of 27 documented agent tendencies with specific countermeasures. This table exists because agents exhibit predictable failure patterns:
 
 | # | Tendency | Countermeasure |
 |---|----------|----------------|
@@ -796,6 +796,10 @@ The **handoff accountability loop** (steps 3A and 3D) is what makes sessions com
 | 21 | Greenfield assumption | Assume existing capabilities; read baseline docs during Orient |
 | 22 | Overwrite user edits | Check git blame before modifying; never regenerate without confirming |
 | 23 | Question-as-instruction | Present options and wait; a question is not a go-ahead |
+| 24 | Build-passes-ship-it (build success ≠ runtime correctness) | If the deliverable changes runtime behavior, launch the app before close-out; "build clean" is necessary but not sufficient |
+| 25 | Horizontal slicing (all-of-a-layer, never end-to-end) | Vertical slices (tracer bullets) — one feature through every layer; ask "if I stop here, is something working?" |
+| 26 | Mega-session posing as a vertical slice | One slice = ONE capability = one pre-declared, operator-approved layer list; split multiple intents |
+| 27 | Unrecorded action (commit/close out without logging it) | Append one dated, source-tagged CHANGELOG.md entry per action at close-out, newest on top |
 
 The failure modes table serves two purposes: it warns the agent about its own tendencies, and it gives the user language for course-correction ("You're doing Failure Mode #2 — stop and close out").
 
@@ -827,7 +831,7 @@ To use the session runner in your own project:
 
 3. **Update the task-to-workstream mapping table** (Phase 1) to match your project's workstream prompts.
 
-4. **Update the failure modes table** with any tendencies specific to your project. The 23 documented modes are common to most AI agent work, but your project may surface additional ones.
+4. **Update the failure modes table** with any tendencies specific to your project. The 27 documented modes are common to most AI agent work, but your project may surface additional ones.
 
 5. **Put the methodology framework in a known location** (e.g., `docs/methodology/`) so the session runner can reference it.
 

--- a/docs/tutorials/T2_first_session.md
+++ b/docs/tutorials/T2_first_session.md
@@ -86,7 +86,7 @@ python -m pytest -q                # green: 12 passed  (7 original + 5 new)
 
 ### 6. Close out — hand off, runtime-verify, commit, and STOP
 
-**Phase 3** is automatic; the agent does it without being asked, in order: record any project learning (3C), write the handoff (3D), then — because this deliverable changes runtime behavior — actually run the app to confirm the feature is live (3E; "tests pass" is not enough for a runtime change), and finally commit one atomic change (3F) and stop.
+**Phase 3** is automatic; the agent does it without being asked, in order: record any project learning (3C), write the handoff (3D), then — because this deliverable changes runtime behavior — actually run the app to confirm the feature is live (3E; "tests pass" is not enough for a runtime change), and finally record the action in the `CHANGELOG.md` ledger and commit one atomic change with that entry co-staged (3F), then stop.
 
 ```sh
 # Track B runtime smoke test — the feature is active, not just compiled:
@@ -95,8 +95,8 @@ python3 todo.py --file demo.json done 1     # -> done #1: write the report
 python3 todo.py --file demo.json list        # -> 1 [x] write the report
 ```
 
-**Expected result:** A full handoff written to `SESSION_NOTES.md` (what was done + commit, what's next, key files with line numbers, gotchas, a self-assessment score), a runtime smoke test, one commit, and a stop.
-**Checkpoint:** `SESSION_NOTES.md` holds a handoff that names the next item (F2) and the key files; `git log` shows one feature commit; the agent did **not** start F2 or fix B1. That stop is "1 and done" — [FM #2](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).
+**Expected result:** A full handoff written to `SESSION_NOTES.md` (what was done + commit, what's next, key files with line numbers, gotchas, a self-assessment score), a runtime smoke test, one `CHANGELOG.md` ledger entry (with F1 struck from `BACKLOG.md`), one commit, and a stop.
+**Checkpoint:** `SESSION_NOTES.md` holds a handoff that names the next item (F2) and the key files; `git log` shows one feature commit; `CHANGELOG.md` gained one dated entry for F1 and `BACKLOG.md` no longer lists it; the agent did **not** start F2 or fix B1. That stop is "1 and done" — [FM #2](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).
 
 ## Common mistakes
 

--- a/docs/tutorials/T2_worked_transcript.md
+++ b/docs/tutorials/T2_worked_transcript.md
@@ -229,10 +229,19 @@ no todo with id 99            # exit status 1
 
 The feature is *active*, not just compiled. (Skipping this is [FM #24, build-passes-ship-it](../../starter-kit/SESSION_RUNNER.md#known-failure-modes).)
 
-### 3F — Commit *(one fix, one commit)*
+### 3F — Record the ledger, then commit *(one action, one commit)*
+
+F1 came from the backlog, so its close-out does two paired things in the **same commit**: prepend a dated, source-tagged line to the project's `CHANGELOG.md` action ledger (setup seeded one — [T1 Step 3](T1_setup.md)) **and** strike F1 from `BACKLOG.md` (a `[BL-N]` entry clears its item). Stage both **explicitly** — a freshly-seeded ledger may still be untracked, and `git commit -am` skips untracked files, so it would silently drop the entry — the very [FM #27, unrecorded action](../../starter-kit/SESSION_RUNNER.md#known-failure-modes) this step prevents:
 
 ```text
-$ git commit -am "feat(todo): add `done <id>` to mark a task complete (F1)"
+# prepended to CHANGELOG.md (newest on top):
+### 2026-06-22 · [BL-F1] todo done <id> — mark a task complete
+- **Commit:** (hash) · **Session:** S1 · **Verified:** 12/12 tests green; CLI smoke-tested (done + invalid id → exit 1)
+
+# F1 struck from BACKLOG.md in the same commit
+
+$ git add CHANGELOG.md BACKLOG.md todo.py test_done.py
+$ git commit -m "feat(todo): add `done <id>` to mark a task complete (F1)"
 ```
 
 ### 3G — Report and STOP


### PR DESCRIPTION
## What

`HOW_TO_USE.md` (a **distributed** file adopters receive via `bin/sync`) and the `docs/tutorials/T2_*` pair predated **v3.1's failure mode #27** and still taught a pre-ledger close-out. This brings them current — a docs-lag correction, no behavioral change.

## Changes

**`HOW_TO_USE.md`** (distributed)
- Failure-mode count **23 → 27** (two sites: the table caption and the "integrating the session runner" step).
- Appended compressed rows **24–27** to the Known Failure Modes table, faithful to canonical `starter-kit/SESSION_RUNNER.md` (including FM #24's "if the deliverable changes runtime behavior" conditional).
- Folded the `CHANGELOG.md` action-ledger recording into the 3E close-out bullet, cited as **Failure Mode #27**.

**`docs/tutorials/T2_first_session.md` + `T2_worked_transcript.md`** (canonical-only)
- The 3F close-out now shows the Phase 3F ledger entry, the **paired `BACKLOG.md` removal** required for a `[BL-N]` item, and **explicit `git add` staging** — because a freshly-seeded, still-untracked `CHANGELOG.md` is silently dropped by `git commit -am`, reproducing the very FM #27 the step prevents.

## Scope

Resolves the **pedagogical-refresh** half of a fork-side tracking item (BL-6). **Deliberately deferred** to keep scope to the ledger/count work (tracked as a BL-6 follow-up): `HOW_TO_USE.md`'s close-out enumeration still lacks the Phase 3E runtime smoke-test step and its 3E/3F lettering lags canonical.

## Verification

- 6-lens adversarial review over the diff (count consistency, FM-row faithfulness, ledger-mechanism correctness, anchors, tutorial reproducibility, scope) — 4 fidelity findings caught and fixed.
- `bin/tests.sh`: **51/51**.
- No version event (docs-lag correction; FM #27 already shipped in v3.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)