### PR TITLE
fix(dashboard): extend framework-installed exclusion for context-budget gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,31 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
 
 ---
 
+### 2026-08-11 · [BL-31] Dashboard's framework-installed exclusion never learned about the context-budget gate PR #66 itself shipped
+
+- **Origin:** fork backlog item BL-31 (`docs/planning/BACKLOG.md`, fork `main` only — not yet pushed
+  to `origin` as of this entry, so no link is given rather than cite one that would not resolve),
+  found re-verifying PR #66's own review-comment fixes after merge. `bin/_manifest.py` gained two
+  new non-markdown dests in this PR (`context_budget.py`, TRACKED; `.context-budget.json`, SEED),
+  but `tools/methodology_dashboard.py`'s `FRAMEWORK_INSTALLED_SOURCE` tuple and the compliance
+  checklist's `CHECKLIST_EXEMPT` map — both purpose-built to stay in sync with this manifest — were
+  never extended to match. Reproduced before the fix, not inferred: a `git worktree` at the merge
+  commit (`a2a7275`) run against `python3 -m unittest tools/test_methodology_dashboard.py` gave
+  2 failures, both in tests that predate this PR (last touched at `bec4095`) and exist specifically
+  to catch this class of drift.
+- **Effect the drift had:** any adopter running `bin/sync` post-merge would have `context_budget.py`
+  misattributed to their own source LOC — the exact miscount `FRAMEWORK_INSTALLED_SOURCE` exists to
+  prevent for `methodology_dashboard.py` itself — and both new root files would read as neither
+  scored nor exempt on the compliance checklist.
+- **Fix:** `FRAMEWORK_INSTALLED_SOURCE` now includes `context_budget.py` and `.context-budget.json`
+  (mirrored byte-for-byte in `tools/` and `starter-kit/`); `CHECKLIST_EXEMPT` gains both, with the
+  same reasoning already on record for `methodology_dashboard.py` — their presence proves a
+  pre-commit hook was installed, not that the session-operating discipline the checklist measures
+  was followed. `DASHBOARD_VERSION` 2.10.2 → 2.10.3.
+- **Verified:** `python3 -m unittest tools/test_methodology_dashboard.py` 197/197 (was 195/197);
+  `bash bin/tests.sh` 114/114; `python3 bin/check-links` OK (83 links / 21 files); twins confirmed
+  byte-identical.
+
 ### 2026-08-10 · [ad hoc] Re-grounded the /caveman row's remaining unsupported claim
 
 - **Change:** `starter-kit/RECOMMENDED_SKILLS.md`'s `/caveman` row.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,23 +41,42 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
   to `origin` as of this entry, so no link is given rather than cite one that would not resolve),
   found re-verifying PR #66's own review-comment fixes after merge. `bin/_manifest.py` gained two
   new non-markdown dests in this PR (`context_budget.py`, TRACKED; `.context-budget.json`, SEED),
-  but `tools/methodology_dashboard.py`'s `FRAMEWORK_INSTALLED_SOURCE` tuple and the compliance
-  checklist's `CHECKLIST_EXEMPT` map — both purpose-built to stay in sync with this manifest — were
-  never extended to match. Reproduced before the fix, not inferred: a `git worktree` at the merge
-  commit (`a2a7275`) run against `python3 -m unittest tools/test_methodology_dashboard.py` gave
-  2 failures, both in tests that predate this PR (last touched at `bec4095`) and exist specifically
-  to catch this class of drift.
+  but `tools/methodology_dashboard.py`'s `FRAMEWORK_INSTALLED_SOURCE` tuple and
+  `tools/test_methodology_dashboard.py`'s `CHECKLIST_EXEMPT` test fixture — both purpose-built to
+  stay in sync with this manifest — were never extended to match. Reproduced before the fix, not
+  inferred: a `git worktree` at the merge commit (`a2a7275`) run against
+  `python3 -m unittest tools/test_methodology_dashboard.py` gave 2 failures, both in tests that
+  predate this PR (last touched at `bec4095`) and exist specifically to catch this class of drift.
 - **Effect the drift had:** any adopter running `bin/sync` post-merge would have `context_budget.py`
   misattributed to their own source LOC — the exact miscount `FRAMEWORK_INSTALLED_SOURCE` exists to
   prevent for `methodology_dashboard.py` itself — and both new root files would read as neither
   scored nor exempt on the compliance checklist.
-- **Fix:** `FRAMEWORK_INSTALLED_SOURCE` now includes `context_budget.py` and `.context-budget.json`
-  (mirrored byte-for-byte in `tools/` and `starter-kit/`); `CHECKLIST_EXEMPT` gains both, with the
-  same reasoning already on record for `methodology_dashboard.py` — their presence proves a
-  pre-commit hook was installed, not that the session-operating discipline the checklist measures
-  was followed. `DASHBOARD_VERSION` 2.10.2 → 2.10.3.
-- **Verified:** `python3 -m unittest tools/test_methodology_dashboard.py` 197/197 (was 195/197);
-  `bash bin/tests.sh` 114/114; `python3 bin/check-links` OK (83 links / 21 files); twins confirmed
+- **First fix (listing the names) did not actually work — found on review, not shipped as-is.**
+  Adding `context_budget.py` and `.context-budget.json` to `FRAMEWORK_INSTALLED_SOURCE` satisfies
+  the name-list agreement test, but `is_framework_installed()` then verified EVERY listed name
+  against `methodology_dashboard.py`'s own content signatures (`DASHBOARD_VERSION`,
+  `METHODOLOGY_ITEMS`, etc.) — which `context_budget.py` never carries — so the content check
+  silently rejected it and the exclusion never fired. Reproduced directly:
+  `is_framework_installed(Path("context_budget.py"), ...)` returned `False` even with the name
+  listed; a real bin/sync-shaped synced doc repo still flipped `doc_only` `True -> False`.
+- **Real fix:** content verification is now PER FILE. `_FRAMEWORK_FILE_SIGNATURES` gives each name
+  in `FRAMEWORK_INSTALLED_SOURCE` its own version pattern and signature set —
+  `context_budget.py`'s own `VERSION`/`CONFIG_NAME`/`HISTORY_NAME` markers, `.context-budget.json`'s
+  own distinctive keys (though that entry is structurally unreachable today: `is_framework_installed`
+  is only called for `category == "source"`, and a `.json` extension is always `"config"` — given a
+  signature anyway so the completeness test below needs no special case). A new canonical test
+  asserts every `FRAMEWORK_INSTALLED_SOURCE` name has a matching signature entry, so a future
+  addition to the tuple cannot repeat this exact gap silently. A new behavior test reproduces the
+  bug end-to-end with the REAL shipped `context_budget.py` content (not a synthetic stand-in) and
+  asserts a synced doc-only repo stays `doc_only` — RED-confirmed against the name-only fix before
+  landing this one. `CHECKLIST_EXEMPT` (a `tools/test_methodology_dashboard.py` test fixture, not
+  scanner source) gains both names, with the same reasoning already on record for
+  `methodology_dashboard.py` — their presence proves a pre-commit hook was installed, not that the
+  session-operating discipline the checklist measures was followed. `DASHBOARD_VERSION` 2.10.2 →
+  2.10.3.
+- **Verified:** `python3 -m unittest tools/test_methodology_dashboard.py` 200/200 (197 prior + 3
+  new; RED-confirmed against the pre-per-file-signature code first); `bash bin/tests.sh` 114/114;
+  `python3 bin/check-links` OK (83 links / 21 files); twins confirmed
   byte-identical.
 
 ### 2026-08-10 · [ad hoc] Re-grounded the /caveman row's remaining unsupported claim

--- a/starter-kit/methodology_dashboard.py
+++ b/starter-kit/methodology_dashboard.py
@@ -439,20 +439,60 @@ FRAMEWORK_SEED_DOCS = (
 )
 
 
-# Structural signatures of this scanner, for copies too old to carry DASHBOARD_VERSION. Two must
-# match. Three are ordinary function names, so two hits are suggestive rather than proof — this is
-# a heuristic, and the .methodology-profile marker is the documented override. Measured need: a
-# live adopter (feedback-loop-comparison) still runs a 1,614-line pre-version copy, and a
-# DASHBOARD_VERSION-only gate silently skipped it — the fix quietly not applying is the same class
-# of defect as the fix being wrong.
-_FRAMEWORK_SIGNATURES = (
-    "METHODOLOGY_ITEMS",
-    "def collect_all",
-    "def score_health",
-    "def assess_risks",
-    "https://github.com/KJ5HST/methodology",
-)
-_FRAMEWORK_SIGNATURE_MIN = 2
+# Content verification is PER FILE: a signature set proves an installed file IS the one it
+# claims to be, and methodology_dashboard.py's OWN signatures prove nothing about a DIFFERENT
+# installed file. The gap this closes: context_budget.py and .context-budget.json were added to
+# FRAMEWORK_INSTALLED_SOURCE above, but is_framework_installed checked every name against the
+# scanner's own signatures below — which context_budget.py never matches — so the exclusion
+# silently never fired for it even though the name-list agreement test passed
+# (test_exclusion_list_matches_the_manifest checks the LIST, not the runtime predicate). A
+# canonical test asserts every FRAMEWORK_INSTALLED_SOURCE name has an entry here, so a future
+# addition to that tuple cannot repeat this gap silently. Two signature hits (or a version
+# match) are suggestive rather than proof — a heuristic, same as before — and the
+# .methodology-profile marker remains the documented override for any repo this still gets wrong.
+_FRAMEWORK_FILE_SIGNATURES = {
+    "methodology_dashboard.py": {
+        # Measured need for the signature fallback: a live adopter (feedback-loop-comparison)
+        # still runs a 1,614-line pre-version copy, and a DASHBOARD_VERSION-only gate silently
+        # skipped it — the fix quietly not applying is the same class of defect as the fix being
+        # wrong. Three of these are ordinary function names, hence min_hits=2, not 1.
+        "version_re": _VERSION_RE,
+        "signatures": (
+            "METHODOLOGY_ITEMS",
+            "def collect_all",
+            "def score_health",
+            "def assess_risks",
+            "https://github.com/KJ5HST/methodology",
+        ),
+        "min_hits": 2,
+    },
+    "context_budget.py": {
+        "version_re": re.compile(r'''^VERSION\s*=\s*["']([^"']+)["']''', re.MULTILINE),
+        "signatures": (
+            "context_budget.py — size budgets",
+            "CONFIG_NAME",
+            "HISTORY_NAME",
+            "growth_run",
+        ),
+        "min_hits": 2,
+    },
+    ".context-budget.json": {
+        # Structurally unreachable today: is_framework_installed() is only called when
+        # category == "source" (see its one call site), and categorize_file() always buckets a
+        # .json extension as "config" (CONFIG_EXTS), never "source" — so this entry can never
+        # affect source-LOC either way. Given a real signature anyway so the completeness test
+        # below needs no special case that could hide a future gap if that call-site guard, or
+        # this file's extension, ever changes.
+        "version_re": None,
+        "signatures": (
+            "bytes_per_token",
+            "fixed_harness_tokens",
+            "growth_run",
+            "calibrate_against",
+        ),
+        "min_hits": 2,
+    },
+}
 
 
 def is_framework_installed(rel_path, fpath):
@@ -462,14 +502,16 @@ def is_framework_installed(rel_path, fpath):
     their source, and the canonical repo's `tools/` + `starter-kit/` copies stay ITS source — it
     authors that file, so its own health score must keep paying for it.
 
-    Content-verified: the file must declare `DASHBOARD_VERSION`, or carry at least two structural
-    signatures of this scanner (for copies predating that constant). The **whole file** is read,
-    not a fixed prefix — an earlier version searched only the first 4096 bytes, and the real
-    constant sits close enough to that boundary that ordinary growth of this module header would
-    have crossed it, silently switching the exclusion off and regressing every doc-only adopter
-    to the defect this exists to fix. (Measured at 2.10.1: byte 3,409, only 687 bytes clear of
-    the old window. That margin is a snapshot, not an invariant — it was 1,572 bytes one commit
-    earlier, and a single docstring addition consumed 56% of it, which is exactly the hazard.
+    Content-verified, PER FILE (see _FRAMEWORK_FILE_SIGNATURES): each name in
+    FRAMEWORK_INSTALLED_SOURCE carries its own version pattern and signature set, because a
+    signature set that proves one file's identity proves nothing about a different file merely
+    sharing the same name-list entry. The **whole file** is read, not a fixed prefix — an
+    earlier version searched only the first 4096 bytes, and the real constant sits close enough
+    to that boundary that ordinary growth of this module header would have crossed it, silently
+    switching the exclusion off and regressing every doc-only adopter to the defect this exists
+    to fix. (Measured at 2.10.1: byte 3,409, only 687 bytes clear of the old window. That margin
+    is a snapshot, not an invariant — it was 1,572 bytes one commit earlier, and a single
+    docstring addition consumed 56% of it, which is exactly the hazard.
     test_predicate_reads_the_whole_file_not_a_prefix is what actually holds the line.)
     A silent cliff inside the fix for a silent-signal bug is
     not a tradeoff worth keeping; the read costs nothing, since the file is read for line-counting
@@ -477,20 +519,22 @@ def is_framework_installed(rel_path, fpath):
 
     **The threat model is accidental miscounting, not an adversarial adopter.** These checks make
     it unlikely that the scanner mistakes an adopter's own work for ours. They do NOT stop someone who
-    deliberately pastes `DASHBOARD_VERSION` into their application to dodge a score — nothing
+    deliberately pastes a version marker into their application to dodge a score — nothing
     file-local could, and the only thing they would win is a wrong dashboard for themselves.
     """
-    if str(rel_path).replace("\\", "/") not in FRAMEWORK_INSTALLED_SOURCE:
+    name = str(rel_path).replace("\\", "/")
+    sig = _FRAMEWORK_FILE_SIGNATURES.get(name)
+    if sig is None:
         return False
     try:
         with open(fpath, "r", encoding="utf-8", errors="ignore") as fh:
             text = fh.read()
     except OSError:
         return False
-    if _VERSION_RE.search(text):
+    if sig["version_re"] is not None and sig["version_re"].search(text):
         return True
-    hits = sum(1 for sig in _FRAMEWORK_SIGNATURES if sig in text)
-    return hits >= _FRAMEWORK_SIGNATURE_MIN
+    hits = sum(1 for s in sig["signatures"] if s in text)
+    return hits >= sig["min_hits"]
 
 
 def find_canonical(start):

--- a/starter-kit/methodology_dashboard.py
+++ b/starter-kit/methodology_dashboard.py
@@ -82,7 +82,7 @@ from collections import defaultdict
 # Every other copy (portfolio root + per-project) is a synced copy of the canonical and must
 # carry the same value. A copy whose DASHBOARD_VERSION is older than the canonical is stale —
 # re-sync from the canonical. Bump on any change to the canonical script.
-DASHBOARD_VERSION = "2.10.2"
+DASHBOARD_VERSION = "2.10.3"
 
 ROOT = Path(__file__).parent
 EXCLUDE_DIRS = {"methodology", "BrogueCE-iOS", ".git", "__pycache__", "node_modules", ".venv", "venv"}
@@ -341,7 +341,11 @@ _VERSION_RE = re.compile(r'''^DASHBOARD_VERSION\s*=\s*["']([^"']+)["']''', re.MU
 # machine-checkable, not re-greppable). Markdown dests are deliberately NOT listed: this tuple
 # exists to correct the source-LOC read, and a general "skip framework files" rule is exactly the
 # laundering hole the exclusion must not become.
-FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py",)
+# The context-budget gate (context_budget.py, TRACKED; its .context-budget.json seed config)
+# added two more non-markdown dests to bin/_manifest.py without this tuple being extended to
+# match — exactly the silent drift the paragraph above warns about, caught by the
+# machine-checkable cross-reference test below, not by inspection.
+FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py", "context_budget.py", ".context-budget.json")
 
 # The markdown half of the same problem, and the mirror of the defect above. `bin/sync` also
 # installs 21 markdown files (~6,353 LOC), which on its own satisfies detect_doc_only's corpus

--- a/tools/methodology_dashboard.py
+++ b/tools/methodology_dashboard.py
@@ -439,20 +439,60 @@ FRAMEWORK_SEED_DOCS = (
 )
 
 
-# Structural signatures of this scanner, for copies too old to carry DASHBOARD_VERSION. Two must
-# match. Three are ordinary function names, so two hits are suggestive rather than proof — this is
-# a heuristic, and the .methodology-profile marker is the documented override. Measured need: a
-# live adopter (feedback-loop-comparison) still runs a 1,614-line pre-version copy, and a
-# DASHBOARD_VERSION-only gate silently skipped it — the fix quietly not applying is the same class
-# of defect as the fix being wrong.
-_FRAMEWORK_SIGNATURES = (
-    "METHODOLOGY_ITEMS",
-    "def collect_all",
-    "def score_health",
-    "def assess_risks",
-    "https://github.com/KJ5HST/methodology",
-)
-_FRAMEWORK_SIGNATURE_MIN = 2
+# Content verification is PER FILE: a signature set proves an installed file IS the one it
+# claims to be, and methodology_dashboard.py's OWN signatures prove nothing about a DIFFERENT
+# installed file. The gap this closes: context_budget.py and .context-budget.json were added to
+# FRAMEWORK_INSTALLED_SOURCE above, but is_framework_installed checked every name against the
+# scanner's own signatures below — which context_budget.py never matches — so the exclusion
+# silently never fired for it even though the name-list agreement test passed
+# (test_exclusion_list_matches_the_manifest checks the LIST, not the runtime predicate). A
+# canonical test asserts every FRAMEWORK_INSTALLED_SOURCE name has an entry here, so a future
+# addition to that tuple cannot repeat this gap silently. Two signature hits (or a version
+# match) are suggestive rather than proof — a heuristic, same as before — and the
+# .methodology-profile marker remains the documented override for any repo this still gets wrong.
+_FRAMEWORK_FILE_SIGNATURES = {
+    "methodology_dashboard.py": {
+        # Measured need for the signature fallback: a live adopter (feedback-loop-comparison)
+        # still runs a 1,614-line pre-version copy, and a DASHBOARD_VERSION-only gate silently
+        # skipped it — the fix quietly not applying is the same class of defect as the fix being
+        # wrong. Three of these are ordinary function names, hence min_hits=2, not 1.
+        "version_re": _VERSION_RE,
+        "signatures": (
+            "METHODOLOGY_ITEMS",
+            "def collect_all",
+            "def score_health",
+            "def assess_risks",
+            "https://github.com/KJ5HST/methodology",
+        ),
+        "min_hits": 2,
+    },
+    "context_budget.py": {
+        "version_re": re.compile(r'''^VERSION\s*=\s*["']([^"']+)["']''', re.MULTILINE),
+        "signatures": (
+            "context_budget.py — size budgets",
+            "CONFIG_NAME",
+            "HISTORY_NAME",
+            "growth_run",
+        ),
+        "min_hits": 2,
+    },
+    ".context-budget.json": {
+        # Structurally unreachable today: is_framework_installed() is only called when
+        # category == "source" (see its one call site), and categorize_file() always buckets a
+        # .json extension as "config" (CONFIG_EXTS), never "source" — so this entry can never
+        # affect source-LOC either way. Given a real signature anyway so the completeness test
+        # below needs no special case that could hide a future gap if that call-site guard, or
+        # this file's extension, ever changes.
+        "version_re": None,
+        "signatures": (
+            "bytes_per_token",
+            "fixed_harness_tokens",
+            "growth_run",
+            "calibrate_against",
+        ),
+        "min_hits": 2,
+    },
+}
 
 
 def is_framework_installed(rel_path, fpath):
@@ -462,14 +502,16 @@ def is_framework_installed(rel_path, fpath):
     their source, and the canonical repo's `tools/` + `starter-kit/` copies stay ITS source — it
     authors that file, so its own health score must keep paying for it.
 
-    Content-verified: the file must declare `DASHBOARD_VERSION`, or carry at least two structural
-    signatures of this scanner (for copies predating that constant). The **whole file** is read,
-    not a fixed prefix — an earlier version searched only the first 4096 bytes, and the real
-    constant sits close enough to that boundary that ordinary growth of this module header would
-    have crossed it, silently switching the exclusion off and regressing every doc-only adopter
-    to the defect this exists to fix. (Measured at 2.10.1: byte 3,409, only 687 bytes clear of
-    the old window. That margin is a snapshot, not an invariant — it was 1,572 bytes one commit
-    earlier, and a single docstring addition consumed 56% of it, which is exactly the hazard.
+    Content-verified, PER FILE (see _FRAMEWORK_FILE_SIGNATURES): each name in
+    FRAMEWORK_INSTALLED_SOURCE carries its own version pattern and signature set, because a
+    signature set that proves one file's identity proves nothing about a different file merely
+    sharing the same name-list entry. The **whole file** is read, not a fixed prefix — an
+    earlier version searched only the first 4096 bytes, and the real constant sits close enough
+    to that boundary that ordinary growth of this module header would have crossed it, silently
+    switching the exclusion off and regressing every doc-only adopter to the defect this exists
+    to fix. (Measured at 2.10.1: byte 3,409, only 687 bytes clear of the old window. That margin
+    is a snapshot, not an invariant — it was 1,572 bytes one commit earlier, and a single
+    docstring addition consumed 56% of it, which is exactly the hazard.
     test_predicate_reads_the_whole_file_not_a_prefix is what actually holds the line.)
     A silent cliff inside the fix for a silent-signal bug is
     not a tradeoff worth keeping; the read costs nothing, since the file is read for line-counting
@@ -477,20 +519,22 @@ def is_framework_installed(rel_path, fpath):
 
     **The threat model is accidental miscounting, not an adversarial adopter.** These checks make
     it unlikely that the scanner mistakes an adopter's own work for ours. They do NOT stop someone who
-    deliberately pastes `DASHBOARD_VERSION` into their application to dodge a score — nothing
+    deliberately pastes a version marker into their application to dodge a score — nothing
     file-local could, and the only thing they would win is a wrong dashboard for themselves.
     """
-    if str(rel_path).replace("\\", "/") not in FRAMEWORK_INSTALLED_SOURCE:
+    name = str(rel_path).replace("\\", "/")
+    sig = _FRAMEWORK_FILE_SIGNATURES.get(name)
+    if sig is None:
         return False
     try:
         with open(fpath, "r", encoding="utf-8", errors="ignore") as fh:
             text = fh.read()
     except OSError:
         return False
-    if _VERSION_RE.search(text):
+    if sig["version_re"] is not None and sig["version_re"].search(text):
         return True
-    hits = sum(1 for sig in _FRAMEWORK_SIGNATURES if sig in text)
-    return hits >= _FRAMEWORK_SIGNATURE_MIN
+    hits = sum(1 for s in sig["signatures"] if s in text)
+    return hits >= sig["min_hits"]
 
 
 def find_canonical(start):

--- a/tools/methodology_dashboard.py
+++ b/tools/methodology_dashboard.py
@@ -82,7 +82,7 @@ from collections import defaultdict
 # Every other copy (portfolio root + per-project) is a synced copy of the canonical and must
 # carry the same value. A copy whose DASHBOARD_VERSION is older than the canonical is stale —
 # re-sync from the canonical. Bump on any change to the canonical script.
-DASHBOARD_VERSION = "2.10.2"
+DASHBOARD_VERSION = "2.10.3"
 
 ROOT = Path(__file__).parent
 EXCLUDE_DIRS = {"methodology", "BrogueCE-iOS", ".git", "__pycache__", "node_modules", ".venv", "venv"}
@@ -341,7 +341,11 @@ _VERSION_RE = re.compile(r'''^DASHBOARD_VERSION\s*=\s*["']([^"']+)["']''', re.MU
 # machine-checkable, not re-greppable). Markdown dests are deliberately NOT listed: this tuple
 # exists to correct the source-LOC read, and a general "skip framework files" rule is exactly the
 # laundering hole the exclusion must not become.
-FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py",)
+# The context-budget gate (context_budget.py, TRACKED; its .context-budget.json seed config)
+# added two more non-markdown dests to bin/_manifest.py without this tuple being extended to
+# match — exactly the silent drift the paragraph above warns about, caught by the
+# machine-checkable cross-reference test below, not by inspection.
+FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py", "context_budget.py", ".context-budget.json")
 
 # The markdown half of the same problem, and the mirror of the defect above. `bin/sync` also
 # installs 21 markdown files (~6,353 LOC), which on its own satisfies detect_doc_only's corpus

--- a/tools/test_methodology_dashboard.py
+++ b/tools/test_methodology_dashboard.py
@@ -37,6 +37,7 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.abspath(__file__))
 TOOLS_PY = os.path.join(HERE, "methodology_dashboard.py")
 STARTER_PY = os.path.join(os.path.dirname(HERE), "starter-kit", "methodology_dashboard.py")
+STARTER_CONTEXT_BUDGET = os.path.join(os.path.dirname(HERE), "starter-kit", "context_budget.py")
 
 _spec = importlib.util.spec_from_file_location("methodology_dashboard_under_test", TOOLS_PY)
 md = importlib.util.module_from_spec(_spec)
@@ -2417,6 +2418,60 @@ class TestFrameworkInstalledExclusion(unittest.TestCase):
                                 md.FRAMEWORK_AMBIGUOUS_EVIDENCE_MIN,
                                 "a real bin/sync install must be able to satisfy the ambiguous "
                                 "evidence threshold on its own")
+
+    # --- per-file signatures: the BL-31 follow-up gap (a listed name proves nothing about a
+    # DIFFERENT file's content) --------------------------------------------------------------
+
+    def test_every_framework_installed_source_name_has_a_signature(self):
+        """The completeness gate the fix is really about. FRAMEWORK_INSTALLED_SOURCE and
+        _FRAMEWORK_FILE_SIGNATURES must enumerate the SAME names, or a future addition to the
+        tuple repeats the exact gap this test exists to close: listed for exclusion, verified
+        against the WRONG file's signatures (or none at all), never actually excluded."""
+        self.assertEqual(set(md.FRAMEWORK_INSTALLED_SOURCE),
+                         set(md._FRAMEWORK_FILE_SIGNATURES.keys()),
+                         "every FRAMEWORK_INSTALLED_SOURCE name needs its own entry in "
+                         "_FRAMEWORK_FILE_SIGNATURES — a name-list addition with no matching "
+                         "signature silently never excludes anything")
+
+    def test_the_real_context_budget_artifact_is_recognized(self):
+        """Guard-the-guard, mirrors test_the_real_shipped_artifact_is_recognized: uses the REAL
+        starter-kit/context_budget.py content, not a synthetic stand-in, so a future edit to
+        that file that drifts from its own declared signatures is caught here, not only in a
+        fixture that could drift right alongside it."""
+        real = Path(STARTER_CONTEXT_BUDGET).read_text(encoding="utf-8")
+        self.assertTrue(md.is_framework_installed(
+            Path("context_budget.py"), Path(STARTER_CONTEXT_BUDGET)))
+        p = self._repo({"context_budget.py": real, "README.md": "# adopter\n"})
+        m = md.collect_all(p)
+        self.assertEqual(m["files"]["by_category"]["vendor"]["count"], 1)
+        self.assertEqual(m["tests"]["source_loc"], 0)
+
+    def test_a_synced_repo_with_context_budget_installed_is_still_doc_only(self):
+        """THE regression test for the actual bug, reproducing the maintainer's own PR #71
+        review finding: adding context_budget.py's NAME to FRAMEWORK_INSTALLED_SOURCE did not
+        exclude it, because the content check verified every name against
+        methodology_dashboard.py's OWN signatures — which context_budget.py never matches. RED
+        against that version (confirmed by running this test before the per-file fix): a real
+        doc-only repo, after a real bin/sync-shaped install of context_budget.py (674 real
+        lines, read from the actual shipped file) alongside the scanner, flips
+        doc_only True -> False and gains a false HIGH "No test infrastructure" risk — v3.2's
+        exact false penalty, a fourth time."""
+        real_scanner = Path(STARTER_PY).read_text(encoding="utf-8")
+        real_context_budget = Path(STARTER_CONTEXT_BUDGET).read_text(encoding="utf-8")
+        p = self._repo({
+            **self.QUARTO,
+            "methodology_dashboard.py": real_scanner,
+            "context_budget.py": real_context_budget,
+        })
+        m = md.collect_all(p)
+        self.assertTrue(m["doc_only"]["is_doc_only"],
+                        "a real bin/sync-shaped install of context_budget.py must not flip a "
+                        "genuine doc-only repo to code")
+        self.assertEqual(m["tests"]["source_loc"], 0,
+                         "context_budget.py's own 674 LOC must not count as the adopter's source")
+        self.assertNotIn("No test infrastructure",
+                         [r["description"] for r in m["scores"]["risks"]],
+                         "the false HIGH risk this whole fix exists to prevent")
 
     def test_seed_docs_need_evidence_the_framework_was_installed(self):
         """The delta boundary review's confirmed regression, and the plan's RED-first clause (c)

--- a/tools/test_methodology_dashboard.py
+++ b/tools/test_methodology_dashboard.py
@@ -293,6 +293,11 @@ CHECKLIST_EXEMPT = {
     "CLAUDE_TEMPLATE.md": "template; the operating artifact is the adopter's CLAUDE.md instance",
     "BOOTSTRAP.md": "one-time setup guide, not a per-session operating artifact",
     "methodology_dashboard.py": "the scanner itself — scoring its own presence is circular",
+    "context_budget.py": "an elective size-governance gate, same class as the scanner above — "
+                         "its presence indicates a pre-commit hook was installed, not that the "
+                         "session-operating discipline this checklist measures was followed",
+    ".context-budget.json": "SEED config for the context-budget gate above; scored the same way "
+                            "for the same reason, not a session-operating artifact",
 }
 
 
@@ -2025,10 +2030,10 @@ class TestFmtRatioAndTwins(unittest.TestCase):
                         "tools/ and starter-kit/ dashboards must be byte-identical")
 
     def test_dashboard_version(self):
-        self.assertEqual(md.DASHBOARD_VERSION, "2.10.2")
+        self.assertEqual(md.DASHBOARD_VERSION, "2.10.3")
         starter_src = Path(STARTER_PY).read_text(encoding="utf-8")
-        self.assertTrue(re.search(r'^DASHBOARD_VERSION\s*=\s*"2\.10\.2"', starter_src, re.MULTILINE),
-                        "starter-kit twin must also declare DASHBOARD_VERSION 2.10.2")
+        self.assertTrue(re.search(r'^DASHBOARD_VERSION\s*=\s*"2\.10\.3"', starter_src, re.MULTILINE),
+                        "starter-kit twin must also declare DASHBOARD_VERSION 2.10.3")
 
 
 class TestEndToEnd(unittest.TestCase):


### PR DESCRIPTION
## What

PR #66 (`feat/context-budget`) added two new non-markdown dests to `bin/_manifest.py` — `context_budget.py` (TRACKED) and `.context-budget.json` (SEED) — but `tools/methodology_dashboard.py`'s `FRAMEWORK_INSTALLED_SOURCE` tuple and the `CHECKLIST_EXEMPT` test fixture (`tools/test_methodology_dashboard.py:293`) were never extended to match. Both exist specifically to stay in sync with the manifest, and both have pre-existing tests (last touched at `bec4095`, well before this PR) built to catch exactly this drift.

## Effect

An adopter running `bin/sync` after PR #66 would have `context_budget.py`'s LOC misattributed to their own source — the exact miscount `FRAMEWORK_INSTALLED_SOURCE` exists to prevent for `methodology_dashboard.py` itself — and both new root files would read as neither scored nor exempt on the compliance checklist.

## Reproduced before the fix

```
git worktree add <tmp> a2a7275   # the PR #66 merge commit
python3 -m unittest tools/test_methodology_dashboard.py
# 2 failures, both in tests that predate PR #66:
#   TestChecklistCurrency.test_every_distributed_adopter_root_file_is_scored_or_exempt
#   TestFrameworkInstalledExclusion.test_exclusion_list_matches_the_manifest
```

## Fix

- `FRAMEWORK_INSTALLED_SOURCE` now includes `context_budget.py` and `.context-budget.json`, mirrored byte-for-byte in `tools/` and `starter-kit/`.
- `CHECKLIST_EXEMPT` (a `tools/test_methodology_dashboard.py` test fixture, not scanner source) gains both, with the same reasoning already on record for `methodology_dashboard.py`: their presence indicates a pre-commit hook was installed, not that the session-operating discipline the checklist measures was followed.
- `DASHBOARD_VERSION` 2.10.2 → 2.10.3.

## Verified

- `python3 -m unittest tools/test_methodology_dashboard.py` — 197/197 (was 195/197 before the fix)
- `bash bin/tests.sh` — 114/114
- `python3 bin/check-links` — OK (83 links / 21 files)
- `tools/` and `starter-kit/` twins confirmed byte-identical

---

**Edit: the fix above did not actually work — found on review, fixed in this branch, not as a follow-on.**

`is_framework_installed()` checked every name in `FRAMEWORK_INSTALLED_SOURCE` against `methodology_dashboard.py`'s OWN content signatures (`DASHBOARD_VERSION`, `METHODOLOGY_ITEMS`, `def collect_all`, etc.). `context_budget.py` carries none of them, so the content check silently rejected it even with the name listed — confirmed directly:

```python
>>> md.is_framework_installed(Path("context_budget.py"), Path("starter-kit/context_budget.py"))
False
```

and end-to-end: a real doc-only repo, after a real bin/sync-shaped install of `context_budget.py` (674 lines, the actual shipped file) alongside the scanner, still flipped `doc_only` `True -> False` and gained the false `HIGH` "No test infrastructure" risk — the same defect PR #66 introduced, unfixed by the first version of this PR.

**Real fix:** content verification is now **per file**. `_FRAMEWORK_FILE_SIGNATURES` gives each name in `FRAMEWORK_INSTALLED_SOURCE` its own version pattern and signature set — `context_budget.py` verified against its own `VERSION`/`CONFIG_NAME`/`HISTORY_NAME` markers, `.context-budget.json` against its own distinctive JSON keys (though that entry is structurally unreachable today, since `is_framework_installed` is only called for `category == "source"` and a `.json` extension is always `"config"` — signed anyway so the completeness test below needs no special case).

Two new tests, per your suggestion:
- `test_every_framework_installed_source_name_has_a_signature` — `FRAMEWORK_INSTALLED_SOURCE` and `_FRAMEWORK_FILE_SIGNATURES` must enumerate the same names, so a future addition to the tuple can't repeat this exact gap silently.
- `test_a_synced_repo_with_context_budget_installed_is_still_doc_only` — the behavior test: builds a fixture from the REAL shipped `context_budget.py` content (not synthetic), reproduces your finding RED against the name-only fix, confirms GREEN against the per-file fix.

Plus `test_the_real_context_budget_artifact_is_recognized`, mirroring the existing `test_the_real_shipped_artifact_is_recognized` guard for the scanner itself.

RED-first throughout (stashed just the two scanner files, kept the new tests, confirmed all 3 fail for the stated reason against the name-only version; restored and confirmed green).

## Re-verified

- `python3 -m unittest tools/test_methodology_dashboard.py` — 200/200 (197 prior + 3 new)
- `bash bin/tests.sh` — 114/114
- `python3 bin/check-links` — OK (83 links / 21 files)
- `tools/` and `starter-kit/` twins confirmed byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)
