### PR TITLE
docs(how-to-use,tutorials): close-out 3E smoke test + T1 setup commit (BL-6 1a/1b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
 
 ---
 
+### 2026-07-08 · [ad hoc] HOW_TO_USE close-out gains Phase 3E smoke test (re-lettered 3E→3F, 3F→3G); T1 commits the seeded ledger
+- **Change:** two v3.1 close-out fidelity fixes to the teaching docs (fork backlog BL-6 follow-ups 1a + 1b).
+  **1a** — `HOW_TO_USE.md` §Phase 3 Close Out gained the missing **3E: Runtime smoke test** step and
+  re-lettered the trailing two to match canonical `SESSION_RUNNER.md` (Commit **3E→3F**, Report and STOP
+  **3F→3G**); the FM #27 ledger recording stays in the re-lettered **3F Commit**, and the failure-mode
+  table now cites the close-out letters (FM #24 → Phase 3E, FM #27 → Phase 3F). **1b** —
+  `docs/tutorials/T1_setup.md` Step 6 now explicitly commits the setup (`git add -A && git commit`) so the
+  Step-1-seeded `CHANGELOG.md`/`ROADMAP.md` are tracked before the first session; Step 5 now gitignores the
+  generated `dashboard.html` (so `git add -A` stays clean and Tutorial 2's clean-tree premise holds), and
+  `T2_worked_transcript.md`'s seed citation is reconciled to **[T1 Step 1]**. Docs-lag correction — **no version event**.
+- **Commit/PR:** this commit — branch `docs/closeout-3e-smoke-and-t1-commit` → upstream PR.
+- **Session:** BL-6 follow-ups 1a/1b · **Verified:** 6-lens adversarial review → 6 findings fixed (2 majors: the T1↔T2 `git commit -am` contradiction and `git add -A` sweeping in `dashboard.html`); 2 focused re-verifies returned CONSISTENT + CLEAN; 51/51 `bin/tests.sh`; co-staged through `.githooks/pre-commit`.
+
 ### 2026-07-08 · [ad hoc] HOW_TO_USE + T2 tutorials: sync close-out docs to the v3.1 FM #27 ledger
 - **Change:** `HOW_TO_USE.md` (a distributed file) and the `docs/tutorials/T2_*` pair predated failure
   mode #27 and still taught a pre-ledger close-out. Now current: `HOW_TO_USE.md` FM count **23 → 27**

--- a/HOW_TO_USE.md
+++ b/HOW_TO_USE.md
@@ -762,8 +762,9 @@ The session runner is deliberately short. It fits in a single read. Every line i
 - **3B: Self-assess** — Compare work to previous sessions' quality bar
 - **3C: Document learnings** — Update the workstream document; record project learnings in CLAUDE.md → Adaptations → Project-specific Learnings (adopters), or append to the SESSION_RUNNER learnings table (canonical repo dogfooding)
 - **3D: Write handoff notes** — Update SESSION_NOTES.md for the next session. **The agent knows the next session will score these notes**, which changes the quality of what gets written.
-- **3E: Commit** — All changes committed. **Record the action ledger:** append one dated, source-tagged entry per action to `CHANGELOG.md` and co-stage it with the commit (Failure Mode #27) — the durable answer to "what was done here, ever?", distinct from the session-overwritten handoff notes.
-- **3F: Report and STOP** — Summary to user including previous session's handoff score, then session is over
+- **3E: Runtime smoke test** — If the deliverable changes runtime behavior (startup, service registration, config resolution, dispatch, plugin loading), launch the app and confirm the change is active *and not silently overridden* before committing — "build clean" is necessary but not sufficient. If you cannot runtime-verify (needs hardware, an external service, or CI), say so in the handoff *and treat it as a defect* — disclosing the gap is not the same as discharging it (Failure Mode #24).
+- **3F: Commit** — All changes committed. **Record the action ledger:** append one dated, source-tagged entry per action to `CHANGELOG.md` and co-stage it with the commit (Failure Mode #27) — the durable answer to "what was done here, ever?", distinct from the session-overwritten handoff notes.
+- **3G: Report and STOP** — Summary to user including previous session's handoff score, then session is over
 
 The close-out is the most important innovation. Before the session runner, close-out was manual — the user had to explicitly tell the agent to self-assess, update the prompt, and stop. The agent's natural tendency is to finish the deliverable and immediately start the next one (Failure Mode #2). Making close-out automatic and mandatory means the self-improvement loop runs every session, not just the sessions where the user remembers to ask for it.
 
@@ -796,10 +797,10 @@ The **handoff accountability loop** (steps 3A and 3D) is what makes sessions com
 | 21 | Greenfield assumption | Assume existing capabilities; read baseline docs during Orient |
 | 22 | Overwrite user edits | Check git blame before modifying; never regenerate without confirming |
 | 23 | Question-as-instruction | Present options and wait; a question is not a go-ahead |
-| 24 | Build-passes-ship-it (build success ≠ runtime correctness) | If the deliverable changes runtime behavior, launch the app before close-out; "build clean" is necessary but not sufficient |
+| 24 | Build-passes-ship-it (build success ≠ runtime correctness) | If the deliverable changes runtime behavior, launch the app before close-out (Phase 3E); "build clean" is necessary but not sufficient |
 | 25 | Horizontal slicing (all-of-a-layer, never end-to-end) | Vertical slices (tracer bullets) — one feature through every layer; ask "if I stop here, is something working?" |
 | 26 | Mega-session posing as a vertical slice | One slice = ONE capability = one pre-declared, operator-approved layer list; split multiple intents |
-| 27 | Unrecorded action (commit/close out without logging it) | Append one dated, source-tagged CHANGELOG.md entry per action at close-out, newest on top |
+| 27 | Unrecorded action (commit/close out without logging it) | Append one dated, source-tagged CHANGELOG.md entry per action at close-out (Phase 3F), newest on top |
 
 The failure modes table serves two purposes: it warns the agent about its own tendencies, and it gives the user language for course-correction ("You're doing Failure Mode #2 — stop and close out").
 

--- a/docs/tutorials/T1_setup.md
+++ b/docs/tutorials/T1_setup.md
@@ -109,16 +109,30 @@ python -m unittest      # stdlib fallback, zero dependencies
 python3 methodology_dashboard.py
 ```
 
-This writes `dashboard.html` and opens it; the page auto-refreshes every 60 seconds. Add `dashboard.html` to your `.gitignore` — it's a generated artifact. See [`BOOTSTRAP.md` §Step 9](../../starter-kit/BOOTSTRAP.md#step-9-set-up-the-methodology-dashboard-recommended).
+This writes `dashboard.html` and opens it; the page auto-refreshes every 60 seconds. It's a generated artifact, so ignore it *before* you commit — otherwise the next step's `git add -A` would track it and every refresh would dirty your tree:
+
+```sh
+echo 'dashboard.html' >> .gitignore
+```
+
+See [`BOOTSTRAP.md` §Step 9](../../starter-kit/BOOTSTRAP.md#step-9-set-up-the-methodology-dashboard-recommended).
 
 **Expected result:** a health report you can open in a browser.
-**Checkpoint:** `dashboard.html` exists and your project's methodology-compliance score is no longer zero.
+**Checkpoint:** `dashboard.html` exists (and is gitignored) and your project's methodology-compliance score is no longer zero.
 
-### 6. Stop here — then start a *fresh* session
+### 6. Commit the setup, then start a *fresh* session
 
-This is the one step everyone gets wrong. The agent read `CLAUDE.md` when this session began — *before* you installed the protocol — so the procedure you just set up is not loaded in the session you set it up in. Do **not** give a real task now.
+First commit the setup, so the synced methodology files and the Step-1-seeded `CHANGELOG.md`/`ROADMAP.md` are **tracked** before your first real session:
 
-**Expected result:** setup is complete and committed; no feature work has begun.
+```sh
+git add -A && git commit -m "chore: bootstrap the methodology framework"
+```
+
+Tracking the seeded ledger now keeps `git status` clean and puts `CHANGELOG.md` under version control before any session writes to it. Tutorial 2's close-out is already careful here — it stages the ledger with an explicit `git add CHANGELOG.md …`, *not* `git commit -am` (which skips a still-untracked seed) — so committing it now just makes that a non-issue.
+
+Then **stop.** This is the one step everyone gets wrong. The agent read `CLAUDE.md` when this session began — *before* you installed the protocol — so the procedure you just set up is not loaded in the session you set it up in. Do **not** give a real task now.
+
+**Expected result:** the setup is committed — `git status` is clean; no feature work has begun.
 **Checkpoint:** You have started a brand-new session (or are about to). The agent's first act in that session is to orient — read `SAFEGUARDS.md` and `SESSION_NOTES.md`, run the dashboard, check `git status`, report, and wait for you. That's [`BOOTSTRAP.md` §First Session Checklist](../../starter-kit/BOOTSTRAP.md#first-session-checklist), and it's exactly what Tutorial 2 walks through.
 
 ## Common mistakes

--- a/docs/tutorials/T2_worked_transcript.md
+++ b/docs/tutorials/T2_worked_transcript.md
@@ -231,7 +231,7 @@ The feature is *active*, not just compiled. (Skipping this is [FM #24, build-pas
 
 ### 3F — Record the ledger, then commit *(one action, one commit)*
 
-F1 came from the backlog, so its close-out does two paired things in the **same commit**: prepend a dated, source-tagged line to the project's `CHANGELOG.md` action ledger (setup seeded one — [T1 Step 3](T1_setup.md)) **and** strike F1 from `BACKLOG.md` (a `[BL-N]` entry clears its item). Stage both **explicitly** — a freshly-seeded ledger may still be untracked, and `git commit -am` skips untracked files, so it would silently drop the entry — the very [FM #27, unrecorded action](../../starter-kit/SESSION_RUNNER.md#known-failure-modes) this step prevents:
+F1 came from the backlog, so its close-out does two paired things in the **same commit**: prepend a dated, source-tagged line to the project's `CHANGELOG.md` action ledger (setup seeded one — [T1 Step 1](T1_setup.md)) **and** strike F1 from `BACKLOG.md` (a `[BL-N]` entry clears its item). Stage both **explicitly** — a freshly-seeded ledger may still be untracked, and `git commit -am` skips untracked files, so it would silently drop the entry — the very [FM #27, unrecorded action](../../starter-kit/SESSION_RUNNER.md#known-failure-modes) this step prevents:
 
 ```text
 # prepended to CHANGELOG.md (newest on top):


### PR DESCRIPTION
## What & why

Two v3.1 close-out **fidelity** fixes to the teaching docs — the two follow-ups discovered during PR #47's refresh (fork backlog **BL-6 follow-ups 1a + 1b**). Both are docs-lag corrections; **no version event** (FM #27 already shipped in v3.1).

### 1a — `HOW_TO_USE.md` close-out gains the missing Phase 3E smoke test
The §"Phase 3: Close Out" enumeration lagged canonical `SESSION_RUNNER.md`: no runtime-smoke-test step, and its trailing letters were off by one (its `3E: Commit` / `3F: Report` vs canonical `3E` smoke / `3F` commit / `3G` report).

- Inserted **3E: Runtime smoke test**, condensed from canonical §3E (trigger = runtime-behavior change, build≠correctness, "active *and not silently overridden*", disclose-isn't-discharge → FM #24).
- Re-lettered Commit **3E→3F** (the FM #27 ledger recording rides along, unchanged) and Report and STOP **3F→3G**.
- FM table now cites the close-out step letters: FM #24 → **(Phase 3E)**, FM #27 → **(Phase 3F)**.

### 1b — `T1_setup.md` commits the seeded ledger before the first session
Step 1 seeds `CHANGELOG.md`/`ROADMAP.md`, but Step 6 only *asserted* "committed" without ever committing — a learner following T1 literally could reach Tutorial 2 with an **untracked** ledger.

- Step 6 now runs `git add -A && git commit` (heading → "Commit the setup, then start a *fresh* session").
- Step 5 now gitignores the generated `dashboard.html` via an explicit command, so `git add -A` stays clean and Tutorial 2's clean-tree premise holds for both tracks.
- `T2_worked_transcript.md`'s seed citation reconciled **[T1 Step 3] → [T1 Step 1]** (the seeding is Step 1; Learning #7 cross-reference completeness).

## Verification
- **6-lens adversarial review → 6 findings fixed** (2 majors: a T1 rationale that wrongly claimed Tutorial 2 uses `git commit -am`; `git add -A` sweeping in the generated `dashboard.html`, breaking T2's clean-tree premise).
- 2 focused re-verify passes: **CONSISTENT** (T1↔T2) + **CLEAN** (clean-tree/`git add`).
- 51/51 `bin/tests.sh`; commit co-staged through `.githooks/pre-commit`.

## Deferred (out of scope — filed, not fixed here)
T2's 3E smoke test writes `demo.json`, which `sample-project/.gitignore` doesn't cover, so it lingers untracked after T2's close-out — a separate pre-existing T2 gap, unrelated to 1a/1b. Candidate BL-6 follow-up 1c (one-line `.gitignore` add).

🤖 Generated with [Claude Code](https://claude.com/claude-code)