### PR TITLE
docs(handoffs): fix two defects in the receipt spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,10 +47,10 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
   a legitimate resting value for both fields, not a duty nobody is assigned to discharge.
 - **(2) `changelog_ref`'s spec offered two locator forms neither of which receipts actually use.**
   The placeholder named `PR #N` or a short-sha; in practice, entries locate a `CHANGELOG.md`
-  action by its quoted `### ` heading instead — this repo's own `bin/check-handoff` diagnostic
-  hints already teach that convention in its remediation text, without the spec ever blessing it.
-  Added the quoted-heading form as a third explicit option and noted that a bare line number is
-  not a durable locator once a ledger is ever trimmed or archived.
+  action by its quoted `### ` heading instead — all 8 live receipts in this repo's own
+  `HANDOFFS.md` already use that form, and none use `PR #N` or a bare sha, without the spec ever
+  blessing it. Added the quoted-heading form as a third explicit option and noted that a bare line
+  number is not a durable locator once a ledger is ever trimmed or archived.
 - **Distribution:** `HANDOFFS.md` is `bin/_manifest.py`-SEED (copied once, then adopter-owned), so
   new adopters receive the corrected spec; existing adopters' own copies are unaffected until they
   choose to re-seed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,26 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
 
 ---
 
+### 2026-08-10 · [ad hoc] Two defects in the HANDOFFS.md receipt spec: an unassigned reconcile promise, an unoffered locator form
+
+- **Change:** `starter-kit/HANDOFFS.md`'s fenced receipt-format spec, two independent fixes in one
+  pass since both sit in the same few lines.
+- **(1) The spec promised a reconcile no procedure ever assigns.** It said `commit: pending` and
+  `what_was_done: pending` are legal at write time because "the next session reconciles them to
+  real shas" — but `SESSION_RUNNER.md` Phase 0 step 6 only reconciles a *missing or still-
+  `status: pending`* receipt, never a `status: complete` receipt whose `commit:` field alone is
+  `pending`. No procedure anywhere performs the promise as written. Reworded to state `pending` as
+  a legitimate resting value for both fields, not a duty nobody is assigned to discharge.
+- **(2) `changelog_ref`'s spec offered two locator forms neither of which receipts actually use.**
+  The placeholder named `PR #N` or a short-sha; in practice, entries locate a `CHANGELOG.md`
+  action by its quoted `### ` heading instead — this repo's own `bin/check-handoff` diagnostic
+  hints already teach that convention in its remediation text, without the spec ever blessing it.
+  Added the quoted-heading form as a third explicit option and noted that a bare line number is
+  not a durable locator once a ledger is ever trimmed or archived.
+- **Distribution:** `HANDOFFS.md` is `bin/_manifest.py`-SEED (copied once, then adopter-owned), so
+  new adopters receive the corrected spec; existing adopters' own copies are unaffected until they
+  choose to re-seed.
+
 ### 2026-08-10 · [ad hoc] Re-grounded the /caveman row's remaining unsupported claim
 
 - **Change:** `starter-kit/RECOMMENDED_SKILLS.md`'s `/caveman` row.

--- a/starter-kit/HANDOFFS.md
+++ b/starter-kit/HANDOFFS.md
@@ -45,8 +45,8 @@ next_steps: <specific and actionable; never "pick next from backlog">
 key_files: <each entry carries a path:line token, e.g. SessionManager.java:245>
 gotchas: <traps the next session should watch for>
 runtime_smoke: <a run result, or "n/a — docs-only", or "impossible: <reason>">
-changelog_ref: <PR #N or a short-sha into CHANGELOG.md>
-commit: <short-sha — or `pending` until the next session reconciles it>
+changelog_ref: <PR #N, a short-sha, or CHANGELOG.md "<its ### heading>" — never a bare line number, which decays once the ledger is trimmed>
+commit: <short-sha — or the literal `pending`, legal only for the newest receipt (see below)>
 ```
 <free-text prose: the durable proxy for the Phase 3G spoken report, plus the +/- self-score breakdown>
 
@@ -61,7 +61,8 @@ when it reconstructs a receipt a crashed session never completed — you never w
 `self_score` and `predecessor_score` are distinct keys so one can never stand in for the other; omit
 `predecessor_score` on Session 1 (there is no predecessor to score). `commit: pending` and
 `what_was_done: pending` are legal at write time (the receipt ships in the very commit whose sha it
-would name); the next session reconciles them to real shas.
+would name); no future session is assigned to fill either in later, so `pending` is a legitimate
+resting value for both, not a promise a later session owes.
 
 **A receipt's identity is `session` + `date`, not `session` alone.** `S<N>` is a per-sequence
 counter, and one ledger may legitimately merge more than one sequence — a fork and its upstream each

--- a/starter-kit/HANDOFFS.md
+++ b/starter-kit/HANDOFFS.md
@@ -46,7 +46,7 @@ key_files: <each entry carries a path:line token, e.g. SessionManager.java:245>
 gotchas: <traps the next session should watch for>
 runtime_smoke: <a run result, or "n/a — docs-only", or "impossible: <reason>">
 changelog_ref: <PR #N, a short-sha, or CHANGELOG.md "<its ### heading>" — never a bare line number, which decays once the ledger is trimmed>
-commit: <short-sha — or the literal `pending`, legal only for the newest receipt (see below)>
+commit: <short-sha — or the literal `pending`>
 ```
 <free-text prose: the durable proxy for the Phase 3G spoken report, plus the +/- self-score breakdown>
 


### PR DESCRIPTION
Two independent fixes in `starter-kit/HANDOFFS.md`'s fenced receipt-format spec, both in the
same few lines.

**1. The spec promised a reconcile no procedure ever assigns.** It said `commit: pending` and
`what_was_done: pending` are legal at write time because "the next session reconciles them to
real shas" — but `SESSION_RUNNER.md` Phase 0 step 6 only reconciles a *missing or still-
`status: pending`* receipt, never a `status: complete` receipt whose `commit:` field alone is
`pending`. No procedure anywhere performs the promise as written. Reworded to state `pending` as
a legitimate resting value for both fields, not a duty nobody is assigned to discharge.

**2. `changelog_ref`'s spec offered two locator forms neither of which receipts actually use.**
The placeholder named `PR #N` or a short-sha; in practice, entries locate a `CHANGELOG.md`
action by its quoted `### ` heading instead — all 8 live receipts in this repo's own
`HANDOFFS.md` already use that form, and none use `PR #N` or a bare sha, without the spec ever
blessing it. Added the quoted-heading form as a third explicit option and noted that a bare line
number is not a durable locator once a ledger is ever trimmed or archived.

## Verification

- `bash bin/tests.sh`: 113/114 passed (pre-existing failure on `main`, unrelated to this change —
  the dashboard scoring unit suite, which #71 fixes).
- `python3 bin/check-links`: OK, 83 links resolve.
- `python3 bin/check-handoff`: OK.
- Rebased onto current `main` (`a2a7275`).

One of three small, independent fixes found while auditing this repo from a fork — opened
separately per your preference, so each is reviewable/mergeable on its own.

---

**Edit:** addressed both review findings.

- Dropped the "legal only for the newest receipt (see below)" clause from the `commit:` spec
  line. Nothing in `bin/check-handoff` enforces a newest-only restriction on `commit:` — the
  `allow_pending and idx == 0` exemption governs `status:` only, and `commit:` gets no content
  validation at all. The clause also contradicted the prose two lines below it in the same diff,
  re-introducing the shape of the defect fix 1 removes. Now reads:
  `commit: <short-sha — or the literal \`pending\`>`.
- Corrected fix 2's attribution, in both this body and the `CHANGELOG.md` entry: `bin/check-handoff`
  has no remediation text teaching the quoted-heading form (grepped for `heading`/`###`/`CHANGELOG`/
  `remediat`/`hint`/`locator` — the only hit is `changelog_ref` in the `REQUIRED_KEYS` list). The
  real evidence is the corpus itself: all 8 live receipts already use the quoted-heading form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
