### PR TITLE
Ship the ledger trimmer, with tests that run outside this fork (read-set budgets, 2 of 4)

### DIFF
--- a/bin/_manifest.py
+++ b/bin/_manifest.py
@@ -42,6 +42,7 @@ DISTRIBUTION = [
     ("starter-kit/CLAUDE_TEMPLATE.md", "CLAUDE_TEMPLATE.md", TRACKED),
     ("starter-kit/BOOTSTRAP.md", "BOOTSTRAP.md", TRACKED),
     ("starter-kit/methodology_dashboard.py", "methodology_dashboard.py", TRACKED),
+    ("starter-kit/methodology_trim.py", "methodology_trim.py", TRACKED),
     ("starter-kit/context_budget.py", "context_budget.py", TRACKED),
     # seed-once root-files: created if absent, then adopter-owned (never clobbered)
     ("starter-kit/SESSION_NOTES.md", "SESSION_NOTES.md", SEED),

--- a/bin/tests.sh
+++ b/bin/tests.sh
@@ -234,6 +234,14 @@ if python3 "$METHODOLOGY/tools/test_methodology_dashboard.py" >/dev/null 2>&1; t
 else
     fail "dashboard scoring unit tests failed"
 fi
+# The trimmer's own tests ran in NOTHING until this line. That was tolerable while the tool was
+# canonical-only; it stops being tolerable once `bin/sync` installs it at adopter roots, because
+# `bash bin/tests.sh` would stay green with a shipped executable arbitrarily broken.
+if python3 "$METHODOLOGY/tools/test_methodology_trim.py" >/dev/null 2>&1; then
+    pass "ledger trimmer unit tests green"
+else
+    fail "ledger trimmer unit tests failed"
+fi
 
 echo "== Test 19: dashboard twins byte-identical + same DASHBOARD_VERSION =="
 diff -q "$METHODOLOGY/tools/methodology_dashboard.py" "$STARTER/methodology_dashboard.py" >/dev/null \

--- a/starter-kit/CHANGELOG.md
+++ b/starter-kit/CHANGELOG.md
@@ -5,7 +5,7 @@ items, repository issues, and ad-hoc work. It is the authoritative answer to *"w
 here, ever?"* Every session records its actions here at close-out (`SESSION_RUNNER.md`
 Phase 3F); Phase 0 reconciles it against `git log` and backfills anything a crashed or
 out-of-band session missed. Taking an action — any commit, or any non-commit action — and
-not recording it is failure mode #27.
+not recording it is failure mode #27. Old entries are archived, never deleted (see below).
 
 <!-- METHODOLOGY-SEED-SENTINEL: fresh ledger, no entries yet. While this line is present AND
      there are no dated (### YYYY-MM-DD) entries below, this is a freshly-seeded ledger, not a
@@ -32,28 +32,153 @@ three sources landed):
   decline/wontfix/grooming decisions all land here.
 
 **Format** — the `###` header line is the required, greppable unit; the detail bullets are
-recommended:
+recommended, plus one further bullet, `Model`, that is optional even relative to the others:
 
 ```
 ### YYYY-MM-DD · [SOURCE] one-line outcome-focused summary
 - **Change:** what is now true in the repo/product that was not before
 - **Commit/PR:** `<short-sha>`  —or—  PR #<N> (merged `<sha>`)
 - **Session:** S<N> · **Verified:** <build/test/render/runtime evidence, or "n/a — docs-only">
+- **Model:** <acting model> (optional — omit the line entirely when not recorded)
 ```
 
 *(The `[SOURCE]`, `[issue #<N>]`, `[BL-<N>]`, and `[ad hoc]` tokens above are illustrative; the
 freshness check keys on dated `###` entries, of which a fresh seed has none.)*
+
+**Model:** — self-reported, free text; omit the line when not recorded. Names which model
+executed the action — an agent-independent key with a concrete value, the same pattern
+`key_files` already uses for paths. Single-tier work names one model:
+
+```
+### 2026-01-15 · [ad hoc] Ship the export-retry fix
+- **Change:** exports now retry once on a transient network error instead of failing immediately
+- **Commit/PR:** `a1b2c3d`
+- **Session:** S42 · **Verified:** unit suite green, manual retry reproduced and confirmed fixed
+- **Model:** <model>
+```
+
+Capability-tiered work (one session whose layers are built or reviewed across different tiers) is
+recorded *per entry*, not compressed into one line: each layer/checkpoint already gets its own
+`CHANGELOG.md` entry, so each entry's **Model:** bullet states only its own role:
+
+```
+### 2026-01-16 · [ad hoc] Layer 3 — draft the parser (delegated layer)
+- **Change:** the new input format parses without a follow-up fixup pass
+- **Commit/PR:** `d4e5f6a`
+- **Session:** S43 · **Verified:** unit tests for the new parser pass
+- **Model:** <model A> (delegated; reviewed by <model B>)
+
+### 2026-01-16 · [ad hoc] Layer 4 — review and land the parser (primary layer)
+- **Change:** the delegated layer's diff is reviewed and the checkpoint committed
+- **Commit/PR:** `b7c8d9e`
+- **Session:** S43 · **Verified:** full suite green after review fixes
+- **Model:** <model B> (primary)
+```
+
+`HANDOFFS.md`'s "How to write a receipt" section documents a complementary session-level
+convention: naming the model once in a receipt's free-text prose, for a reader who wants one
+session's answer without correlating multiple entries here. That convention adds no new
+`HANDOFFS.md` schema key — it is not a second, competing structured field, and it is fine for both
+files to name the same model for a single-tier session, since they answer different questions
+("what happened, action by action" vs. "which model ran this session"). A canonical-only
+`bin/model-report` (copy it into your `bin/` if you want it) reads this file's **Model:** bullets
+back alongside `HANDOFFS.md`'s free-text mentions and git's `Co-Authored-By` trailers, keeping all
+three visually separate — see that tool's own docstring for why trailers are corroboration-only,
+never authoritative.
 
 Work committed but not finished — an in-progress hand-off, a reverted slice — still owes an
 entry: mark it `(in progress)` in the summary, and a later session closes it out or records
 the revert as its own entry. Reverse-chronological, prepend-only, so close-out never re-sorts.
 Promote to `## YYYY-MM` sections as the list grows — group by month, **not** by release.
 
+## Size, and when to archive
+
+Sectioning organises this file; it does not shrink it. The file grows without bound and Phase 0
+reads it every session, so it also has a size discipline. **Two caps, because there are two
+distinct failure modes and neither subsumes the other. Fire if either fires; stop only when both
+stop conditions hold.**
+
+| Cap | Protects against | Form | Fire when | Cut until |
+|---|---|---|---|---|
+| **Lines** — ~2,000, a **proxy** for the agent `Read` cap (the cap itself is denominated in **tokens**, not lines) | **measures an unread tail** — it does not, on its own, establish a remedy. A read past the cap returns only the prefix that fits, and says so: a `PARTIAL view` banner names the delivered span, the true length and the cap, and an explicit over-cap line range errors outright with no content at all. **Announced, not silent.** **Whether archiving the tail REMEDIES this is an open question, not a settled benefit.** Truncation is ordered top-down and this file is newest-on-top, so the records a cut removes are ones a whole-file read was not delivering anyway: the delivered prefix is the same before and after, and what changes is that the reader stops being warned. Raised as BL-52. **Re-measure rather than trusting this row** — the reproduction is `docs/planning/read-cap-premise-correction-plan.md` Appendix A in the framework repo | a **rate** | headroom < **15** entries | headroom > **30** |
+| **Bytes** — a per-file budget, default **65,536 B** (64 KB) | **context tax**: every session pays for the whole file, every time | a **level with hysteresis** | `size > budget` | `size ≤ ½ × budget` |
+
+**Run this. Do not eyeball it, and do not trust a size written here or anywhere else** — a number
+in prose is stale the next time anyone prepends:
+
+```sh
+python3 methodology_trim.py --file CHANGELOG.md --check
+```
+
+`--check` evaluates both conditions, reports whether the trigger fires, and never writes. `--write`
+performs the trim; a dry run is the default, and it refuses to write unless it can prove the split
+lossless. **It neither commits nor stages** — it leaves the live file modified and the new shard
+*untracked*, prints the rollback, and leaves the commit to you. Stage both yourself:
+`git add CHANGELOG.md docs/archive/` — committing with `-a` alone would land the shortened ledger
+while the shard, being untracked, never enters history at all.
+
+**Why the line cap is a rate.** Headroom is `(2000 − lines) × entries-added ÷ lines-added` since the
+last split, so it re-derives itself from the file on every read. A hand-written level cannot: it is
+a derived value frozen at the moment someone typed it. This framework's own receipt ledger is the
+worked example — it states its trigger as a level, *"approaches ~1,200 lines"*, and **that level has
+never once fired.** The single archive that file has ever had was taken on judgment at 997 lines,
+*before* the level was written; since then the file has grown several times past its byte budget
+while still reading "under 1,200 lines". A level in the wrong unit says *fine* indefinitely. Where
+there is no slope yet — before the first split, or immediately after one — the rate **abstains out
+loud** rather than print a number it cannot support.
+
+**Why the byte cap is not.** *"Cut until headroom is back above 30"* is unreachable on bytes at any
+budget: a tool applying it would trim the file to a single record and still report the trigger
+unsatisfied. A level with hysteresis terminates, and the ½ factor is what keeps the next entry from
+re-firing the trigger immediately.
+
+**The budget is judgment, and it is yours to set.** It does not follow from the line cap — at real
+ledger densities, 2,000 lines is a different byte count for every file. Calibrate it the way this
+default was: take the sizes your repo has actually operated at comfortably after previous archives,
+and set the budget just above them. `--budget-bytes <N>` overrides it for a single run.
+
+**Archiving again is not always the answer.** If the file has already given back everything the
+last archive removed, another archive resets the *level* and not the *rate* — the tool measures
+exactly that and **refuses to fire**; `--force` is how you overrule it deliberately. Before a file's
+first archive there is no baseline to measure against, so it abstains rather than compute a zero.
+
+### The shard convention
+
+An archive is a **shard** — a new frozen file, same format, same newest-on-top order.
+
+- **Path: `docs/archive/<LIVE-BASENAME>-through-<CUT-KEY>.md`.** Both halves are load-bearing. The
+  directory keeps a shard from shadowing the live file by sort order, and the `CHANGELOG-` prefix is
+  what the trigger's own glob looks for when it hunts its baseline — a shard named otherwise is
+  silently invisible to it, and the trigger then measures against the wrong boundary.
+- **The live file keeps one short pointer** naming each shard and the span it covers. Every count
+  stated in that pointer carries the command that recomputes it, because a hand-maintained count
+  drifts on the next prepend.
+- **The shard back-links to the live file and states only facts about itself** — its own span, its
+  own count. It must **not** restate a forward-looking rule. A shard is frozen, so a rule copied
+  into one is wrong the moment the live rule moves, and correcting it means editing a frozen
+  record. Cite the live file; do not copy it.
+- **After a split the authority is the live file *and* its shards.** Any command that enumerates
+  this ledger must span both by glob — `CHANGELOG.md docs/archive/CHANGELOG-*.md` — or the split
+  silently shrinks the population the audit was counting.
+- **Prefer a release frontier as the cut key**, because a shipped release is a boundary nothing can
+  ever be written back into. A calendar date works too, but it is frozen only by convention; if you
+  cut at one, say in the shard's own front matter that you departed and why.
+
+**A trim is an action, not a side effect.** It earns its own commit and its own `[ad hoc]` entry
+here — one ledger, one shard, one commit, one revert. It does **not** belong in Phase 0, which is
+read-only apart from the reconcile backfill.
+
+**Not everything that grows can be archived this way.** Archiving moves *history*. A file that grows
+because someone keeps adding *procedure* has no past to move — extract a section to a sibling file
+and leave a pointer instead. A backlog of open items is live state rather than history: that is a
+grooming problem, and its completed items belong here, in this ledger, not in a frozen shard.
+
 ## CHANGELOG.md vs SESSION_NOTES.md — two files, two questions, one shared key
 
 `SESSION_NOTES.md` is the **transient handoff** — *"what's next, what traps?"* — overwritten
 every session. `CHANGELOG.md` is the **cumulative ledger** — *"what was done, ever?"* —
-append-only. The commit SHA is the only intended intersection. Close-out **distills** the
+append-only, and split into shards once it outgrows a session's read (see above). Nothing is
+ever deleted; the oldest entries move. The commit SHA is the only intended intersection. Close-out **distills** the
 durable outcome into a ledger entry; it does not copy the handoff. The belongs-here test:
 *would the operator, six months out, need this to know what the repo does or how it got there?*
 

--- a/starter-kit/HANDOFFS.md
+++ b/starter-kit/HANDOFFS.md
@@ -30,6 +30,21 @@ breadcrumb: if the session ends before close-out, the next session's Phase 0 rec
 **At Phase 3D (close-out)** — overwrite that block in place to `status: complete` and fill every
 field. The block must satisfy all six Minimum Handoff Requirements (`SESSION_RUNNER.md` §3D).
 
+**Naming the acting model (optional).** No new key — `REQUIRED_KEYS` is unchanged, and the fenced
+block below stays exactly as documented. When a one-line summary is useful, especially for a
+single-tier session where it saves a reader a cross-reference into `CHANGELOG.md`'s per-action
+**Model:** bullet (see that file's format section), name the model in this receipt's free-text
+prose area — the Format section below documents that area as *"the durable proxy for the Phase 3G
+spoken report."* This formalizes what a capability-tiered session already does organically when it
+states which tier built which layer and which tier reviewed it; this fork's own first receipt
+(root `HANDOFFS.md`, session S1) is the worked precedent. `CHANGELOG.md`'s **Model:** bullet
+remains the structured, per-action record; this is a convenience pointer for the session-level
+view, not a second schema — and it is fine for both to name the same model on a single-tier
+session, since they answer different questions ("what happened, action by action" vs. "which model
+ran this session"). A canonical-only `bin/model-report` (copy it into your `bin/` if you want it,
+same as `bin/check-handoff`) reads this free-text convention back alongside `CHANGELOG.md`'s
+**Model:** bullets and git's `Co-Authored-By` trailers, keeping all three visually separate.
+
 ## Format — a fenced `handoff` block
 
 ````
@@ -71,11 +86,69 @@ within a sequence if you can (never renumber an already-written receipt to do it
 that closes on merge is the lesser defect), but do not treat a repeated id across sequences as
 corruption. `bin/check-handoff --all` keys on the pair for this reason.
 
+## Size, and when to archive
+
+This file gains a receipt every session and Phase 0 reads it every session, so it carries the same
+size discipline as `CHANGELOG.md`: **two caps, two distinct failure modes, fire if either fires,
+stop only when both stop conditions hold.**
+
+| Cap | Protects against | Form | Fire when | Cut until |
+|---|---|---|---|---|
+| **Lines** — ~2,000, a **proxy** for the agent `Read` cap (the cap itself is denominated in **tokens**, not lines) | **measures an unread tail** — it does not, on its own, establish a remedy. A read past the cap returns only the prefix that fits, and says so: a `PARTIAL view` banner names the delivered span and the true length, and an explicit over-cap line range errors outright. **Announced, not silent.** **Whether archiving the tail REMEDIES this is an open question, not a settled benefit.** Truncation is ordered top-down and this file is newest-on-top, so the records a cut removes are ones a whole-file read was not delivering anyway: the delivered prefix is the same before and after, and what changes is that the reader stops being warned. Raised as BL-52. **Re-measure rather than trusting this row** — the reproduction is `docs/planning/read-cap-premise-correction-plan.md` Appendix A in the framework repo | a **rate** | headroom < **15** receipts | headroom > **30** |
+| **Bytes** — a per-file budget, default **65,536 B** (64 KB) | **context tax**: every session pays for the whole file, every time | a **level with hysteresis** | `size > budget` | `size ≤ ½ × budget` |
+
+**Run this rather than estimating it:**
+
+```sh
+python3 methodology_trim.py --file HANDOFFS.md --check
+```
+
+`--check` evaluates both conditions and never writes. `--write` performs the trim, refuses unless it
+can prove the split lossless, and **neither commits nor stages** — it leaves this file modified and
+the new shard *untracked*, and leaves the commit to you (`git add HANDOFFS.md docs/archive/`).
+
+An archive is a **shard**: a new frozen file, same format, same newest-on-top order.
+
+- **Path: `docs/archive/HANDOFFS-through-<CUT-KEY>.md`.** Both halves are load-bearing — the
+  directory keeps the shard from shadowing this file, and the `HANDOFFS-` prefix is what the
+  trigger's own glob looks for. A shard named otherwise is silently invisible to it.
+- **This file keeps one short pointer** naming each shard, the span it covers and how many receipts
+  it holds — with the command that recomputes those counts, never a hand-maintained number.
+- **The shard back-links here and states only facts about itself.** It must not restate a
+  forward-looking rule: a shard is frozen, so a rule copied into one cannot be corrected when the
+  live rule moves.
+- **After a split, anything that enumerates receipts must span both** — `HANDOFFS.md
+  docs/archive/HANDOFFS-*.md` — or it silently counts a shrunken population.
+
+If a `CHANGELOG.md` sits beside this file, its own **Size, and when to archive** section carries the
+reasoning both files share: why the line cap must be a rate, why the byte cap cannot be one, and how
+to choose the budget. Everything needed to *act* is here.
+
+What is specific to *this* file, and gets receipts wrong if assumed:
+
+- **A record is a `handoff` block *plus the prose beneath it*, not the fence alone.** The self-score
+  and predecessor-score paragraphs sit outside the fence and belong to the receipt above them. A
+  fence-only cut severs every receipt from its own scoring.
+- **Archive oldest-first by position, never by sorting on `session:`.** Two independent `S<N>`
+  sequences can share one ledger — a fork and its upstream each running their own counter — and
+  their numbers collide. The record's identity is **session + date**.
+- **A trim leaves the newest-receipt check alone and moves what the older-receipt checks see.**
+  Phase 0 reconcile is frontier-based and a structural checker applies the full schema to the newest
+  receipt only, so neither is disturbed. Its other passes are not so confined — an answer-slot rule
+  reads every receipt below the newest, and a locator-form rule reads every receipt in the file. So
+  after a trim, **run the checker against each shard as well**, and recompute any "all N older
+  receipts" count from the files rather than carrying it forward.
+- **Never trim to zero receipts.** An empty receipt ledger is indistinguishable from a broken one.
+- **A shard freezes, with one exception this file needs:** a `commit:` answer slot may still be
+  reconciled inside an archived receipt, because that field was always going to be filled by a later
+  session. Nothing else in a shard is rewritten.
+
 ## Three files, three questions, one shared key
 
 - **`SESSION_NOTES.md`** — the *transient scratchpad*: rich working notes, overwritten every session.
 - **`HANDOFFS.md`** (this file) — the *durable receipt*: the distilled, machine-checkable proof that
-  the handoff was written, kept forever.
+  the handoff was written. Nothing is ever deleted; once the file outgrows a session's read, the
+  oldest receipts move to a frozen shard (see **Size, and when to archive** above).
 - **`CHANGELOG.md`** — the *cumulative action ledger*: *"what was done here, ever?"*, append-only.
 
 The shared key across all three is the commit sha (`changelog_ref` / `commit` here). This file

--- a/starter-kit/methodology_dashboard.py
+++ b/starter-kit/methodology_dashboard.py
@@ -357,7 +357,8 @@ _VERSION_RE = re.compile(r'''^DASHBOARD_VERSION\s*=\s*["']([^"']+)["']''', re.MU
 # added two more non-markdown dests to bin/_manifest.py without this tuple being extended to
 # match — exactly the silent drift the paragraph above warns about, caught by the
 # machine-checkable cross-reference test below, not by inspection.
-FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py", "context_budget.py", ".context-budget.json")
+FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py", "methodology_trim.py",
+                              "context_budget.py", ".context-budget.json")
 
 # The markdown half of the same problem, and the mirror of the defect above. `bin/sync` also
 # installs 22 markdown files, which on its own satisfies detect_doc_only's corpus
@@ -476,6 +477,20 @@ _FRAMEWORK_FILE_SIGNATURES = {
             "def score_health",
             "def assess_risks",
             "https://github.com/KJ5HST/methodology",
+        ),
+        "min_hits": 2,
+    },
+    "methodology_trim.py": {
+        # Its own constant is TRIM_VERSION, not VERSION or DASHBOARD_VERSION, so it needs its own
+        # pattern rather than the scanner's: a shared _VERSION_RE would never match and the file
+        # would fall through to the signature path on every scan, which is the silent-skip defect
+        # the comment above this table describes.
+        "version_re": re.compile(r'''^TRIM_VERSION\s*=\s*["']([^"']+)["']''', re.MULTILINE),
+        "signatures": (
+            "LEDGERS",
+            "def classify_zones",
+            "def apply_regenerated",
+            "def build_pointer_block",
         ),
         "min_hits": 2,
     },

--- a/starter-kit/methodology_trim.py
+++ b/starter-kit/methodology_trim.py
@@ -1,0 +1,2181 @@
+#!/usr/bin/env python3
+"""methodology_trim.py — the ledger trimmer.
+
+Moves the oldest records out of a grow-and-must-be-read ledger into a frozen shard under
+`docs/archive/`, and refuses to do it unless the move is provably lossless.
+
+Implements the ledger-trimmer design (S35). `bin/sync` installs this file at your project root
+and does NOT install that design, which lives only in the methodology repository as
+`docs/planning/ledger-trimmer-design.md` — deliberately, since it is a working document for the
+tool's authors rather than something an adopter operates. No URL is given for it on purpose: it
+has not been published to a public remote, and a link that 404s is worse than a path plus the
+repository's name. The design is the spec and this file does not re-open it; whoever changes this
+module reads its §2 (the three-zone record model), §4 (the three assertions) and §5 (the trigger)
+first, from a checkout of that repository. Nothing mechanical protects this reference:
+`bin/check-links` validates only the distributed *markdown*, so a dangling citation inside this
+module is never reported.
+
+WHY THREE ASSERTIONS AND NOT ONE
+    The manual procedure this replaces proved whole-file byte identity under concatenation, and
+    that proof passed while a paragraph was silently lost (`020ba3f` — the pre-v3.0 scope footer
+    of the root CHANGELOG, still missing today). It *had* to pass: moving a paragraph from the
+    live file into the shard is exactly byte-preserving under concatenation. So:
+
+      L1  concatenation identity, scoped to the RECORDS zone   — is every record byte still somewhere?
+      L2  zone pinning                                          — is every byte still in the RIGHT file?
+      L3  record partition, per record, by identity+order+bytes — was it a pure move, or a move plus an edit?
+
+    None of the three is the whole-file check, and that is deliberate: the unscoped whole-file form
+    is unsatisfiable on any run that regenerates the pointer (design §4.2).
+
+DEFAULTS THAT ARE INVERTED ON PURPOSE
+    Dry run is the default; `--write` is required to touch anything. The tool never commits, and
+    it never runs `git mv` (design P2 — `--no-renames` in the FM #27 pre-commit hook means a
+    rename-shaped trim passes a gate meant to notice it).
+
+Python 3 stdlib only, cross-platform — this file is destined for adopter roots (design §6.1).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+TRIM_VERSION = "1.5.0"   # 1.5.0: Phase C2 — the Class A archive threshold, and the byte budget
+                         # raised to meet it. An adopter's ROOT CHANGELOG.md/HANDOFFS.md now fires
+                         # at 196,608 B instead of 65,536 and cuts back to 98,304 instead of
+                         # 32,768, so a ledger that reported FIRES yesterday can report
+                         # NOTHING_TO_DO today and a trim that does run archives fewer records.
+                         # A NESTED ledger of the same name is unchanged: it keeps the 56,750 B
+                         # one-read arm, which is new behaviour where before all paths were equal.
+                         # The TRIGGER_READ row's text changes shape for a root ledger. Changed
+                         # behaviour on a distributed tool, no finding code removed: MINOR.
+                         #
+                         # 1.4.0: Phase B — the read cap is RE-DENOMINATED from lines onto bytes,
+                         # and the line RATE is removed rather than re-tuned. Two finding codes
+                         # change on the CLI (TRIGGER_LINES and LINE_METRIC_ABSTAINS are gone,
+                         # TRIGGER_READ replaces them), `stops()` loses its rate arms and
+                         # LINE_FIRE_BELOW/LINE_STOP_ABOVE are deleted, so an adopter's next trim
+                         # can cut to a different depth than it would have yesterday. New finding
+                         # code and changed behaviour on a distributed tool: MINOR, not patch.
+                         # READ_CAP_LINES' third job (seed plausibility) keeps the value 2000
+                         # under its own name, SEED_PLAUSIBLE_MAX_LINES — no behaviour change.
+                         # 1.3.0: BL-41 — the shard name is derived from a RECORD DATE while
+                         # the cut is POSITIONAL, so it is NOT injective: whenever two records share
+                         # a date, distinct cuts derive one name. The write-once rule then refused
+                         # every admissible cut, and the tool's own advice ("Disambiguate with
+                         # --cut") had no solution — that date both selects the records AND becomes
+                         # the key, so there is no second knob. A live ledger sat 14,317 B over its
+                         # ceiling with no reachable remedy. A taken name is now DISAMBIGUATED with
+                         # a numeric suffix instead of refused. MINOR: nothing is ever overwritten
+                         # (write-once is unchanged, and still REFUSES past SHARD_SUFFIX_MAX), but
+                         # a run that previously exited 2 now writes a shard, and its name can
+                         # carry a suffix — so a reader comparing two archives must be able to tell
+                         # which rule each ran under.
+                         #
+                         # 1.2.0: BL-36 — the GENERATED .verify.sh identified the records the trim
+                         # COMMIT added by a constant baked in at generation time (`INJECTED`, a
+                         # 0/1 flag) and skipped that many POSITIONS. A commit bundling any second
+                         # ledger write therefore failed by construction with zero data loss — four
+                         # of this repo's six shipped proofs did. The injected set is now measured
+                         # from record CONTENT at verification time and `INJECTED` is gone from the
+                         # template. MINOR, not patch: what a generated proof reports changes (a
+                         # bundled add is no longer a failure; missing/added records are named), so
+                         # a reader comparing two proofs must be able to tell which rules each ran
+                         # under. Losses, edits and reorders still fail, unchanged.
+                         #
+                         # 1.1.3: BL-28 — the GENERATED .verify.sh's L2 "missing front-matter line"
+                         # check compared by substring (`ln not in afront`) instead of exact-line-
+                         # set membership, so an append-style edit that kept the original line as a
+                         # literal prefix of the new one evaded detection. No new finding code or
+                         # exit-code change: patch, not minor — a correctness fix to what the tool
+                         # WRITES, same class as 1.1.2.
+                         # 1.1.2: BL-27 — the GENERATED .verify.sh had two false-positive triggers
+                         # the internal --check/--write assertions do not share: a declared
+                         # front-matter regen field (e.g. HANDOFFS.md's receipt count) read as L2
+                         # data loss, and a same-commit close-out bundling (this repo's own
+                         # established practice) read as an unqualified L1/L3 record alteration.
+                         # No new finding code on the TOOL's own CLI and no exit-code change, so:
+                         # patch, not minor — this is a correctness fix to what the tool WRITES.
+                         # 1.1.0: GRAMMAR_MISMATCH — a grammar this tool cannot read
+                         # is no longer reported as an empty file (UAT F1). New finding code and
+                         # a new exit status on a distributed tool, so: minor, not patch.
+
+# --- Tunables, all of them judgment, all of them labelled as such in the design ---------------
+# THE AGENT READ CAP, RE-DENOMINATED — Phase B, 2026-08-26. The cap is TOKEN-denominated and
+# always was. The 2,000-line proxy that stood here was wrong on the axis, and measured across the
+# fleet it was STRICTLY DOMINATED: over 18 watched ledgers in 5 repos it fired on 3 and stayed
+# silent on 8 that a byte threshold at ANY point in the measured ratio band catches, while
+# catching nothing a byte threshold misses. So the axis choice does not rest on picking the right
+# constant. It is NOT published as one opaque number — a number goes stale when the harness moves
+# and the command does not — but DERIVED from two inputs that each carry their own re-measurement.
+READ_CAP_TOKENS = 25_000       # [M] stated verbatim by the tool itself: "exceeds maximum allowed
+                               # tokens (25000)". Harness behaviour, not a repo property.
+MIN_BYTES_PER_TOKEN = 2.27     # [M] the FLOOR of the band 2.2705–3.0300 B/token measured over 9
+                               # real markdown files in 5 repos. The floor and not the mean,
+                               # because a guard that must not stay silent on a truncating file
+                               # has to assume the densest content it will meet. Deliberately NOT
+                               # context_budget.py's `bytes_per_token`: that is calibrated on
+                               # OPENING CONTEXT against CLAUDE.md's size, a different quantity —
+                               # and re-running its own --calibrate today returns 2.46 at R² 0.59,
+                               # a value that predicts FRAMEWORK_LEARNINGS.md truncates when a
+                               # probe shows it comes back whole. Re-derive with Appendix A.
+READ_CAP_BYTES = int(READ_CAP_TOKENS * MIN_BYTES_PER_TOKEN)   # 56,750 B — computed, never written
+READ_REFUSE_BYTES = 256 * 1024 # [M] a SECOND and HARDER boundary, and it is NOT truncation: past
+                               # it a default Read is refused outright with ZERO content —
+                               # "File content (256.1KB) exceeds maximum allowed size (256KB)".
+                               # So "truncation is ordered top-down, and the prefix a session
+                               # needs still arrives" is true only BETWEEN the two boundaries.
+                               # Past this one nothing arrives at all, front matter included.
+                               # 5 of the 18 watched fleet ledgers are already past it.
+# --- Phase C2, 2026-08-26: the CLASS A pair, and the budget moved to meet it ------------------
+# WHAT CHANGED AND WHY, stated here because both numbers below are judgment and the next session
+# must be able to re-open them on the reasoning rather than on taste.
+#
+# Phase C1 established that the watched population is TWO CLASSES, and that the class this tool
+# can act on -- the names in LEDGERS -- is exactly Class A. For those two files READ_CAP_BYTES is
+# the wrong thing to FIRE on. It is a true statement about them ("one Read does not deliver this
+# whole file") and it stays in the --check report for that reason, but it is not a fault: these
+# ledgers are newest-on-top and delivery is an ORDERED PREFIX, so truncation removes the OLDEST
+# records, which is the end nothing was reading. Measured across 85 transcripts of this repo, each
+# root ledger was read WHOLE exactly ONCE and in PART 1,696 times. What front matter + the newest
+# record costs is 30-32% of one read, with ~40 KB of growth headroom (plan §3).
+#
+# The failure that DOES matter is READ_REFUSE_BYTES, where the prefix stops existing and a default
+# Read returns nothing at all -- front matter included. So the Class A arm is denominated against
+# the REFUSAL, not against the cap, and it fires BELOW it rather than at it: a trigger set at the
+# refusal parks the file exactly on the edge where degradation stops being graceful (plan §3
+# caveat 1). 192 KiB leaves 64 KiB of margin under the refusal; 96 KiB is the stop, which is the
+# `level with hysteresis` shape ledger-trimmer-design.md §5.2 prescribes for a threshold sitting at
+# operating size, and NOT the rate form that was deleted for being unsatisfiable.
+#
+# ⚠ SCOPED TO THE REPO ROOT, and this was an operator decision made on a measurement. LEDGERS is
+# resolved by BASENAME at any depth (`LEDGERS.get(path.name)`, :1674+), so an unscoped relaxation
+# would hand the 192 KiB arm to any */CHANGELOG.md or */HANDOFFS.md -- 3.38x READ_CAP_BYTES -- for
+# a file the dashboard never classified as anything (its read_cap_class() is a repo-relative PATH
+# lookup and answers None for a nested one). A nested ledger keeps READ_CAP_BYTES. See
+# Trigger.class_a and evaluate_trigger.
+CLASS_A_FIRE_BYTES = 192 * 1024   # 196,608 — fire above this, for a ROOT Class A ledger only
+CLASS_A_STOP_BYTES = 96 * 1024    # 98,304 — cut back to at or under this. Deliberately equal to
+                                  # int(DEFAULT_BUDGET_BYTES * BYTE_STOP_FRACTION) today, and
+                                  # deliberately NOT written as that expression: the two arms
+                                  # answer different questions (see the Trigger comment below) and
+                                  # deriving one from the other would assert they are one question.
+                                  # The coincidence is asserted by a test as INTENTIONAL, so that
+                                  # moving one without the other is a decision and not an accident.
+
+# RAISED 64 KiB -> 192 KiB at Phase C2 (option C1), by operator decision, in the SAME change as the
+# Class A arm above because separately each is inert: `fires` is `read_fires or byte_fires`, so a
+# relaxed read arm changes nothing while a 64 KiB byte arm fires first (plan §5, §10 dragon 1).
+# THE OLD JUSTIFICATION IS RETIRED, NOT CARRIED FORWARD. It read "design §5.4: calibrated to the
+# three sizes this repo operated at" -- 52,927 / 53,512 / 49,382 B, the post-archive resets of
+# 2026-08. Those are no longer the sizes this repo operates at (81,070 and 111,388 B at this
+# commit), and the campaign that measured them adjudicated the growth as costing nothing anyone
+# reads. A calibration whose basis has moved is not a baseline; it is a stale number with a
+# citation. ⚠ A DERIVATION NOTE THE PLAN GOT WRONG AND A SUCCESSOR SHOULD NOT INHERIT: it is
+# widely written that this constant is "the number BL-9/BL-32/BL-36/S87/S89 have all measured
+# against". That is impossible for BL-9, which CLOSED 2026-08-01 against a constant first written
+# 2026-08-03 (df381ea); §5.4's 52,927 B is BL-9's own output commit 7a71df0, so BL-9 is this
+# constant's INPUT. The other four were not re-derived and are claimed neither way.
+DEFAULT_BUDGET_BYTES = 192 * 1024  # 196,608 — the per-file context-tax budget, still overridable
+                                   # per LedgerSpec and per run via --budget-bytes
+
+# LINE_FIRE_BELOW / LINE_STOP_ABOVE ARE GONE, DELIBERATELY. This note is the record of why, so a
+# later session re-adds them on purpose or not at all. They were "archive when headroom falls
+# below 15 RECORDS; cut until it is back above 30" — denominated in records of headroom TO the
+# cap. Measured at Phase B: a one-read CHANGELOG.md holds 20.9 records and a one-read HANDOFFS.md
+# holds 4.3, so a rule demanding 30 records of headroom is UNSATISFIABLE ON BOTH AT EVERY HONEST
+# CAP, and `choose_cut` falls through to `return 1` — retaining ONE record with every test in the
+# repo still green. It only ever looked satisfiable because 2,000 lines granted CHANGELOG.md 2.32×
+# and HANDOFFS.md 8.75× more capacity than a real read. design §5.2 states the reason itself: the
+# units-of-headroom form is well-formed only while the cap "sits far above normal operating size",
+# and at operating size that design prescribes "a level with hysteresis, not a rate — the form
+# that terminates". `byte_fires` + BYTE_STOP_FRACTION below is already that form, so the read cap
+# now takes it too. Re-deriving the two thresholds was considered and rejected on the measurement
+# rather than on taste; the arithmetic is in read-cap-premise-correction-plan.md, Phase B.
+BYTE_STOP_FRACTION = 0.5       # hysteresis — stops a trim re-firing on the next record
+SRF_RED = 1.00                 # plan §3.3 H3: at or above this, a reset is the wrong move
+ARCHIVE_DIR = "docs/archive"
+REBASE_PREFIX = "../../"       # docs/archive/<shard>.md -> repo root is exactly two levels
+SHARD_SUFFIX_MAX = 99          # BL-41 — bound on collision disambiguation; past it, refuse
+
+# --- "is this plausibly a fresh seed?" — a DIFFERENT question from "is it over its budget" ----
+# Deliberately its own literal rather than an alias of DEFAULT_BUDGET_BYTES, and deliberately not
+# `opts.budget_bytes`: --budget-bytes tunes when a trim FIRES, and the seeds invite an adopter to
+# lower it. Wiring that knob into this test would let a calibration choice decide whether the tool
+# tells you your ledger grammar is wrong — and a budget set below 12,124 B would declare the seed
+# we ship to be unreadable. The two numbers may drift apart; nothing should couple them.
+SEED_PLAUSIBLE_MAX_BYTES = 64 * 1024
+SEED_PLAUSIBLE_MAX_LINES = 2000
+# ^ THE VALUE IS UNCHANGED AND THE NAME IS NEW, and that is the whole point (Phase B, J3). This
+# line count used to be READ_CAP_LINES, borrowed. But the question here is not "does one Read
+# deliver this file?" — it is "is a file THIS LONG plausibly a fresh, empty seed, or is my grammar
+# wrong?" Nothing about truncation bears on it. Sharing the name meant a correction made for the
+# reporter's reasons would silently move the REFUSAL boundary: at a corrected cap, a record-less
+# file of 700–2,000 lines would newly refuse with GRAMMAR_MISMATCH instead of reporting NO_RECORDS,
+# and no test in this repo would have caught it. The byte disjunct beside it already covers "big
+# file"; this one uniquely covers LONG BUT SMALL — say 3,000 lines averaging 20 B. Re-tune it, if
+# ever, on seed plausibility and on nothing else.
+
+
+# =============================================================================================
+# Findings — the tool's output vocabulary.
+#
+# Tests assert on CODES, never on the process exit code: the exit code is a union over every
+# check the tool runs, so adding one check silently re-labels unrelated assertions (design §6.3).
+# =============================================================================================
+
+class Finding:
+    __slots__ = ("code", "message")
+
+    def __init__(self, code, message):
+        self.code = code
+        self.message = message
+
+    def __repr__(self):
+        return "Finding(%s)" % self.code
+
+
+class Result:
+    """Everything one --file evaluation produced. `codes` is the assertable surface."""
+
+    def __init__(self, path):
+        self.path = path
+        self.findings = []
+        self.exit = 0
+        self.plan = None          # TrimPlan, when one was computed
+        self.written = []         # paths actually written
+
+    def add(self, code, message, exit_code=None):
+        self.findings.append(Finding(code, message))
+        if exit_code is not None and exit_code > self.exit:
+            self.exit = exit_code
+        return self
+
+    @property
+    def codes(self):
+        return [f.code for f in self.findings]
+
+    def has(self, code):
+        return code in self.codes
+
+
+# =============================================================================================
+# Config table — a table in the tool, never a config file.
+#
+# A file with no entry exits 3. It does NOT fall back to a generic rule, because a generic rule
+# is exactly what would mis-zone an adopter's differently-shaped ledger (design §6.3).
+# =============================================================================================
+
+class LedgerSpec:
+    def __init__(self, basename, record_kind, footer_mode, date_of_record,
+                 record_start=None, fence_info=None, regenerated=(), budget_bytes=DEFAULT_BUDGET_BYTES,
+                 content_probe=None, seed_negation=None):
+        self.basename = basename
+        self.record_kind = record_kind        # "heading" | "fence"
+        self.record_start = record_start      # compiled regex, for record_kind == "heading"
+        self.fence_info = fence_info          # info string, for record_kind == "fence"
+        self.footer_mode = footer_mode        # "separator" | "none"
+        self.date_of_record = date_of_record  # callable(record_text) -> "YYYY-MM-DD" or None
+        self.regenerated = list(regenerated)  # [(name, compiled regex w/ 3 groups, value_fn)]
+        self.budget_bytes = budget_bytes
+        self.content_probe = content_probe    # loose "this LOOKS like a record" regex, or None
+        self.seed_negation = seed_negation    # the seed comment's own "and there are no X below"
+
+
+def _changelog_date(text):
+    m = re.match(r"^### (\d{4}-\d{2}-\d{2}) · ", text)
+    return m.group(1) if m else None
+
+
+def _handoff_date(text):
+    m = re.search(r"^date: (\d{4}-\d{2}-\d{2})\s*$", text, re.M)
+    return m.group(1) if m else None
+
+
+LEDGERS = {
+    "CHANGELOG.md": LedgerSpec(
+        basename="CHANGELOG.md",
+        record_kind="heading",
+        # Anchored on the dated, source-tagged heading the ledger's own audit grep uses.
+        record_start=re.compile(r"^### \d{4}-\d{2}-\d{2} · \["),
+        footer_mode="separator",
+        date_of_record=_changelog_date,
+        # The live root ledger carries no count sentence today, so this list is empty and the
+        # pointer block below is the whole of the front-matter change. Declared-empty is not the
+        # same as unchecked: L2 still confines the front-matter diff to the pointer block.
+        regenerated=(),
+        # Evidence that entries EXIST in a grammar this config cannot read. Anchored to a line
+        # that could plausibly BE a record — an ATX heading or a table row — not to "a date
+        # somewhere on the line", which also matches ordinary front-matter prose describing dates.
+        # Measured over the real population: the anchored form loses no detection — 147 and 87 hits
+        # on the two ledgers the UAT named, and 11 and 4 on two more found while building this fix
+        # and NOT part of that audit — while dropping to zero on both shipped seeds and on dated
+        # prose. Do not re-attribute all four to the UAT; it examined six repositories, not eight.
+        content_probe=re.compile(r"^(#{1,6} |\|).*\d{4}-\d{2}-\d{2}"),
+        # No separate negation: for a HEADING-keyed ledger the probe already subsumes it. Every
+        # `### <date>` line is also `#{1,6} `-shaped and dated, so a negation here can never be the
+        # only signal that fires, and a clause no mutant can falsify is a comment shaped like a
+        # guard. HANDOFFS.md keeps one because its records are fences, where that is not true.
+        seed_negation=None,
+    ),
+    "HANDOFFS.md": LedgerSpec(
+        basename="HANDOFFS.md",
+        record_kind="fence",
+        fence_info="handoff",
+        # Declared to have NO footer: trailing prose below the last fence belongs to that receipt.
+        # The declaration is asserted, not assumed — see classify_zones().
+        footer_mode="none",
+        date_of_record=_handoff_date,
+        regenerated=(
+            ("retained receipt count",
+             re.compile(r"(This file currently holds \*\*)(\d+)(\*\*)"),
+             lambda ctx: str(ctx["retained"])),
+        ),
+        # The SAME probe as CHANGELOG.md, deliberately. The first draft left this None on the
+        # argument that a receipt ledger keeps its records inside fences — true of a WORKING one,
+        # and beside the point for a broken one: a ledger whose receipts are not ```handoff fences
+        # keeps them somewhere, and heading-shaped is the likeliest somewhere. Leaving it None also
+        # made the tool's strictness depend on which of two filenames you were holding, which is a
+        # guard you can walk around by picking a name. Measured at zero hits on the shipped seed
+        # (its worked receipt is inside a 4-backtick wrapper, and the probe is fence-aware).
+        content_probe=re.compile(r"^(#{1,6} |\|).*\d{4}-\d{2}-\d{2}"),
+        # This file's seed states its own freshness rule in its own terms — fresh "While this line
+        # is present AND there are no `session:` blocks below" — so the negation is `session:`,
+        # not a dated heading. Fence-aware, so the seed's wrapped example does not count itself.
+        seed_negation=re.compile(r"^session:\s"),
+    ),
+}
+
+
+# =============================================================================================
+# Fence tracking — mandatory, and the seed files are the proof.
+#
+# `starter-kit/CHANGELOG.md` holds 3 `^### YYYY-MM-DD` lines and ALL 3 are inside fenced
+# documentation examples; `starter-kit/HANDOFFS.md` holds 1 ```handoff and it is inside a
+# 4-backtick wrapper. A trimmer that is not fence-aware trims an adopter's freshly seeded
+# ledger on day one (design §2.2).
+# =============================================================================================
+
+_FENCE = re.compile(r"^(`{3,}|~{3,})(.*)$")
+
+
+def fence_scan(lines):
+    """Yield (index, stripped_line, inside_before, info_string).
+
+    `inside_before` is the fence state BEFORE this line, so a fence-opening line reports False —
+    which is what makes a ```handoff opener recognisable as a record start.
+    """
+    marker = None
+    for i, raw in enumerate(lines):
+        s = raw.rstrip("\r\n")
+        inside_before = marker is not None
+        m = _FENCE.match(s)
+        info = ""
+        if marker is None:
+            if m:
+                marker = (m.group(1)[0], len(m.group(1)))
+                info = m.group(2).strip()
+        else:
+            ch, n = marker
+            if m and m.group(1)[0] == ch and len(m.group(1)) >= n and m.group(2).strip() == "":
+                marker = None
+        yield i, s, inside_before, info
+
+
+def code_span_ranges(line):
+    """Character ranges covered by inline code spans, so a link inside one is out of domain.
+
+    Not hypothetical: the 2026-08-01 shard contains `](../../` inside an inline code span, in a
+    sentence explaining the rebase. A naive key rewrites the explanation of the rewrite.
+    """
+    ranges = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if line[i] == "`":
+            j = i
+            while j < n and line[j] == "`":
+                j += 1
+            ticks = j - i
+            k = j
+            while k < n:
+                if line[k] == "`":
+                    m = k
+                    while m < n and line[m] == "`":
+                        m += 1
+                    if m - k == ticks:
+                        ranges.append((i, m))
+                        i = m
+                        break
+                    k = m
+                else:
+                    k += 1
+            else:
+                break
+            continue
+        i += 1
+    return ranges
+
+
+# =============================================================================================
+# Zone classification — declared, never inferred. Ambiguity is a refusal.
+# =============================================================================================
+
+class Zones:
+    def __init__(self, lines, starts, footer_start):
+        self.lines = lines
+        self.starts = starts                  # record start line indices
+        self.footer_start = footer_start      # index, or len(lines) when there is no footer
+        self.front_end = starts[0] if starts else footer_start
+
+    @property
+    def front(self):
+        return "".join(self.lines[:self.front_end])
+
+    @property
+    def footer(self):
+        return "".join(self.lines[self.footer_start:])
+
+    def record_spans(self):
+        """[(start, end)] — a record runs to the next record start, or to the footer.
+
+        Design §2.2 defines both families this way: a record ends at "the line before the next
+        record start / footer". Inter-record scaffolding (`## YYYY-MM` group headings, `---`
+        separators) therefore rides inside the preceding record's span and moves with it. That is
+        a partition; regenerating those headings in both files would be duplication, which L3
+        forbids by construction.
+        """
+        spans = []
+        for k, s in enumerate(self.starts):
+            e = self.starts[k + 1] if k + 1 < len(self.starts) else self.footer_start
+            spans.append((s, e))
+        return spans
+
+    def records(self):
+        return ["".join(self.lines[s:e]) for s, e in self.record_spans()]
+
+
+def classify_zones(text, spec, result):
+    """Split into FRONT MATTER | RECORDS | FOOTER. Returns Zones, or None after a refusal."""
+    lines = text.splitlines(keepends=True)
+    starts, hrs = [], []
+    for i, s, inside, info in fence_scan(lines):
+        if inside:
+            continue
+        if spec.record_kind == "heading" and spec.record_start.match(s):
+            starts.append(i)
+        elif spec.record_kind == "fence" and info == spec.fence_info:
+            starts.append(i)
+        if s.strip() == "---":
+            hrs.append(i)
+
+    if not starts:
+        return Zones(lines, [], len(lines))
+
+    last = starts[-1]
+    tail_hrs = [i for i in hrs if i > last]
+
+    if spec.footer_mode == "separator":
+        # A footer is a standalone `---` after the last record start whose remainder contains no
+        # further record start. In a newest-on-top file this sits exactly where an oldest-first
+        # cut takes from, which is how the scope footer migrated into the shard.
+        for i in tail_hrs:
+            if "".join(lines[i + 1:]).strip():
+                return Zones(lines, starts, i)
+        return Zones(lines, starts, len(lines))
+
+    if spec.footer_mode == "none":
+        # Declared to have no footer — and the declaration is ASSERTED. Trailing content set apart
+        # by a separator is content the config cannot name, so the run aborts with the span printed
+        # rather than sweeping it into a record that is about to move.
+        for i in tail_hrs:
+            span = "".join(lines[i + 1:])
+            if span.strip():
+                result.add(
+                    "ZONE_UNCLASSIFIED",
+                    "%s declares footer_mode='none', but line %d is a standalone '---' with %d B of "
+                    "content after it that the config cannot classify. Refusing rather than guessing "
+                    "which zone it belongs to. Span:\n%s"
+                    % (spec.basename, i + 1, len(span.encode("utf-8")), _indent(span[:400])),
+                    exit_code=2,
+                )
+                return None
+        return Zones(lines, starts, len(lines))
+
+    result.add("NO_CONFIG", "unknown footer_mode %r for %s" % (spec.footer_mode, spec.basename), exit_code=3)
+    return None
+
+
+def _safe_cut_key(key):
+    """A cut key must be a flat filename fragment — no separator, no leading dot."""
+    return bool(re.match(r"^[A-Za-z0-9][A-Za-z0-9._-]*$", key or ""))
+
+
+def shard_name_taken(shard_path):
+    """True if EITHER half of the pair this name would write already exists.
+
+    A trim writes `<shard>.md` and `<shard>.md.verify.sh` together. An interrupted or partially
+    reverted run can leave the proof behind without its shard, and a check that looked only at the
+    shard would then report the name free and overwrite a frozen proof — the same corruption the
+    write-once rule exists to exclude, one file over. The pair is the unit, so the pair is the test.
+    """
+    return shard_path.exists() or Path(str(shard_path) + ".verify.sh").exists()
+
+
+def _indent(s, pad="    | "):
+    return "\n".join(pad + ln for ln in s.splitlines())
+
+
+# =============================================================================================
+# The only permitted mutation: a uniform ../../ prefix on root-relative link targets.
+#
+# The domain predicate IS the contract. `](` alone is not it: on the corpus the design cites, of
+# 23 link targets in the 2026-08-01 shard exactly ONE is a genuine candidate and 14 are absolute
+# URLs the bare key would have rewritten into `](../../https://…)`.
+# =============================================================================================
+
+_LINK = re.compile(r"\]\(([^)\s]*)\)")
+_SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:")
+
+
+def _in_domain(target):
+    if not target:
+        return False
+    if _SCHEME.match(target):          # absolute URL / mailto:
+        return False
+    if target.startswith("#"):         # in-page anchor
+        return False
+    if target.startswith("/"):         # absolute path
+        return False
+    if target.startswith("../"):       # already relative — prefixing it is not invertible
+        return False
+    return True
+
+
+def _map_links(text, fn):
+    """Apply fn to every in-domain link target outside fenced blocks and inline code spans."""
+    lines = text.splitlines(keepends=True)
+    out = []
+    for i, s, inside, info in fence_scan(lines):
+        raw = lines[i]
+        if inside or _FENCE.match(s):
+            out.append(raw)
+            continue
+        spans = code_span_ranges(raw)
+
+        def repl(m):
+            if any(a <= m.start() < b for a, b in spans):
+                return m.group(0)
+            new = fn(m.group(1))
+            return m.group(0) if new is None else "](%s)" % new
+
+        out.append(_LINK.sub(repl, raw))
+    return "".join(out)
+
+
+def transform_record(text):
+    return _map_links(text, lambda t: REBASE_PREFIX + t if _in_domain(t) else None)
+
+
+def invert_record(text):
+    def back(t):
+        if not t.startswith(REBASE_PREFIX):
+            return None
+        stripped = t[len(REBASE_PREFIX):]
+        return stripped if _in_domain(stripped) else None
+    return _map_links(text, back)
+
+
+def check_invertible(records, result):
+    """Apply the transform then its inverse and assert the round-trip is the identity.
+
+    "Uniform because uniform is invertible and therefore provable" — operationally, this. A record
+    that already carries a `../`-prefixed target cannot survive the round-trip, so it is rejected
+    rather than silently mangled.
+    """
+    bad = []
+    for idx, rec in enumerate(records):
+        if invert_record(transform_record(rec)) != rec:
+            bad.append(idx)
+    if bad:
+        result.add(
+            "TRANSFORM_NOT_INVERTIBLE",
+            "the ../../ rebase does not round-trip to the identity on record(s) %s — refusing. A "
+            "record carrying an already-relative ('../') link target cannot be rebased provably."
+            % ", ".join(str(b) for b in bad),
+            exit_code=2,
+        )
+        return False
+    return True
+
+
+# =============================================================================================
+# The three assertions. Pure functions over the in-memory partition, so a test can drive each
+# one RED with a corrupted triple and watch it fail before any green is trusted.
+# =============================================================================================
+
+def assert_L1(before_records, retained_records, shard_records, result):
+    """records(live_after) ++ invert(transform(records(shard))) == records(live_before).
+
+    Scoped to the RECORDS zone. The unscoped whole-file form is unsatisfiable on any run that
+    regenerates the pointer, and does not hold on the real event either (design §4.2).
+
+    NOTE — THE OPERAND ORDER IS THE REVERSE OF THE DESIGN'S §4.2 FORMULA, AND THE DESIGN IS WRONG.
+    §4.2 writes `invert(transform(records(shard))) ++ records(live_after)`, which holds only for an
+    OLDEST-on-top ledger. Both ledgers here are NEWEST-on-top — the shard takes the oldest records,
+    from the BOTTOM — so the retained (newer) records precede the archived (older) ones. The
+    design's order fails on the very first real run, at char 26 of a reconstruction with the correct
+    total length: not loss, just the two halves swapped. Found by implementing it; recorded in the
+    S37 close-out rather than silently corrected.
+    """
+    reconstructed = "".join(retained_records) + "".join(invert_record(r) for r in shard_records)
+    original = "".join(before_records)
+    if reconstructed != original:
+        i = _first_diff(reconstructed, original)
+        result.add(
+            "L1_MISMATCH",
+            "records-zone concatenation is not byte-identical to the pre-trim records zone: first "
+            "difference at char %d (reconstructed %d B, original %d B)."
+            % (i, len(reconstructed.encode("utf-8")), len(original.encode("utf-8"))),
+            exit_code=2,
+        )
+        return False
+    return True
+
+
+def assert_L2(before_zones, after_front, after_footer, shard_text, declared_inserts, reversals,
+              result):
+    """Zone pinning — every FOOTER byte stays live and is absent from the shard; the FRONT MATTER
+    diff is confined to the declared regenerated fields and the pointer block.
+
+    This is the assertion whose absence cost a paragraph.
+    """
+    ok = True
+    footer = before_zones.footer
+
+    if footer.strip():
+        if after_footer != footer:
+            result.add(
+                "L2_FOOTER_ALTERED",
+                "the FOOTER zone (%d B) is not byte-identical in the live file after the trim. The "
+                "footer is file-scoped, not a record; it is pinned to live, always."
+                % len(footer.encode("utf-8")),
+                exit_code=2,
+            )
+            ok = False
+        # Compare against the INVERTED shard. A footer swept into the records zone travels through
+        # the ../../ rebase on its way in, so its link targets are rewritten and a verbatim
+        # substring test misses it — including on the real 020ba3f footer, whose one link is
+        # exactly the kind the transform rewrites.
+        if footer.strip() and (footer.strip() in shard_text
+                               or footer.strip() in invert_record(shard_text)):
+            result.add(
+                "L2_FOOTER_MOVED",
+                "the FOOTER zone appears in the shard. In a newest-on-top file the footer sits "
+                "exactly where an oldest-first cut takes from, so it migrates BY POSITION unless "
+                "something pins it — this is the `020ba3f` loss, caught.",
+                exit_code=2,
+            )
+            ok = False
+
+    # The front-matter diff must be CONFINED to the declared changes — itself an assertion, not a
+    # carve-out. Proved by REVERSING each declared change and requiring the original bytes back:
+    # remove the pointer block, then put every regenerated field's old value back. Anything else
+    # that moved survives the reversal and shows up as a mismatch.
+    #
+    # The exception is load-bearing and was first written as a contradiction — the zone model says
+    # front matter is rewritten (counts and pointers change every run), while a flat "byte-identical"
+    # L2 forbids exactly that. Naming the regenerated fields is what makes both true at once, and it
+    # converts the rewrite from an unconstrained edit into a bounded one.
+    residue = after_front
+    for n, block in enumerate(declared_inserts):
+        if not block:
+            continue          # an optional declared insertion this run did not make
+        if block in residue:
+            residue = residue.replace(block, "", 1)
+        elif n == 0:
+            result.add("L2_POINTER_MISSING",
+                       "the shard pointer block is not present verbatim in the rewritten front "
+                       "matter; a severed record set with no pointer to its shard is the failure "
+                       "mode that ruled out truncate-and-let-git-be-the-archive.", exit_code=2)
+            ok = False
+        else:
+            result.add("L2_DECLARED_INSERT_MISSING",
+                       "a declared front-matter insertion is not present verbatim: %r" % block[:60],
+                       exit_code=2)
+            ok = False
+    for rx, old, new in reversals:
+        m = rx.search(residue)
+        if m and m.group(2) == new:
+            residue = residue[:m.start()] + m.group(1) + old + m.group(3) + residue[m.end():]
+    if residue != before_zones.front:
+        i = _first_diff(residue, before_zones.front)
+        result.add(
+            "L2_FRONTMATTER_UNDECLARED",
+            "the FRONT MATTER changed outside the declared regenerated fields and the pointer "
+            "block: reversing every declared change does not restore the original bytes (first "
+            "residual difference at char %d). Front matter may be rewritten only where the config "
+            "says it may be." % i,
+            exit_code=2,
+        )
+        ok = False
+    return ok
+
+
+def assert_L3(before_records, retained_records, shard_source_records, result):
+    """Record partition by identity, ORDER and byte-equality of each record.
+
+    Not hypothetical: the first manual archive moved 19 receipts and rewrote the RETAINED S22
+    receipt in the same commit (1,791 -> 1,799 chars). The correction was right; bundling it into
+    the move made "the move was verbatim" unfalsifiable. A run is a pure partition, or it aborts.
+    """
+    rebuilt = list(retained_records) + list(shard_source_records)
+    if len(rebuilt) != len(before_records):
+        result.add(
+            "L3_RECORD_COUNT",
+            "record partition is not a partition: %d before, %d after (retained %d + archived %d)."
+            % (len(before_records), len(rebuilt), len(retained_records), len(shard_source_records)),
+            exit_code=2,
+        )
+        return False
+    altered = [i for i, (a, b) in enumerate(zip(before_records, rebuilt)) if a != b]
+    if altered:
+        i = altered[0]
+        result.add(
+            "L3_RECORD_ALTERED",
+            "record %d is not byte-identical across the move (%d B before, %d B after). A trim is a "
+            "pure move; an edit co-mingled with it makes losslessness unfalsifiable. Altered "
+            "record(s): %s" % (i, len(before_records[i].encode("utf-8")),
+                               len(rebuilt[i].encode("utf-8")),
+                               ", ".join(str(x) for x in altered)),
+            exit_code=2,
+        )
+        return False
+    return True
+
+
+def _first_diff(a, b):
+    n = min(len(a), len(b))
+    for i in range(n):
+        if a[i] != b[i]:
+            return i
+    return n
+
+
+# =============================================================================================
+# git helpers
+# =============================================================================================
+
+def git(repo, *args):
+    try:
+        p = subprocess.run(["git", "-C", str(repo)] + list(args),
+                           capture_output=True, text=True, check=False)
+    except OSError:
+        return None
+    return p.stdout.rstrip("\n") if p.returncode == 0 else None
+
+
+def git_bytes(repo, *args):
+    try:
+        p = subprocess.run(["git", "-C", str(repo)] + list(args),
+                           capture_output=True, check=False)
+    except OSError:
+        return None
+    return p.stdout if p.returncode == 0 else None
+
+
+def repo_root(path):
+    r = git(path.parent if path.is_file() else path, "rev-parse", "--show-toplevel")
+    return Path(r) if r else None
+
+
+def size_at(repo, sha, relpath):
+    b = git_bytes(repo, "show", "%s:%s" % (sha, relpath))
+    return None if b is None else len(b)
+
+
+def lines_at(repo, sha, relpath):
+    b = git_bytes(repo, "show", "%s:%s" % (sha, relpath))
+    return None if b is None else b.decode("utf-8", "replace").count("\n")
+
+
+# =============================================================================================
+# The trigger — two metrics, because there are two distinct failure modes. BOTH ARE NOW LEVELS
+# WITH HYSTERESIS on the same axis (bytes), and that is the Phase B change: what used to be a
+# line-denominated RATE is now a byte-denominated LEVEL.
+#
+#   READ DELIVERY — does one `Read` still return this file? The cap is TOKEN-denominated
+#   (~25,000), truncation is ANNOUNCED rather than silent, and there is a SECOND boundary at
+#   256 KiB past which a default read is REFUSED with zero content. READ_CAP_BYTES converts the
+#   token cap at the densest content measured, so the guard is conservative by construction.
+#   Re-measure with Appendix A of docs/planning/read-cap-premise-correction-plan.md; nothing in
+#   this repo can falsify it, because nothing here can invoke the agent's Read tool.
+#
+#   AND THE METRIC MEASURES A CONDITION IT MAY NOT REMEDY (BL-52, open, and Phase B did not close
+#   it). Truncation is ordered top-down and these ledgers are newest-on-top, so between the two
+#   boundaries the records a cut removes are ones a whole-file read was NOT DELIVERING ANYWAY:
+#   the delivered prefix is the same before and after, and what changes is that the reader stops
+#   being WARNED. Two things narrow that caveat rather than dissolve it. Past READ_REFUSE_BYTES
+#   there IS no delivered prefix, so a cut back under it turns nothing into something. And below
+#   the cap the whole file is delivered and every byte is paid for, so a cut moves a file from
+#   truncated to fully delivered. The caveat bites hardest well past the cap and not at all near
+#   it. Do not read this metric as a settled argument for cutting; do not read it as no argument.
+#
+#   CONTEXT TAX — G1, the operator's stated goal. Bytes, against a per-file budget. A separate
+#   claim, not covered by the caveat above, and untouched by Phase B.
+#
+# The two are deliberately NOT deduplicated here even though they now share an axis: they answer
+# different questions and their thresholds have unrelated provenance. Whether the dashboard should
+# still report them as two rows is S38's residual 1, still open (Phase C).
+class Trigger:
+    def __init__(self):
+        self.size_bytes = 0
+        self.budget = DEFAULT_BUDGET_BYTES
+        # PHASE C2. False is the CONSERVATIVE default and that is deliberate: a caller that never
+        # sets it gets the tighter READ_CAP_BYTES arm, so forgetting to classify errs toward
+        # firing early rather than toward silence. evaluate_trigger sets it from the file's
+        # repo-relative path -- never from its basename, which is the distinction the scoping
+        # decision turns on.
+        self.class_a = False
+        self.srf = None                # (value, boundary_sha) for the most recent archive
+        self.srf_largest = None        # (value, boundary_sha) for H3's own largest-drop boundary
+        self.srf_abstains = None
+
+    @property
+    def read_fire_at(self):
+        """The read arm's threshold for THIS file. One place, so fire and stop cannot diverge.
+
+        A root Class A ledger is denominated against the REFUSAL (CLASS_A_FIRE_BYTES); everything
+        else keeps the one-read cap. The two are not degrees of the same thing: below the refusal
+        a Class A read still delivers front matter and the newest records, and past it no read
+        delivers anything."""
+        return CLASS_A_FIRE_BYTES if self.class_a else READ_CAP_BYTES
+
+    @property
+    def read_stop_at(self):
+        """The read arm's STOP for this file — the half `stops()` reads.
+
+        SEPARATE FROM read_fire_at ON PURPOSE, and this is the trap Phase C2 was written to avoid.
+        Before C2 the fire and the stop were the SAME constant (READ_CAP_BYTES), so moving "the
+        read arm's threshold" read like one edit. It is two. Moving only the fire leaves
+        `choose_cut` still cutting back to 56,750 B -- silently, with every test green, because
+        nothing asserted what a trim cuts BACK to. Both are named here so a future move of one is
+        visibly a move of one."""
+        return CLASS_A_STOP_BYTES if self.class_a else READ_CAP_BYTES
+
+    @property
+    def read_fires(self):
+        return self.size_bytes > self.read_fire_at
+
+    @property
+    def byte_fires(self):
+        return self.size_bytes > self.budget
+
+    @property
+    def fires(self):
+        return self.read_fires or self.byte_fires
+
+    def stops(self, size_bytes, unused_line_count=None, unused_de=None, unused_dl=None):
+        """Both stop conditions must hold. Fire if EITHER fires; stop only when BOTH stop.
+
+        Both are LEVELS now, so both terminate — which is the property the deleted line rate did
+        not have. `read_ok` is written out rather than left implicit because `--budget-bytes` is an
+        adopter-facing knob and a raised budget must not quietly let a file stop above the read
+        arm's stop.
+
+        ⚠ WHICH ARM BINDS MOVED AT PHASE C2, and the direction is worth stating. At the old budget
+        `byte_ok` was the tighter of the two (32,768 B against READ_CAP_BYTES' 56,750). At the
+        raised budget the two COINCIDE for a root Class A ledger — 98,304 B on both sides — and for
+        everything else `read_ok` (56,750) is now the tighter. So a nested ledger, or any file
+        whose class was not established, still stops at the one-read cap no matter what the budget
+        says. That is the conservative direction, and it is the reason `class_a` defaults False.
+
+        When this returns False at EVERY retained count, `choose_cut` still falls through to
+        `return 1` — but that now means what it says: trimming genuinely cannot satisfy the goal,
+        e.g. the front matter alone is over. It is no longer reachable by a rule that was
+        unsatisfiable by construction, which is what the line rate had become."""
+        byte_ok = size_bytes <= int(self.budget * BYTE_STOP_FRACTION)
+        read_ok = size_bytes <= self.read_stop_at
+        return byte_ok and read_ok
+
+
+def archive_events(repo, spec):
+    """[(sha, pre_size, post_size, relpath)] for every shard of this ledger, oldest first.
+
+    Derived by GLOB over docs/archive/, never from hardcoded literal paths: `bin/tests.sh` wires
+    exactly one shard by literal path in two places, so a second shard would never be checked and
+    the suite would still pass (design §8.2).
+    """
+    adir = repo / ARCHIVE_DIR
+    if not adir.is_dir():
+        return []
+    stem = spec.basename[:-3] if spec.basename.endswith(".md") else spec.basename
+    events = []
+    for shard in sorted(adir.glob("%s-*.md" % stem)):
+        rel = shard.relative_to(repo).as_posix()
+        sha = git(repo, "log", "--diff-filter=A", "-1", "--format=%H", "--", rel)
+        if not sha:
+            continue
+        pre = size_at(repo, sha + "^", spec.basename)
+        post = size_at(repo, sha, spec.basename)
+        if pre is None or post is None or pre <= post:
+            continue
+        events.append((sha, pre, post, rel))
+    # Order by position in the commit graph, NEWEST first, then reverse — never by %ct. Two
+    # archives committed in the same second are ordinary (a script, a test), and a timestamp tie
+    # falls back to sha order, which is arbitrary: "the most recent archive" would then be a coin
+    # flip, and the SRF refusal is decided by exactly that choice.
+    #
+    # MUTATION NOTE, recorded rather than papered over: replacing this with a plain `events.sort()`
+    # (i.e. sha order) SURVIVES the test suite. It is not an equivalent mutant — sha order is wrong
+    # in general — but for a two-event fixture sha order coincides with graph order about half the
+    # time, and commit shas vary run to run, so no functional test can kill it deterministically.
+    # Claiming it as covered would be the inflated-mutation-score failure this repo already names.
+    walk = git(repo, "rev-list", "--topo-order", "HEAD") or ""
+    rank = {sha: i for i, sha in enumerate(walk.split())}
+    events.sort(key=lambda e: -rank.get(e[0], 1 << 30))
+    return events
+
+
+def is_root_class_a(repo, path, spec):
+    """Is this file a Class A ledger AT THE REPOSITORY ROOT?
+
+    PHASE C2, and the whole point is that this asks a different question from `LEDGERS.get(name)`.
+    That lookup is by BASENAME at any depth, so `starter-kit/CHANGELOG.md` and a hypothetical
+    `docs/x/HANDOFFS.md` both resolve to a spec and get a fully evaluated trigger. Having a
+    grammar is what makes a file TRIMMABLE; sitting at the root is what makes it the ledger the
+    protocol actually reads, and only the latter earns the relaxed Class A arm.
+
+    This mirrors methodology_dashboard.py's read_cap_class(), which is a repo-relative PATH lookup
+    and answers None -- neither A nor B -- for a nested one. The two tools were already asking
+    different questions here; before C2 the difference cost nothing because both arms used the
+    same constant. Returns False on anything it cannot resolve, which routes the caller to the
+    tighter arm."""
+    try:
+        rel = path.resolve().relative_to(repo).as_posix()
+    except (ValueError, OSError):
+        return False
+    return rel == spec.basename
+
+
+def evaluate_trigger(repo, path, spec, zones, budget, result):
+    t = Trigger()
+    t.budget = budget
+    t.class_a = is_root_class_a(repo, path, spec)
+    text = read_text(path)
+    t.size_bytes = len(text.encode("utf-8"))
+
+    events = archive_events(repo, spec)
+
+    # --- SRF: reported for BOTH boundaries, because they differ by 3x on the same file ---------
+    if not events:
+        t.srf_abstains = ("no prior archive — SRF is undefined before a ledger's first archive "
+                          "(H3's own stated limit). Abstaining rather than computing a zero.")
+    else:
+        def srf(pre, post):
+            return None if pre == post else (t.size_bytes - post) / float(pre - post)
+        recent = events[-1]
+        t.srf = (srf(recent[1], recent[2]), recent[0])
+        largest = max(events, key=lambda e: e[1] - e[2])
+        t.srf_largest = (srf(largest[1], largest[2]), largest[0])
+
+    result.plan_trigger = t
+    return t
+
+
+# =============================================================================================
+# The plan
+# =============================================================================================
+
+class TrimPlan:
+    def __init__(self):
+        self.retained = []
+        self.archived = []
+        self.shard_rel = None
+        self.verify_rel = None
+        self.cut_key = None
+        self.span = None
+        self.before_bytes = 0
+        self.after_bytes = 0
+        self.live_after = None
+        self.shard_text = None
+        self.verify_text = None
+        self.ledger_entry = None
+        self.pointer_block = None
+
+
+def choose_cut(zones, spec, trigger, explicit, spec_date, result):
+    """Pick how many records to retain. Cuts are by POSITION in file order, never by sorting on a
+    parsed key: this ledger interleaves two independent S<N> sequences that collide, and a calendar
+    day straddles the existing cut (design §2.3)."""
+    records = zones.records()
+    n = len(records)
+    front_b = len(zones.front.encode("utf-8"))
+    foot_b = len(zones.footer.encode("utf-8"))
+    front_l = zones.front.count("\n")
+    foot_l = zones.footer.count("\n")
+
+    def resulting(k):
+        keep = records[:k]
+        b = front_b + foot_b + sum(len(r.encode("utf-8")) for r in keep)
+        l = front_l + foot_l + sum(r.count("\n") for r in keep)
+        return b, l
+
+    if explicit is not None:
+        k = _explicit_retain(records, spec, explicit, spec_date, result)
+        if k is None:
+            return None
+        return k
+
+    for k in range(n - 1, 0, -1):
+        b, l = resulting(k)
+        if trigger.stops(b):
+            return k
+    return 1
+
+
+def _explicit_retain(records, spec, explicit, repo, result):
+    if explicit.isdigit():
+        k = int(explicit)
+        if not (0 < k < len(records)):
+            result.add("CUT_OUT_OF_RANGE",
+                       "--cut %s must retain between 1 and %d records" % (explicit, len(records) - 1),
+                       exit_code=3)
+            return None
+        return k
+    date = explicit
+    if explicit.startswith("@"):
+        iso = git(repo, "log", "-1", "--format=%cs", explicit[1:])
+        if not iso:
+            result.add("CUT_UNKNOWN_REF", "--cut %s: no such git ref" % explicit, exit_code=3)
+            return None
+        date = iso
+    if not re.match(r"^\d{4}-\d{2}-\d{2}$", date):
+        result.add("CUT_BAD_KEY", "--cut %s is neither a count, a YYYY-MM-DD date, nor @<ref>"
+                   % explicit, exit_code=3)
+        return None
+    # Archive every record dated <= date; records are newest-on-top, so retain the prefix.
+    k = 0
+    for rec in records:
+        d = spec.date_of_record(rec)
+        if d is not None and d <= date:
+            break
+        k += 1
+    if k == 0 or k >= len(records):
+        result.add("CUT_OUT_OF_RANGE",
+                   "--cut %s selects %d retained records of %d — refusing" % (explicit, k, len(records)),
+                   exit_code=3)
+        return None
+    return k
+
+
+# =============================================================================================
+# What the trimmer writes
+# =============================================================================================
+
+def assemble_live(front, retained, footer):
+    """Rebuild the live file from its three zones.
+
+    A named step rather than an inline concatenation, so a test can replace it and prove that L2
+    is wired to the ARTIFACT: with `assert_L2` handed the before-footer as its after-footer (the
+    defect this file shipped once), a footer-dropping assembly is written with [L2_OK].
+    """
+    return front + "".join(retained) + footer
+
+
+def build_pointer_block(spec, shard_rel, verify_rel, count, span, live_rel):
+    first, last = span
+    return (
+        "**Archived %d record(s), %s → %s** into [`%s`](%s) — same format, same order, frozen.\n"
+        "Losslessness is proved by [`%s`](%s), which re-derives L1/L2/L3 from git; run it rather\n"
+        "than trusting this sentence. Written by `methodology_trim.py` v%s.\n\n"
+        % (count, first, last, shard_rel, shard_rel, verify_rel, verify_rel, TRIM_VERSION)
+    )
+
+
+def insert_pointer(front, block):
+    """Insert the pointer block immediately before the LAST standalone '---' in front matter, or
+    at the end of front matter when there is none. Deterministic and declared, so L2 can confine
+    the front-matter diff to exactly this span."""
+    lines = front.splitlines(keepends=True)
+    hr = None
+    for i, s, inside, _info in fence_scan(lines):
+        if not inside and s.strip() == "---":
+            hr = i
+    if hr is None:
+        return front + ("\n" if front and not front.endswith("\n\n") else "") + block
+    return "".join(lines[:hr]) + block + "".join(lines[hr:])
+
+
+def apply_regenerated(front, spec, ctx, result):
+    """Regenerate declared front-matter fields. Each is COMPUTED, never carried forward, because
+    every one of them has already drifted by hand (HANDOFFS.md's own count said 19 while the file
+    held 20, and the file's own blockquote admits the number is unguarded).
+
+    Returns (new_front, reversals) where reversals is [(regex, old_value, new_value)] — L2 replays
+    it backwards to prove the front-matter diff is confined to exactly these spans.
+    """
+    out = front
+    reversals = []
+    for name, rx, fn in spec.regenerated:
+        new = fn(ctx)
+        m = rx.search(out)
+        if not m:
+            result.add("FRONTMATTER_FIELD_ABSENT",
+                       "declared regenerated field %r not found in front matter — its value cannot "
+                       "be kept true. Add it, or remove it from the config." % name)
+            continue
+        old = m.group(2)
+        if old != new:
+            result.add("FRONTMATTER_FIELD_REGENERATED", "%s: %s → %s" % (name, old, new))
+        out = out[:m.start()] + m.group(1) + new + m.group(3) + out[m.end():]
+        reversals.append((rx, old, new))
+    return out, reversals
+
+
+def build_shard(spec, live_rel, shard_rel, records, span, cut_key):
+    first, last = span
+    body = "".join(transform_record(r) for r in records)
+    back = REBASE_PREFIX + live_rel
+    head = (
+        "# %s — archive: %s → %s\n"
+        "\n"
+        "Retired records from [`%s`](%s), moved here so the live ledger stays small enough to read\n"
+        "in one pass. Same format, same newest-on-top order — this is the same ledger, continued.\n"
+        "\n"
+        "Holds **%d record(s), %s → %s**. Cut key: `%s`. Counts here are computed from the file\n"
+        "itself, never carried forward. This shard is frozen: it states no forward-looking rule,\n"
+        "because the live file owns those and a copy of one was wrong a day after it was written.\n"
+        "\n"
+        "---\n"
+        "\n"
+        % (spec.basename, first, last, live_rel, back, len(records), first, last, cut_key)
+    )
+    return head + body
+
+
+LEDGER_ENTRY_TEMPLATE = (
+    "### %(date)s · [ad hoc] Ledger trim: `%(live)s` → `%(shard)s` "
+    "(%(n)d record(s), %(before)s B → %(after)s B)\n"
+    "\n"
+    "**Written by:** `methodology_trim.py` v%(ver)s — a tool action, not a session's judgment.\n"
+    "Moved the oldest **%(n)d** record(s) (%(first)s → %(last)s) out of [`%(live)s`](%(live)s) into\n"
+    "[`%(shard)s`](%(shard)s). Losslessness is asserted by L1 (records-zone concatenation), L2 (zone\n"
+    "pinning) and L3 (record partition), and is **re-derivable** — run [`%(verify)s`](%(verify)s)\n"
+    "rather than trusting a digest printed here. Live file %(before)s B → %(after)s B (%(pct)s).\n"
+    "\n"
+)
+
+
+def build_ledger_entry(live_rel, shard_rel, verify_rel, n, span, before_b, after_b, today):
+    first, last = span
+    pct = "−%.1f%%" % (100.0 * (before_b - after_b) / before_b) if before_b else "n/a"
+    return LEDGER_ENTRY_TEMPLATE % {
+        "date": today, "live": live_rel, "shard": shard_rel, "verify": verify_rel,
+        "n": n, "first": first, "last": last, "ver": TRIM_VERSION,
+        "before": "{:,}".format(before_b), "after": "{:,}".format(after_b), "pct": pct,
+    }
+
+
+def insert_ledger_entry(ledger_text, spec, entry, today, result):
+    """Prepend the entry at the top of the records zone, under a `## YYYY-MM` heading matching its
+    month — creating the heading when the month has turned.
+
+    Returns (text, month_heading_added). The heading, when added, lands in the FRONT MATTER zone
+    (it sits above the first record), so it is a declared front-matter insertion and L2 is told
+    about it rather than tripping over it.
+
+    A month boundary is reported, not silently smoothed over: the previous month's heading is left
+    above the new one, where it heads nothing. The tool never commits, so this is one line for the
+    operator to move — which is strictly better than silently re-filing the retained records of the
+    old month under the new month's heading, which is what the first draft did.
+    """
+    z = classify_zones(ledger_text, spec, result)
+    if z is None:
+        return None, ""
+    month = today[:7]
+    front = "".join(z.lines[:z.front_end])
+    rest = ledger_text[len(front):]
+    heading = ""
+    if not re.search(r"^## %s\s*$" % re.escape(month), front, re.M):
+        heading = "## %s\n\n" % month
+        entry = heading + entry
+    return front + entry + rest, heading
+
+
+# =============================================================================================
+# The re-runnable proof. A digest without its payload definition and its command is an assertion
+# wearing a hash's clothes — the last hand-published one is not reproducible from the artifacts.
+# =============================================================================================
+
+VERIFY_TEMPLATE = r"""#!/usr/bin/env bash
+# Losslessness proof for @@SHARD@@ — generated by methodology_trim.py v@@VER@@.
+#
+# Self-contained and FROZEN: it embeds the record grammar it was written against, so a later change
+# to the trimmer cannot silently change what this shard's proof means. Re-derives L1 (records-zone
+# concatenation), L2 (zone pinning) and L3 (record partition). Exits non-zero on failure.
+# Run it; do not trust a digest. The last hand-published digest for this repo is not reproducible
+# from the artifacts it describes, which is the whole reason this file exists.
+#
+# NOTE: file contents are read by python, never through $(...) — command substitution strips
+# trailing newlines, which silently truncates the LAST record and fails L1/L3 on a correct trim.
+# That is not hypothetical: it is what the first version of this script did.
+set -u
+cd "$(git rev-parse --show-toplevel)" || exit 3
+LIVE=@@LIVE@@
+SHARD=@@SHARD@@
+TRIM_SHA="$(git log --diff-filter=A -1 --format=%H -- "$SHARD" 2>/dev/null)"
+export LIVE SHARD TRIM_SHA
+python3 - <<'PYEOF_VERIFY'
+import os, re, subprocess, sys
+from collections import Counter
+
+RECORD_KIND = "@@KIND@@"
+RECORD_START = r"@@START@@"
+FENCE_INFO = "@@INFO@@"
+FOOTER_MODE = "@@FOOTER@@"
+PREFIX = "../../"
+
+# BL-27 fix 1: the same declared front-matter fields assert_L2's reversal exception already knows
+# about (design's regenerated-field table), so a line that changed ONLY inside one of these spans
+# is not "lost" — every OTHER line still must survive verbatim, unchanged from before this fix.
+REGEN_PATTERNS = @@REGEN@@
+REGEN = [re.compile(p) for p in REGEN_PATTERNS]
+
+FENCE = re.compile(r"^(`{3,}|~{3,})(.*)$")
+LINK = re.compile(r"\]\(([^)\s]*)\)")
+SCHEME = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:")
+
+
+def scan(lines):
+    marker = None
+    for i, raw in enumerate(lines):
+        s = raw.rstrip("\r\n")
+        inside = marker is not None
+        m = FENCE.match(s)
+        info = ""
+        if marker is None:
+            if m:
+                marker = (m.group(1)[0], len(m.group(1)))
+                info = m.group(2).strip()
+        else:
+            ch, n = marker
+            if m and m.group(1)[0] == ch and len(m.group(1)) >= n and m.group(2).strip() == "":
+                marker = None
+        yield i, s, inside, info
+
+
+def spans(line):
+    r = []
+    i = 0
+    n = len(line)
+    while i < n:
+        if line[i] == "`":
+            j = i
+            while j < n and line[j] == "`":
+                j += 1
+            t = j - i
+            k = j
+            while k < n:
+                if line[k] == "`":
+                    mm = k
+                    while mm < n and line[mm] == "`":
+                        mm += 1
+                    if mm - k == t:
+                        r.append((i, mm))
+                        i = mm
+                        break
+                    k = mm
+                else:
+                    k += 1
+            else:
+                break
+            continue
+        i += 1
+    return r
+
+
+def indomain(t):
+    return bool(t) and not SCHEME.match(t) and not t.startswith(("#", "/", "../"))
+
+
+def maplinks(text, fn):
+    lines = text.splitlines(keepends=True)
+    out = []
+    for i, s, inside, _info in scan(lines):
+        raw = lines[i]
+        if inside or FENCE.match(s):
+            out.append(raw)
+            continue
+        sp = spans(raw)
+
+        def repl(m):
+            if any(a <= m.start() < b for a, b in sp):
+                return m.group(0)
+            new = fn(m.group(1))
+            return m.group(0) if new is None else "](" + new + ")"
+
+        out.append(LINK.sub(repl, raw))
+    return "".join(out)
+
+
+def invert(text):
+    def back(t):
+        if not t.startswith(PREFIX):
+            return None
+        s = t[len(PREFIX):]
+        return s if indomain(s) else None
+    return maplinks(text, back)
+
+
+def zones(text):
+    lines = text.splitlines(keepends=True)
+    starts, hrs = [], []
+    for i, s, inside, info in scan(lines):
+        if inside:
+            continue
+        if RECORD_KIND == "heading" and re.match(RECORD_START, s):
+            starts.append(i)
+        elif RECORD_KIND == "fence" and info == FENCE_INFO:
+            starts.append(i)
+        if s.strip() == "---":
+            hrs.append(i)
+    if not starts:
+        return "".join(lines), [], ""
+    foot = len(lines)
+    if FOOTER_MODE == "separator":
+        for i in [h for h in hrs if h > starts[-1]]:
+            if "".join(lines[i + 1:]).strip():
+                foot = i
+                break
+    recs = []
+    for k, st in enumerate(starts):
+        en = starts[k + 1] if k + 1 < len(starts) else foot
+        recs.append("".join(lines[st:en]))
+    return "".join(lines[:starts[0]]), recs, "".join(lines[foot:])
+
+
+def show(ref, path):
+    p = subprocess.run(["git", "show", "%s:%s" % (ref, path)], stdout=subprocess.PIPE)
+    if p.returncode:
+        sys.exit("verify: cannot read %s:%s" % (ref, path))
+    return p.stdout.decode("utf-8")
+
+
+def readf(path):
+    with open(path, "r", encoding="utf-8", newline="") as fh:
+        return fh.read()
+
+
+LIVE, SHARD = os.environ["LIVE"], os.environ["SHARD"]
+TRIM = os.environ["TRIM_SHA"]
+if TRIM:
+    before, after, shard = show(TRIM + "^", LIVE), show(TRIM, LIVE), show(TRIM, SHARD)
+    origin = "the trim commit " + TRIM[:7]
+else:
+    before, after, shard = show("HEAD", LIVE), readf(LIVE), readf(SHARD)
+    origin = "HEAD vs the working tree (trim not yet committed)"
+
+bfront, br, bfoot = zones(before)
+afront, ar, afoot = zones(after)
+sfront, sr, _sfoot = zones(shard)
+sr_inv = [invert(r) for r in sr]
+fails = []
+ran = []
+
+
+def anchor(rec):
+    # The record's own first content line — its heading for a heading-kind ledger, its first
+    # key: value line for a fence-kind one. Used only to LABEL records in the report; nothing
+    # below decides pass or fail from it.
+    for ln in rec.splitlines():
+        s = ln.rstrip()
+        if s.strip() and not FENCE.match(s):
+            return s.strip()
+    return ""
+
+
+# --- What the TRIM COMMIT introduced, MEASURED rather than assumed (BL-36) -------------------
+#
+# This script re-derives from git at commit granularity, and a commit may legitimately carry more
+# than the trim: this repository's own close-out practice writes the trim's ledger entry, that
+# session's other entries, and the archive move in one commit. Those extra records are new
+# content. They were never in `before`, so they make no claim whatsoever about whether an
+# archived record survived — and they must not be able to fail a losslessness proof.
+#
+# The shipped versions of this script skipped them POSITIONALLY, via a constant `INJECTED` baked
+# in at generation time as `1 if trims_the_ledger else 0`. That is a 0/1 flag, not a count: it is
+# structurally incapable of modelling a commit that lands two records instead of one, so every
+# bundled trim failed by construction with zero data loss. Four of this repo's six shipped proofs
+# failed exactly that way while an independent identity-keyed re-derivation measured 0 records
+# missing at every trim (docs/audits/2026-08-15-bl36-archive-losslessness.md).
+#
+# So the injected set is measured HERE, from record content: the records present in
+# `after + shard` and absent from `before`. This is a different function of the same three
+# artifacts — never the difference L1/L3 are about to assert on — so it cannot make those
+# assertions vacuous: delete an archived record and it is missing from `have` no matter what else
+# the commit added. Occurrences are removed one-for-one, preserving order, so L1 still compares
+# bytes in sequence and a REORDER is still a failure.
+#
+# It deliberately does NOT excuse a record EDITED inside the trim commit. Such a record's
+# pre-trim bytes exist nowhere afterwards; it is reported as MISSING and the proof stays red,
+# which is BL-27's judgement and is still correct — a real loss has that same shape.
+# NAMES: `absent_records` / `added_records`, not the obvious `missing` / `added`. This is a flat
+# script -- every binding here is a module global -- and L2's front-matter clause below already
+# binds `missing` for its own, unrelated meaning (front-matter LINES that vanished). Calling this
+# one `missing` silently rebinds it before L3 reads it, and because L2 usually finds nothing the
+# rebind is to [], so L3 skips its own clause and reports a downstream symptom instead. That is
+# not hypothetical: it is what the first build of this fix did, and the narrowed loss control
+# caught it. Anything added here needs the same namespace check.
+have = Counter(ar) + Counter(sr_inv)
+added_records = list((have - Counter(br)).elements())
+absent_records = list((Counter(br) - have).elements())
+
+
+def drop_added(seq, remaining):
+    out = []
+    for r in seq:
+        if remaining.get(r, 0) > 0:
+            remaining[r] -= 1
+        else:
+            out.append(r)
+    return out
+
+
+still_to_drop = dict(Counter(added_records))
+ar_cmp = drop_added(ar, still_to_drop)
+sr_cmp = drop_added(sr_inv, still_to_drop)
+
+# --- L1: records-zone concatenation ---------------------------------------------------------
+ran.append("L1")
+rebuilt = ar_cmp + sr_cmp
+if "".join(rebuilt) != "".join(br):
+    fails.append("L1 records-zone concatenation is not byte-identical")
+
+# --- L2: zone pinning. BOTH halves — footer AND front matter. -------------------------------
+# The footer half is conditional (a ledger may legitimately have no footer); the front-matter
+# half is not, and its absence is why an earlier version of this script printed "L1, L2 and L3
+# hold" after running zero L2 assertions on both of this repo's real ledgers.
+if bfoot.strip():
+    ran.append("L2/footer")
+    if afoot != bfoot:
+        fails.append("L2 FOOTER is not byte-identical in the live file")
+    if bfoot.strip() in shard or bfoot.strip() in invert(shard):
+        fails.append("L2 FOOTER migrated into the shard")
+
+ran.append("L2/front-matter")
+# Front matter may GAIN declared blocks (the shard pointer, a new month heading); it may not lose
+# or reword anything. Every non-blank line of the original must survive verbatim in the new front
+# matter, and none of it may have travelled into the shard — UNLESS the only change is confined to
+# a declared regenerated field's own value (BL-27 fix 1), the same exception assert_L2 already
+# applies via its reversal loop. This is a narrower carve-out than assert_L2's, on purpose: it
+# excuses a specific LINE only when it has a same-shaped partner line in the new front matter with
+# identical bytes everywhere outside the declared span — an actual reword just outside the field's
+# own parens still fails, same as an edit anywhere else in front matter.
+def field_reversible(missing_line):
+    for rx in REGEN:
+        m = rx.search(missing_line)
+        if not m:
+            continue
+        prefix, suffix = m.group(1), m.group(3)
+        residue = missing_line[:m.start()] + missing_line[m.end():]
+        for al in afront.splitlines():
+            am = rx.search(al)
+            if (am and am.group(1) == prefix and am.group(3) == suffix
+                    and al[:am.start()] + al[am.end():] == residue):
+                return True
+    return False
+
+
+# BL-28 fix: exact-line-set membership, not substring containment. `ln not in afront` tested
+# whether `ln` occurs anywhere in the whole front-matter TEXT — an append-style edit that keeps
+# the original line as a literal prefix of a new, longer line leaves that substring intact and
+# reads as "found," so a real change to the line evaded detection. Comparing against the SET of
+# exact lines in the new front matter closes that gap without touching field_reversible's own
+# separate, correct line-by-line carve-out for the declared regenerated fields.
+afront_lines = set(afront.splitlines())
+missing = [ln for ln in bfront.splitlines()
+           if ln.strip() and ln not in afront_lines and not field_reversible(ln)]
+if missing:
+    fails.append("L2 FRONT MATTER lost %d line(s), first: %r" % (len(missing), missing[0][:70]))
+leaked = [ln for ln in bfront.splitlines()
+          if ln.strip() and len(ln.strip()) > 24 and (ln in sfront or ln in "".join(sr))]
+if leaked:
+    fails.append("L2 FRONT MATTER leaked %d line(s) into the shard, first: %r"
+                 % (len(leaked), leaked[0][:70]))
+
+# --- L3: record partition ---------------------------------------------------------------------
+ran.append("L3")
+bad = None
+if absent_records:
+    # The only way a record from `before` fails to appear in `after + shard`: it was dropped, or
+    # it was edited (in which case its pre-trim bytes are gone and an edited twin shows up in
+    # `added_records`). Both are real; neither is excused. A count mismatch cannot occur here
+    # without this firing first — len(rebuilt) is len(br) - len(absent_records) by construction —
+    # so there is no separate count clause to state, and none that could ever run.
+    fails.append("L3 %d record(s) present before the trim are MISSING from live+shard afterwards"
+                 % len(absent_records))
+else:
+    bad = [i for i, (x, y) in enumerate(zip(br, rebuilt)) if x != y]
+    if bad:
+        fails.append("L3 record(s) out of order across the move: %s" % bad)
+
+# BL-27 fix 2: a same-commit close-out bundling (this repo's own established practice — a
+# session's own frontier receipt going status: pending -> complete, committed together with the
+# archive write) makes position 0 (newest) legitimately differ between this commit's parent and
+# itself. NOT an exemption — this stays a FAIL, loud, because a real loss can have this exact
+# shape too — only a NOTE naming the known pattern, so a reader does not mistake it for an
+# unqualified loss. Narrow on purpose: any OTHER record differing (bad != [0]) gets no such note.
+#
+# BL-36 re-expressed the gate in the new vocabulary. It was `bad == [0]` — the record-ALTERED
+# shape under the old positional comparison — which is why it never fired for the busier ledger,
+# whose bundling produced a count mismatch instead and so failed with no explanation at all
+# (audit Finding #4). Additions no longer fail, so that half is gone; what remains is the edit,
+# which now presents as exactly one MISSING record that was the frontier, paired with an added
+# record carrying the same anchor. Still narrow on purpose: an edit to any other record, or one
+# whose anchor changed, gets no such note.
+notes = []
+frontier_edit = (len(absent_records) == 1 and br and absent_records[0] == br[0]
+                 and anchor(absent_records[0]) != ""
+                 and any(anchor(a) == anchor(absent_records[0]) for a in added_records))
+if fails and frontier_edit:
+    notes.append(
+        "the only missing record is the frontier one (position 0, newest), and an added record "
+        "carries the same anchor -- matches a known, accepted pattern (BL-27): this repository's "
+        "own practice bundles a session's close-out finalize edit into the same commit as an "
+        "archive write, so the frontier record can legitimately differ between this commit's "
+        "parent and itself. This does NOT confirm losslessness -- manually diff record 0 by hand "
+        "to be sure it is a receipt finalize, not real data loss.")
+
+print("source : %s" % origin)
+print("records: %d before = %d retained + %d archived; added by the trim commit: %d"
+      % (len(br), len(ar_cmp), len(sr_cmp), len(added_records)))
+for m in absent_records:
+    print("   MISSING: %s" % anchor(m)[:100])
+for a in added_records:
+    print("   added  : %s" % anchor(a)[:100])
+print("checked: %s" % ", ".join(ran))
+for f in fails:
+    print("FAIL:", f)
+for n in notes:
+    print("NOTE:", n)
+if fails:
+    sys.exit(1)
+# State what actually ran, never a blanket claim: on a ledger with no footer the footer clause is
+# genuinely inapplicable, and saying "L2 holds" would be asserting something nothing tested.
+print("OK: %s hold for %s" % (", ".join(ran), SHARD))
+PYEOF_VERIFY
+"""
+
+
+def build_verify(spec, live_rel, shard_rel):
+    # REGEN travels as a repr()'d list of plain (non-raw) pattern strings, not a wrapped r-string
+    # like @@START@@ — spec.regenerated is 0-or-more patterns, and an r-string wrapper only ever
+    # holds one. repr() doubles each backslash; the generated script parses that back as a normal
+    # (non-raw) Python string literal, which un-doubles it — the round trip restores the exact
+    # pattern .compile() would see. Safe only because no config pattern contains a quote character
+    # (true of both entries in LEDGERS today); a pattern that did would need a different encoding.
+    regen_patterns = repr([rx.pattern for _name, rx, _fn in spec.regenerated])
+    out = VERIFY_TEMPLATE
+    for key, val in (("@@SHARD@@", shard_rel), ("@@LIVE@@", live_rel), ("@@VER@@", TRIM_VERSION),
+                     ("@@KIND@@", spec.record_kind),
+                     ("@@START@@", spec.record_start.pattern if spec.record_start else ""),
+                     ("@@INFO@@", spec.fence_info or ""), ("@@FOOTER@@", spec.footer_mode),
+                     ("@@REGEN@@", regen_patterns)):
+        out = out.replace(key, val)
+    return out
+
+
+# =============================================================================================
+# Atomic writes. A crash must never leave a record in neither file.
+# =============================================================================================
+
+def read_text(path):
+    """Read verbatim: newline='' keeps CRLF intact, so byte-equality assertions mean what they say.
+
+    Not Path.read_text(newline=...) — that keyword is Python 3.13+, and this file is stdlib-only
+    and cross-platform by contract.
+    """
+    with open(str(path), "r", encoding="utf-8", newline="") as fh:
+        return fh.read()
+
+
+def atomic_write(path, text, executable=False):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".mtrim-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="") as fh:
+            fh.write(text)
+            fh.flush()
+            os.fsync(fh.fileno())
+        if executable:
+            os.chmod(tmp, 0o755)
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# =============================================================================================
+# P1 / P1a — the frontier-poisoning countermeasures.
+#
+# Phase 0 reconcile computes frontier = git log -1 -- CHANGELOG.md and treats frontier..HEAD as
+# the undocumented set. A trim commit rewrites CHANGELOG.md, so it advances that frontier past any
+# commit that was never recorded — permanently hiding it. Reproduced end to end (design §8.1).
+# =============================================================================================
+
+def check_P1(repo, ledger_rel, result):
+    frontier = git(repo, "log", "-1", "--format=%H", "--", ledger_rel)
+    if not frontier:
+        result.add("P1_NO_LEDGER",
+                   "no commit has ever recorded %s — self-provision and reconcile before trimming"
+                   % ledger_rel, exit_code=2)
+        return False
+    count = git(repo, "rev-list", "--count", "--no-merges", "%s..HEAD" % frontier)
+    n = int(count) if count and count.isdigit() else 0
+    if n:
+        listing = git(repo, "log", "--no-merges", "--oneline", "%s..HEAD" % frontier) or ""
+        result.add(
+            "P1_UNDOCUMENTED",
+            "the undocumented set is non-empty (%d commit(s) since the ledger frontier %s). A trim "
+            "commit advances that frontier and would hide them PERMANENTLY. Reconcile first, then "
+            "trim.\n%s" % (n, frontier[:7], _indent(listing)),
+            exit_code=2,
+        )
+        return False
+    return True
+
+
+def check_P1a(ledger_path, spec_for_ledger, expected_after_partition, result):
+    """Post-condition: the ledger gained exactly one record, and that record is this trim.
+
+    P1 runs BEFORE the trim commit exists, so it constrains only the commits before it. The FM #27
+    hook does not close the remainder: it passes on mere CO-STAGING of the ledger and never checks
+    that an entry was ADDED — and a ledger trim co-stages it by construction.
+
+    `expected_after_partition` is the count the ledger would hold if this run wrote NO entry — which
+    is len(retained) when the trimmed file IS the ledger, and the ledger's own pre-run count when it
+    is not. Getting that wrong is not academic: the first draft of this function compared against the
+    ledger's pre-trim count in both cases, and this assertion caught it on the first real write.
+    """
+    text = read_text(ledger_path)
+    z = classify_zones(text, spec_for_ledger, Result(ledger_path))
+    after = len(z.starts) if z else -1
+    want = expected_after_partition + 1
+    if after != want:
+        result.add(
+            "P1A_LEDGER_ENTRY",
+            "post-condition failed: the ledger holds %d record(s), expected %d (one more than the "
+            "%d it would hold after the partition alone). Without that entry the trim's very first "
+            "act would be to hide itself." % (after, want, expected_after_partition),
+            exit_code=2,
+        )
+        return False
+    result.add("P1A_OK", "ledger gained exactly one entry (%d → %d)"
+               % (expected_after_partition, after))
+    return True
+
+
+# =============================================================================================
+# Zero records — "I found nothing" and "I could not read this" are different answers.
+#
+# This branch used to give one answer to both, at exit 0, in the words reserved for a fresh seed:
+# a 597,717 B ledger holding 130 dated entries and a 1,239,085 B one keying its entries on table
+# rows under 8 `## YYYY-MM` group headings were both
+# told they held "zero records ... nothing to archive. (A freshly seeded ledger looks exactly like
+# this ...)" — byte-identical to what a genuine 324 B seed is told, and with the same exit status,
+# so a wrapper reading the code was told everything was fine. Neither file uses the declared
+# `### YYYY-MM-DD · [tag]` heading; one uses an em dash, the other keys entries on table rows.
+# That is UAT finding F1, and the failure shape is the worst available for a tool whose entire
+# justification is that manual trimming does not happen.
+#
+# Design §6.3's exit table already said `3 | usage error: ... no records`, and this branch shipped
+# with no exit code at all. Restoring 3 for the unreadable half is a return to the ratified table.
+# KEEPING 0 FOR THE GENUINELY-EMPTY HALF IS ADDED POLICY, labelled here as such: a day-one adopter
+# running --check from a hook must not be handed a usage error for a correctly-seeded file, and the
+# design's own edge-case list ("zero archivable records → 0 with a stated reason") shows the family
+# it belongs to. ZONE_UNCLASSIFIED is the model the refusal copies — refuse, name the evidence,
+# print the offending span, and do not guess.
+# =============================================================================================
+
+def classify_empty(path, text, spec, result):
+    """Decide whether a zero-record file is a fresh seed or a grammar we cannot read."""
+    lines = text.splitlines()
+    size_bytes = len(text.encode("utf-8"))       # same source and unit as Trigger.size_bytes
+    line_count = text.count("\n")                # same unit as evaluate_trigger's line_count
+    hits, negations = [], 0
+    for i, s, inside, _info in fence_scan(lines):
+        if inside:
+            continue                             # a fenced example is documentation, not a record
+        if spec.content_probe is not None and spec.content_probe.search(s):
+            hits.append((i + 1, s))
+        if spec.seed_negation is not None and spec.seed_negation.match(s):
+            negations += 1
+
+    # `negations` is EVIDENCE, not bookkeeping. The seed's negation test is the seed's own answer to
+    # "has anything been recorded below?", so a file that answers yes and still parses to zero
+    # records is a mismatch by definition. The first draft computed that answer and discarded it,
+    # which left a receipt ledger of bare `session:` blocks — nothing for the probe to see —
+    # reporting NO_RECORDS at exit 0: F1 intact in the file this branch had just been widened to
+    # cover.
+    evidence = bool(hits) or negations > 0
+
+    # THERE IS DELIBERATELY NO SEED-SENTINEL EXEMPTION HERE, and it was tried.
+    # An earlier draft let a ledger still carrying METHODOLOGY-SEED-SENTINEL suppress the probe, on
+    # the theory that a seed documenting example dates should not be accused of being broken. It
+    # left one shape of F1 uncovered — NOT a regression, and the difference matters to whoever reads
+    # this next. A 6,150 B ledger with 120 real table-row entries and the sentinel left in place
+    # answered `[NO_RECORDS]` at exit 0, because table rows do not match the `^###` negation, so the
+    # seal held while 121 probe hits were thrown away. That case behaved identically BEFORE any of
+    # this existed; it was never correct, so nothing was re-broken. The defect was a guard whose
+    # negation test was narrower than the evidence it suppressed — which is a question about which
+    # record shapes were enumerated, not about what changed. A seal you can hold open by choosing a
+    # record shape is worse than no seal, because F1's lesson is that silence costs the most.
+    # The seeds are protected by the probe being ANCHORED instead: both ship with zero hits, which
+    # `TestGrammarMismatchFixtureControls` pins, so a seed edit that would flag every adopter fails
+    # in OUR suite rather than at their root. That is the right place to catch it. The accepted cost
+    # is stated rather than hidden: an adopter who adds a dated `##` heading or a dated table row to
+    # their own front matter, while holding no records, gets a loud false refusal. Loud and wrong is
+    # recoverable; quiet and wrong is what this whole finding is about.
+    if not (size_bytes > SEED_PLAUSIBLE_MAX_BYTES or line_count > SEED_PLAUSIBLE_MAX_LINES
+            or evidence):
+        result.add("NO_RECORDS",
+                   "%s holds zero records under its declared grammar — nothing to archive. (A "
+                   "freshly seeded ledger looks exactly like this, and must not be trimmed.)"
+                   % path.name)
+        return result
+
+    where = ""
+    if hits:
+        n, first = hits[0]
+        where = ("\n  First line that looks like a record but is not one, at line %d:\n%s"
+                 % (n, _indent(first[:200])))
+    result.add(
+        "GRAMMAR_MISMATCH",
+        "%s holds %s B on %s line(s) and NOT ONE record the declared grammar can read. This is a "
+        "file this tool cannot parse, not a file with nothing in it — %s. Refusing rather than "
+        "reporting an absence.\n  Declared record start (%s): %s\n  Lines matching the looser "
+        "content probe: %d%s%s\n  Fix the config entry for this file, or bring the ledger to the "
+        "declared grammar. Do not trim until one of those is true."
+        % (spec.basename, "{:,}".format(size_bytes), "{:,}".format(line_count),
+           "records are visibly present in another shape" if hits else
+           ("the ledger's own freshness test says content has been recorded below"
+            if negations else "a freshly seeded ledger is small, and this is not"),
+           spec.record_kind,
+           spec.record_start.pattern if spec.record_start else "```%s" % spec.fence_info,
+           len(hits),
+           ("" if spec.seed_negation is None else
+            " (and %d line(s) matching this ledger's own freshness test)" % negations),
+           where),
+        exit_code=3,
+    )
+    return result
+
+
+# =============================================================================================
+# Driver
+# =============================================================================================
+
+def evaluate(path, opts, result):
+    spec = LEDGERS.get(path.name)
+    if spec is None:
+        result.add("NO_CONFIG",
+                   "%s has no entry in the config table. There is deliberately no generic fallback: "
+                   "a generic rule is what would mis-zone a differently-shaped ledger." % path.name,
+                   exit_code=3)
+        return result
+    if not path.is_file():
+        result.add("FILE_ABSENT", "%s does not exist" % path, exit_code=3)
+        return result
+    path = path.resolve()          # relative_to(repo) below needs both sides absolute
+    repo = repo_root(path)
+    if repo is None:
+        result.add("NOT_A_REPO", "%s is not inside a git work tree" % path, exit_code=3)
+        return result
+
+    text = read_text(path)
+    zones = classify_zones(text, spec, result)
+    if zones is None:
+        return result
+    if not zones.starts:
+        classify_empty(path, text, spec, result)
+        return result
+
+    # Validate --cut before anything else consumes it: the key is interpolated straight into the
+    # shard PATH, and `--cut @refs/tags/v1.0` is an ordinary git ref that would otherwise write
+    # docs/archive/CHANGELOG-through-refs/tags/v1.0.md — nested, and therefore invisible to the
+    # single-level glob that both the rate trigger and this tool use to find their own baseline.
+    if opts.cut and not opts.cut.isdigit() and not _safe_cut_key(opts.cut.lstrip("@")):
+        result.add("CUT_KEY_UNSAFE",
+                   "cut key %r would not produce a flat, single-level shard name. §4.5(b) makes "
+                   "the flat docs/archive/<BASENAME>-through-<CUTKEY>.md shape mandatory precisely "
+                   "because a nested or differently-cased name is silently excluded from the glob, "
+                   "and the trigger then computes against the wrong baseline."
+                   % opts.cut.lstrip("@"), exit_code=3)
+        return result
+
+    budget = opts.budget_bytes or spec.budget_bytes
+    trigger = evaluate_trigger(repo, path, spec, zones, budget, result)
+    result.trigger = trigger
+
+    # PHASE C2: this row now reports the threshold ACTUALLY IN FORCE for this file, and names which
+    # arm it is. Reporting READ_CAP_BYTES unconditionally, as it did before, would have printed a
+    # number the trigger no longer keys on for a root Class A ledger -- a row that is arithmetic
+    # about a threshold nothing uses. The one-read cap is still stated for Class A, because "one
+    # Read does not deliver this whole file" stays TRUE and is the reason a reader might still want
+    # an explicit offset/limit; it is simply no longer the fault condition.
+    if trigger.class_a:
+        read_row = ("%s B against a %s B Class A archive threshold (this file is a ROOT ledger the "
+                    "trimmer can act on, so the arm is denominated against the %s B hard refusal, "
+                    "not against the one-read cap). FOR REFERENCE AND NOT AS A FAULT: it is also "
+                    "past the %s B one-read cap, so a whole-file read comes back truncated — but "
+                    "delivery is an ordered prefix and this ledger is newest-on-top, so what "
+                    "truncates is the OLDEST records" %
+                    ("{:,}".format(trigger.size_bytes), "{:,}".format(CLASS_A_FIRE_BYTES),
+                     "{:,}".format(READ_REFUSE_BYTES), "{:,}".format(READ_CAP_BYTES))
+                    if trigger.size_bytes > READ_CAP_BYTES else
+                    "%s B against a %s B Class A archive threshold (ROOT ledger; the arm is "
+                    "denominated against the %s B hard refusal, not the %s B one-read cap)" %
+                    ("{:,}".format(trigger.size_bytes), "{:,}".format(CLASS_A_FIRE_BYTES),
+                     "{:,}".format(READ_REFUSE_BYTES), "{:,}".format(READ_CAP_BYTES)))
+    else:
+        read_row = ("%s B against a %s B one-read cap (%s tokens x %s B/token, the measured floor)"
+                    % ("{:,}".format(trigger.size_bytes), "{:,}".format(READ_CAP_BYTES),
+                       "{:,}".format(READ_CAP_TOKENS), MIN_BYTES_PER_TOKEN))
+    result.add("TRIGGER_READ",
+               read_row +
+               ("" if trigger.size_bytes <= READ_REFUSE_BYTES else
+                " — AND PAST THE %s B HARD REFUSAL: a default Read of this file returns NO CONTENT "
+                "AT ALL, front matter included" % "{:,}".format(READ_REFUSE_BYTES)))
+    result.add("TRIGGER_BYTES", "%s B against a %s B budget" %
+               ("{:,}".format(trigger.size_bytes), "{:,}".format(budget)))
+    if trigger.srf_abstains:
+        result.add("SRF_UNDEFINED", trigger.srf_abstains)
+    else:
+        v, sha = trigger.srf
+        lv, lsha = trigger.srf_largest
+        if sha == lsha:
+            note = ("both boundaries resolve to the same archive, so there is nothing to choose "
+                    "between here")
+        elif v <= 0 or lv <= 0:
+            # A non-positive SRF means the file is now no larger than it was right after that
+            # archive — real information, but a ratio between the two is not meaningful.
+            note = ("at least one boundary gives a non-positive SRF (the file has not grown back "
+                    "past it at all), so the two are not usefully compared as a ratio")
+        else:
+            note = ("the two boundaries differ by %.2fx on the same file; the refusal below uses "
+                    "the MOST RECENT one, which is a policy addition on top of H3 (H3 says \"the "
+                    "largest single size drop\") and is labelled as an addition, not dressed as a "
+                    "reading" % (v / lv))
+        result.add("SRF", "SRF %.4f vs the most recent archive %s; %.4f vs H3's largest-drop "
+                          "boundary %s — %s" % (v, sha[:7], lv, lsha[:7], note))
+
+    if opts.check:
+        result.exit = 1 if trigger.fires else 0
+        result.add("CHECK", "trigger %s" % ("FIRES" if trigger.fires else "does not fire"))
+        return result
+
+    if not trigger.fires and opts.cut is None:
+        result.add("NOTHING_TO_DO", "under budget and above the line floor — nothing to do")
+        return result
+
+    if not check_P1(repo, ledger_rel_for(repo), result):
+        return result
+
+    if trigger.srf and trigger.srf[0] is not None and trigger.srf[0] >= SRF_RED and not opts.force:
+        result.add(
+            "SRF_RED",
+            "SRF %.4f (RED) against %s. The last archive has been entirely given back; archiving "
+            "again resets the LEVEL and not the RATE — see plan §3.3, whose action rule for RED is "
+            "\"do not archive again\". Re-run with --force to archive anyway."
+            % (trigger.srf[0], trigger.srf[1][:7]),
+            exit_code=2,
+        )
+        return result
+
+    records = zones.records()
+    k = choose_cut(zones, spec, trigger, opts.cut, repo, result)
+    if k is None:
+        return result
+    if k <= 0:
+        result.add("WOULD_EMPTY",
+                   "trimming to satisfy the trigger would leave zero records, which makes the "
+                   "receipt checker hard-fail. Floor is one record.", exit_code=2)
+        return result
+
+    retained, archived = records[:k], records[k:]
+    if not archived:
+        result.add("NOTHING_TO_DO", "the computed cut archives zero records")
+        return result
+
+    if not check_invertible(archived, result):
+        return result
+
+    dates = [spec.date_of_record(r) for r in archived]
+    dates = [d for d in dates if d]
+    span = (min(dates), max(dates)) if dates else ("unknown", "unknown")
+    cut_key = opts.cut if (opts.cut and not opts.cut.isdigit()) else span[1]
+    cut_key = cut_key.lstrip("@")
+
+    # The cut key is interpolated straight into the shard PATH, so it must not be able to carry a
+    # separator. `--cut @refs/tags/v1.0` is an ordinary git ref and would otherwise write
+    # docs/archive/CHANGELOG-through-refs/tags/v1.0.md — nested, and therefore invisible to the
+    # single-level glob that both the rate trigger and this tool use to find their own baseline.
+    if not _safe_cut_key(cut_key):
+        result.add("CUT_KEY_UNSAFE",
+                   "cut key %r would not produce a flat, single-level shard name. §4.5(b) makes the "
+                   "flat docs/archive/<BASENAME>-through-<CUTKEY>.md shape mandatory precisely "
+                   "because a nested or differently-cased name is silently excluded from the glob, "
+                   "and the trigger then computes against the wrong baseline." % cut_key,
+                   exit_code=3)
+        return result
+
+    # Cuts are POSITIONAL, so a calendar day can straddle one — 2026-07-30 already appears in both
+    # the live file and the existing archive. Say so, because "-through-<date>" reads as a boundary
+    # claim and in that case it is only a span label.
+    retained_dates = {spec.date_of_record(r) for r in retained} - {None}
+    if cut_key in retained_dates:
+        result.add(
+            "CUT_STRADDLES_DAY",
+            "the cut key %s also appears among the RETAINED records, so the shard name is a span "
+            "label and not a day boundary. The cut is positional by design (§2.3); pass "
+            "--cut <earlier date> if you want a clean calendar seam." % cut_key)
+
+    stem = spec.basename[:-3]
+    base_rel = "%s/%s-through-%s.md" % (ARCHIVE_DIR, stem, cut_key)
+
+    # Write-once, and it stays write-once: overwriting would destroy the earlier shard's records
+    # while L1/L2/L3 all still pass — they quantify only over THIS run's triple, so it is the one
+    # corruption the three assertions cannot see.
+    #
+    # But REFUSING was the wrong way to enforce it (BL-41). The name is a function of a RECORD
+    # DATE while the cut is POSITIONAL, so it is not injective: when two records share a date,
+    # distinct cuts derive one name. The old advice — "Disambiguate with --cut" — had no solution,
+    # because a date cut key both SELECTS the records and BECOMES the key; there is no second knob
+    # to turn. On this repo's own receipt ledger every admissible cut derived the same taken name,
+    # and the file sat 14,317 B over its ceiling with no reachable remedy.
+    #
+    # So a taken name is resolved, not refused. Nothing is overwritten — the loop only ever moves
+    # to a name that does not exist — and the rename is REPORTED, because a shard whose name no
+    # longer uniquely says "through this date" must not arrive silently.
+    shard_rel, suffix = base_rel, 1
+    while shard_name_taken(repo / shard_rel):
+        suffix += 1
+        if suffix > SHARD_SUFFIX_MAX:
+            result.add("SHARD_EXISTS",
+                       "%s and every disambiguation up to -%d are taken. Refusing to overwrite: a "
+                       "collision destroys the earlier shard's records while all three assertions "
+                       "still pass, because none of them quantifies over any other file in %s. "
+                       "Archive by hand, or clear the stale names."
+                       % (base_rel, SHARD_SUFFIX_MAX, ARCHIVE_DIR), exit_code=2)
+            return result
+        shard_rel = "%s/%s-through-%s-%d.md" % (ARCHIVE_DIR, stem, cut_key, suffix)
+
+    if shard_rel != base_rel:
+        result.add("SHARD_NAME_DISAMBIGUATED",
+                   "%s was taken, so this shard is %s. The date in a shard name is a SPAN LABEL, "
+                   "not a unique key — cuts are positional (§2.3) and two records can share a "
+                   "date, so more than one shard may legitimately end on the same day. The "
+                   "earlier shard is untouched."
+                   % (base_rel, shard_rel))
+
+    shard_path = repo / shard_rel
+    verify_rel = shard_rel + ".verify.sh"
+
+    live_rel = path.relative_to(repo).as_posix()
+    plan = TrimPlan()
+    plan.retained, plan.archived = retained, archived
+    plan.shard_rel, plan.verify_rel, plan.cut_key, plan.span = shard_rel, verify_rel, cut_key, span
+    plan.shard_text = build_shard(spec, live_rel, shard_rel, archived, span, cut_key)
+    plan.pointer_block = build_pointer_block(spec, shard_rel, verify_rel, len(archived), span, live_rel)
+
+    front, reversals = apply_regenerated(zones.front, spec, {"retained": len(retained)}, result)
+    front = insert_pointer(front, plan.pointer_block)
+    live_after_core = assemble_live(front, retained, zones.footer)
+
+    plan.before_bytes = len(text.encode("utf-8"))
+    today = opts.today or datetime.date.today().isoformat()
+    ledger_rel = ledger_rel_for(repo)
+    trims_the_ledger = (live_rel == ledger_rel)
+
+    # The reported "after" size must be the size of the file actually written — and when the trimmed
+    # file IS the ledger, the entry stating that size is itself part of it. Iterate to a fixed point
+    # rather than publish a figure that is short by the length of its own entry: the number is baked
+    # into a frozen dated record, and a hand-typed size in this repo has now been wrong three times.
+    plan.after_bytes = len(live_after_core.encode("utf-8"))
+    month_heading = ""
+    for _ in range(5):
+        entry = build_ledger_entry(live_rel, shard_rel, verify_rel, len(archived), span,
+                                   plan.before_bytes, plan.after_bytes, today)
+        if trims_the_ledger:
+            candidate, month_heading = insert_ledger_entry(live_after_core, spec, entry,
+                                                           today, Result(path))
+        else:
+            candidate, month_heading = live_after_core, ""
+        size = len(candidate.encode("utf-8"))
+        if size == plan.after_bytes:
+            break
+        plan.after_bytes = size
+    else:
+        result.add("SIZE_UNCONVERGED",
+                   "the reported live size did not reach a fixed point; refusing to publish a figure "
+                   "that is not the size of the file written.", exit_code=2)
+        return result
+    plan.ledger_entry = entry
+    plan.live_after = candidate
+    if month_heading:
+        prior = re.findall(r"(?m)^## (\d{4}-\d{2})\s*$", live_after_core[:len(front)])
+        if prior:
+            result.add("LEDGER_MONTH_BOUNDARY",
+                       "this entry opens a new month section (%s) while the ledger's front matter "
+                       "still ends with ## %s, which now heads nothing. Move that one line below "
+                       "the new entry before committing — the tool will not reorder a heading it "
+                       "cannot prove is safe to move, and it never commits."
+                       % (month_heading.strip(), prior[-1]))
+    plan.verify_text = build_verify(spec, live_rel, shard_rel)
+    result.plan = plan
+
+    # --- THE ASSERTIONS RUN ON THE ARTIFACTS, NOT ON THE INPUT PARTITION ------------------------
+    #
+    # This is the whole point, and the first build of this tool got it exactly wrong. It asserted
+    # over `records`, `records[:k]` and `records[k:]` — but `records[:k] ++ records[k:] == records`
+    # is an IDENTITY, so L1 and L3 could never fire, and L2 was handed the BEFORE footer as its
+    # "after" argument, so its clause compared a value with itself. All three were comments shaped
+    # like guards: a write path that silently dropped a record printed [L1_OK] [L2_OK] [L3_OK]
+    # [WROTE] while the independent verify.sh caught it. Design §6.4 says it plainly — "verify
+    # L1/L2/L3 on the in-memory RESULT; only then write" — and the result is these two strings.
+    #
+    # So: re-parse what is about to be written, with the same grammar, and assert over that.
+    shard_zones = classify_zones(plan.shard_text, spec, Result(path))
+    live_zones = classify_zones(plan.live_after, spec, Result(path))
+    if shard_zones is None or live_zones is None:
+        result.add("ARTIFACT_UNPARSEABLE",
+                   "the text this run would write does not parse under its own declared grammar — "
+                   "refusing to write something the proof could not read back.", exit_code=2)
+        return result
+    # BL-36 replaced the EXPORTED proof's identically-shaped constant with a measured set, and
+    # deliberately left this one alone. The two look alike and are not the same claim. Here the
+    # operand is `plan.live_after` — text this function just built — so the count is not an
+    # estimate of what some commit will contain: this run injects exactly one ledger entry when
+    # it trims the ledger and none otherwise, and it knows which. The exported script has no such
+    # knowledge, because it re-derives from a commit that may carry a whole session's other
+    # writes. Do not "make this consistent" with the template; consistency here would replace a
+    # fact with an inference.
+    injected = 1 if trims_the_ledger else 0
+    after_records = live_zones.records()[injected:]
+    shard_records = shard_zones.records()
+    shard_source = [invert_record(r) for r in shard_records]
+
+    ok = assert_L1(records, after_records, shard_records, result)
+    ok = assert_L2(zones, live_zones.front, live_zones.footer, plan.shard_text,
+                   [plan.pointer_block, month_heading], reversals, result) and ok
+    ok = assert_L3(records, after_records, shard_source, result) and ok
+    if not ok:
+        return result
+    result.add("L1_OK", "records-zone concatenation is byte-identical (asserted on the artifacts)")
+    result.add("L2_OK", "zones pinned; front-matter diff confined to declared changes")
+    result.add("L3_OK", "%d record(s) partitioned; every one byte-identical across the move"
+               % len(records))
+
+    if not opts.write:
+        result.add("DRY_RUN",
+                   "would archive %d of %d record(s) (%s → %s) to %s; live %s B → %s B. Nothing "
+                   "written — pass --write."
+                   % (len(archived), len(records), span[0], span[1], shard_rel,
+                      "{:,}".format(plan.before_bytes), "{:,}".format(plan.after_bytes)))
+        return result
+
+    # --- the write: shard first, then live. At no point is a record in neither file. ------------
+    ledger_path = repo / ledger_rel
+    ledger_spec = LEDGERS.get(Path(ledger_rel).name)
+    lz = classify_zones(read_text(ledger_path), ledger_spec, Result(ledger_path))
+    # What the ledger would hold if this run wrote NO entry — the partition's own outcome.
+    expected_after_partition = len(retained) if trims_the_ledger else (len(lz.starts) if lz else 0)
+
+    atomic_write(shard_path, plan.shard_text)
+    result.written.append(shard_rel)
+    atomic_write(repo / verify_rel, plan.verify_text, executable=True)
+    result.written.append(verify_rel)
+    atomic_write(path, plan.live_after)
+    result.written.append(live_rel)
+    if not trims_the_ledger:
+        lt, _lh = insert_ledger_entry(read_text(ledger_path),
+                                      ledger_spec, plan.ledger_entry, today, result)
+        atomic_write(ledger_path, lt)
+        result.written.append(ledger_rel)
+
+    check_P1a(ledger_path, ledger_spec, expected_after_partition, result)
+    result.add("WROTE", "archived %d record(s) to %s; live %s B → %s B"
+               % (len(archived), shard_rel, "{:,}".format(plan.before_bytes),
+                  "{:,}".format(plan.after_bytes)))
+    return result
+
+
+def ledger_rel_for(repo):
+    return "CHANGELOG.md"
+
+
+def report(result, opts):
+    print("== %s ==" % result.path)
+    for f in result.findings:
+        print("  [%s] %s" % (f.code, f.message))
+    if result.written:
+        print("\n  WRITTEN (uncommitted — this tool never commits):")
+        for w in result.written:
+            print("    %s" % w)
+        live = [w for w in result.written if not w.startswith(ARCHIVE_DIR)]
+        shards = [w for w in result.written if w.startswith(ARCHIVE_DIR)]
+        print("\n  Rollback:  git checkout -- %s && rm -f %s"
+              % (" ".join(live), " ".join(shards)))
+        print("  Verify:    bash %s" % (result.plan.verify_rel if result.plan else ""))
+        print("  Then commit yourself — one ledger, one shard, one entry, one commit, one revert.")
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(
+        prog="methodology_trim.py",
+        description="Trim a grow-and-must-be-read ledger into a frozen shard, provably losslessly.")
+    p.add_argument("--file", action="append", default=[], metavar="PATH",
+                   help="the ledger to trim (repeatable). Required.")
+    p.add_argument("--write", action="store_true",
+                   help="actually write. Absent -> dry run, which is the default.")
+    p.add_argument("--cut", metavar="N|YYYY-MM-DD|@REF", help="override the computed cut point")
+    p.add_argument("--budget-bytes", type=int, default=None, help="override the byte budget")
+    p.add_argument("--force", action="store_true", help="proceed despite the SRF-RED refusal")
+    p.add_argument("--check", action="store_true",
+                   help="evaluate the trigger and report; never writes, even with --write")
+    p.add_argument("--today", help=argparse.SUPPRESS)   # test seam: deterministic dates
+    p.add_argument("--version", action="version", version="methodology_trim.py v" + TRIM_VERSION)
+    opts = p.parse_args(argv)
+
+    if not opts.file:
+        p.print_usage(sys.stderr)
+        print("methodology_trim.py: --file is required", file=sys.stderr)
+        return 3
+    if opts.write and not opts.check and len(opts.file) > 1:
+        print("methodology_trim.py: one --file per --write. A batched trim has a rollback that "
+              "cannot be expressed as one revert, and the 5-file per-commit cap applies regardless.",
+              file=sys.stderr)
+        return 3
+
+    worst = 0
+    for f in opts.file:
+        result = Result(Path(f))
+        evaluate(Path(f), opts, result)
+        report(result, opts)
+        worst = max(worst, result.exit)
+    return worst
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/methodology_dashboard.py
+++ b/tools/methodology_dashboard.py
@@ -357,7 +357,8 @@ _VERSION_RE = re.compile(r'''^DASHBOARD_VERSION\s*=\s*["']([^"']+)["']''', re.MU
 # added two more non-markdown dests to bin/_manifest.py without this tuple being extended to
 # match — exactly the silent drift the paragraph above warns about, caught by the
 # machine-checkable cross-reference test below, not by inspection.
-FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py", "context_budget.py", ".context-budget.json")
+FRAMEWORK_INSTALLED_SOURCE = ("methodology_dashboard.py", "methodology_trim.py",
+                              "context_budget.py", ".context-budget.json")
 
 # The markdown half of the same problem, and the mirror of the defect above. `bin/sync` also
 # installs 22 markdown files, which on its own satisfies detect_doc_only's corpus
@@ -476,6 +477,20 @@ _FRAMEWORK_FILE_SIGNATURES = {
             "def score_health",
             "def assess_risks",
             "https://github.com/KJ5HST/methodology",
+        ),
+        "min_hits": 2,
+    },
+    "methodology_trim.py": {
+        # Its own constant is TRIM_VERSION, not VERSION or DASHBOARD_VERSION, so it needs its own
+        # pattern rather than the scanner's: a shared _VERSION_RE would never match and the file
+        # would fall through to the signature path on every scan, which is the silent-skip defect
+        # the comment above this table describes.
+        "version_re": re.compile(r'''^TRIM_VERSION\s*=\s*["']([^"']+)["']''', re.MULTILINE),
+        "signatures": (
+            "LEDGERS",
+            "def classify_zones",
+            "def apply_regenerated",
+            "def build_pointer_block",
         ),
         "min_hits": 2,
     },

--- a/tools/test_methodology_dashboard.py
+++ b/tools/test_methodology_dashboard.py
@@ -401,6 +401,14 @@ CHECKLIST_EXEMPT = {
     "CLAUDE_TEMPLATE.md": "template; the operating artifact is the adopter's CLAUDE.md instance",
     "BOOTSTRAP.md": "one-time setup guide, not a per-session operating artifact",
     "methodology_dashboard.py": "the scanner itself — scoring its own presence is circular",
+    "methodology_trim.py": "the ledger trimmer (S39'): sync installs it automatically alongside "
+                           "the scanner, so like FRAMEWORK_LEARNINGS.md its presence measures "
+                           "sync, not adoption — an adopter cannot fail to have it and cannot "
+                           "demonstrate anything by having it. Scoring it would also re-cut "
+                           "METHODOLOGY_MAX and move every already-compliant adopter's percentage "
+                           "for a change they did not make. Whether an adopter USES it is a "
+                           "different question, and the dashboard already answers it in the "
+                           "trim-trigger row rather than in the compliance checklist",
     "context_budget.py": "an elective size-governance gate, same class as the scanner above — "
                          "its presence indicates a pre-commit hook was installed, not that the "
                          "session-operating discipline this checklist measures was followed",

--- a/tools/test_methodology_trim.py
+++ b/tools/test_methodology_trim.py
@@ -1,0 +1,2259 @@
+#!/usr/bin/env python3
+"""Functional tests for starter-kit/methodology_trim.py — the ledger trimmer.
+
+CANONICAL-ONLY. Not in bin/_manifest.py, so adopters do not receive it.
+
+DISCIPLINE THIS FILE IS WRITTEN UNDER (design §11 Phase 1, and this repo's own learnings):
+
+  * PROVE THE FIXTURE FIRST. A test green for a year can assert nothing about its stated case if
+    its fixture was never that artifact. Every fixture here has an unmutated control that asserts
+    what the fixture IS before anything is asserted about what the code does to it.
+  * DRIVE EACH GUARD RED AND WATCH IT FAIL. Green is not evidence until red has been observed.
+  * NARROW THE GUARD, DO NOT ONLY DELETE IT. Deleting a guard proves only that it runs. Each
+    assertion below also has a NARROWED variant — the plausible weaker implementation — shown to
+    PASS the case the full-strength guard catches. That is what makes the strong clause load-bearing.
+  * ASSERT ON NAMED FINDINGS, NEVER ON THE EXIT CODE. The exit code is a union over every check
+    the tool runs, so adding a check silently re-labels unrelated assertions (design §6.3).
+
+TWO FIXTURES ARE REAL HISTORY, NOT INVENTED — both events happened in this repository:
+  L2  `020ba3f^:CHANGELOG.md` — the last tree in which the root ledger still had its pre-v3.0
+      scope footer. The commit that archived from it lost that footer, and it is still missing.
+  L3  `7a71df0` — the archive that moved 19 receipts AND rewrote the RETAINED S22 receipt in the
+      same commit, making "the move was verbatim" unfalsifiable.
+"""
+
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.dont_write_bytecode = True          # no starter-kit/__pycache__ from this import
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+TRIM_PY = REPO / "starter-kit" / "methodology_trim.py"
+
+_spec = importlib.util.spec_from_file_location("methodology_trim", str(TRIM_PY))
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def show(ref):
+    p = subprocess.run(["git", "-C", str(REPO), "show", ref], stdout=subprocess.PIPE,
+                       stderr=subprocess.DEVNULL)
+    return None if p.returncode else p.stdout.decode("utf-8")
+
+
+def records_of(text, spec):
+    z = mod.classify_zones(text, spec, mod.Result("x"))
+    return z.records() if z else []
+
+
+# =============================================================================================
+# SYNTHETIC FIXTURES — portable stand-ins for this repository's own archive events.
+#
+# UPSTREAM PORT. L1/L2/L3 were originally driven by two commits in the canonical fork's history:
+# `020ba3f`, a CHANGELOG archive that carried the scope footer out of the live file, and
+# `7a71df0`, a HANDOFFS archive that bundled a record edit with the move. Neither is reachable in
+# any other clone, so the whole L-series could only run in one repository — including for an
+# adopter who installs the trimmer and wants to know it works.
+#
+# These reproduce the STRUCTURAL PROPERTIES those events supplied, never their bytes:
+#   * SYNTHETIC_CHANGELOG — front matter, records, and a NON-EMPTY footer carrying a rebasable
+#     `](link)`. The link is load-bearing: it is what makes the footer-moved clause detectable
+#     through `transform_record`, and a footer without one silently weakens that test.
+#   * SYNTHETIC_BEFORE / _AFTER / _SHARD — a 25 = 6 + 19 partition in which one RETAINED record
+#     was edited. Counts partition; content does not. That is precisely what made `7a71df0` the
+#     event worth testing against.
+#
+# The original docstrings warned that "a synthetic one tests the test". That warning is ANSWERED,
+# not waved away, by TestSyntheticFixtureControls below: it proves each fixture actually carries
+# the property the tests rely on, and that the assertions still go RED against it. A fixture
+# nobody has driven red is not a fixture.
+# =============================================================================================
+
+SYNTHETIC_CHANGELOG = (
+    "# Changelog\n"
+    "\n"
+    "Front-matter prose. A trim pins this zone and must never move it.\n"
+    "\n"
+    "### 2026-01-03 · [ad hoc] third\n"
+    "\n"
+    "body three\n"
+    "\n"
+    "### 2026-01-02 · [ad hoc] second\n"
+    "\n"
+    "body two\n"
+    "\n"
+    "### 2026-01-01 · [ad hoc] first\n"
+    "\n"
+    "body one\n"
+    "\n"
+    "---\n"
+    "\n"
+    "**Release history before v1.0:** not re-narrated here — see\n"
+    "[`docs/RELEASE_HISTORY.md`](docs/RELEASE_HISTORY.md) for the per-version entries.\n"
+)
+
+
+def _syn_receipt(n, extra=""):
+    """One HANDOFFS-shaped record. `extra` makes an otherwise identical record differ."""
+    return "```handoff\nsession: S%d\ndate: 2026-01-%02d\nstatus: complete%s\n```\n\n" % (
+        n, n, extra)
+
+
+# 25 = 6 retained + 19 archived, with retained record [0] EDITED across the move — the shape of a
+# close-out finalised in the same commit as the archive write.
+SYNTHETIC_BEFORE = [_syn_receipt(i) for i in range(1, 26)]
+SYNTHETIC_AFTER = ([_syn_receipt(1, "\nnote: finalised at close-out")]
+                   + SYNTHETIC_BEFORE[1:6])
+SYNTHETIC_SHARD = SYNTHETIC_BEFORE[6:]
+
+
+# The token the two shipped seeds carry until first real use. The TOOL no longer reads it — an
+# exemption keyed on it left one shape of F1 uncovered — see the 120-entry sealed-table-row test
+# below — so this is
+# purely a fixture token here, used to build files that DO carry the marker and must be judged on
+# their contents anyway.
+SEED_SENTINEL_TOKEN = "METHODOLOGY-SEED-SENTINEL"
+
+
+def mod_seed_sentinel():
+    return SEED_SENTINEL_TOKEN
+
+
+def negations_of(text, spec):
+    """Fence-aware count for the spec's seed negation. 0 when none is declared."""
+    if spec.seed_negation is None:
+        return 0
+    return sum(1 for i, s, inside, _ in mod.fence_scan(text.splitlines())
+               if not inside and spec.seed_negation.match(s))
+
+
+def probe_hits_of(text, spec):
+    """[(1-based line, line)] for the spec's content probe, fence-aware. [] when none declared.
+
+    Reimplemented here rather than called through the module: an assertion computed by the same
+    code it is testing cannot fail. This walks the module's fence_scan — the shared primitive the
+    production path also uses — but applies the predicate itself.
+    """
+    if spec.content_probe is None:
+        return []
+    out = []
+    for i, s, inside, _info in mod.fence_scan(text.splitlines()):
+        if not inside and spec.content_probe.search(s):
+            out.append((i + 1, s))
+    return out
+
+
+CL = mod.LEDGERS["CHANGELOG.md"]
+HF = mod.LEDGERS["HANDOFFS.md"]
+
+
+def live_handoffs_declares_the_regen_field():
+    """True iff the live root HANDOFFS.md carries HANDOFFS.md's declared regenerated-count sentence.
+
+    UPSTREAM-PORT PRECONDITION. `LEDGERS["HANDOFFS.md"]` declares one regenerated field, the retained
+    receipt count. A repository that keeps every receipt declares no retention policy and so carries
+    no count to regenerate — upstream's root HANDOFFS.md is exactly that. The two tests below use the
+    REAL field on the REAL front matter deliberately (a synthetic anchor would test the test), so they
+    have no fixture there and must skip rather than fail.
+
+    Read from the RAW FILE with the declared pattern, never from `classify_zones(...).front`: a
+    precondition computed by the code under test would agree with a broken zone-splitter and convert
+    a real defect into a silent skip. Reading raw is also the SAFE direction — it is true at least as
+    often as the front-zone form, so a sentence present but mis-zoned still RUNS the test and fails
+    its `assertIsNotNone` control, which is the signal we want rather than a skip.
+    """
+    try:
+        raw = (REPO / "HANDOFFS.md").read_text(encoding="utf-8")
+    except OSError:
+        return False
+    return HF.regenerated[0][1].search(raw) is not None
+
+
+# =============================================================================================
+# Controls — prove the fixtures before asserting anything about the code.
+# =============================================================================================
+
+class TestFixtureControls(unittest.TestCase):
+
+    def test_L2_fixture_really_carries_a_footer_worth_pinning(self):
+        """A fixture nobody has checked is an assumption. SYNTHETIC_CHANGELOG is only a fixture for
+        the L2 clauses if its footer is genuinely IN the footer zone and genuinely rebasable."""
+        z = mod.classify_zones(SYNTHETIC_CHANGELOG, CL, mod.Result("x"))
+        self.assertEqual(len(z.starts), 3, "fixture must hold 3 records")
+        self.assertTrue(z.footer.strip(), "the L2 fixture is only a fixture if a footer exists")
+        self.assertIn("Release history before v1.0", z.footer,
+                      "the phrase must be in the FOOTER zone, not merely in the file")
+        self.assertIn("](", z.footer,
+                      "control: the footer must carry a rebasable link, or the footer-moved clause "
+                      "is tested only in its verbatim form and the transform path goes uncovered")
+        self.assertEqual(z.front + "".join(z.records()) + z.footer, SYNTHETIC_CHANGELOG,
+                         "control: the zones must partition the fixture exactly")
+
+    def test_L2_fixture_can_actually_exhibit_the_loss_it_stands_for(self):
+        """The insight the original fork-history version carried, kept and made portable.
+
+        That version asserted a real footer had left a real live file and still had not come back.
+        The transferable half is WHY zones were needed at all: a whole-file substring grep cannot
+        tell "the footer is present" from "something merely quotes it", and that ambiguity is what
+        made the loss invisible. Asserted here on the fixture rather than on one repository's
+        history, so it runs in any clone."""
+        z = mod.classify_zones(SYNTHETIC_CHANGELOG, CL, mod.Result("x"))
+        phrase = "Release history before v1.0"
+
+        # The loss shape: footer gone from live, present in the shard.
+        lost_live = z.front + "".join(z.records())
+        shard = "shard body\n" + z.footer
+        r = mod.Result("x")
+        ok = mod.assert_L2(z, z.front + "PTR\n", "", shard, ["PTR\n"], [], r)
+        self.assertFalse(ok, "the fixture must be able to go RED, or it proves nothing")
+        self.assertIn("L2_FOOTER_MOVED", r.codes)
+
+        # ...and the control that justifies zones over grep: a record that merely QUOTES the
+        # phrase makes a whole-file search green while the footer is genuinely gone.
+        quoting = lost_live + "### 2026-01-04 · [ad hoc] quoting\n\nwe removed the %s line\n" % phrase
+        self.assertIn(phrase, quoting, "a whole-file grep still finds it — the false positive")
+        zq = mod.classify_zones(quoting, CL, mod.Result("x"))
+        self.assertNotIn(phrase, zq.footer, "but the FOOTER zone correctly reports it gone")
+
+    def test_L3_fixture_is_a_partition_that_bundled_an_edit_with_the_move(self):
+        """The counts DO partition, so any L3 failure is about record BYTES, not a miscount. That
+        is the whole reason this triple is the interesting one."""
+        b, a, s = SYNTHETIC_BEFORE, SYNTHETIC_AFTER, SYNTHETIC_SHARD
+        self.assertEqual((len(b), len(a), len(s)), (25, 6, 19),
+                         "fixture must be the 25 = 6 + 19 partition the design describes")
+        self.assertEqual(len(a) + len(s), len(b), "control: the counts partition")
+        edited = [i for i, (x, y) in enumerate(zip(b, a)) if x != y]
+        self.assertEqual(edited, [0],
+                         "exactly one RETAINED record differs, and it is the frontier one — the "
+                         "close-out-finalised-in-the-trim-commit shape")
+        self.assertEqual(s, b[6:], "control: the archived records themselves are untouched")
+
+    def test_seed_files_hold_zero_records_under_the_declared_grammar(self):
+        """Fence-awareness control. Both seeds contain record-shaped lines that are NOT records."""
+        cl_seed = (REPO / "starter-kit" / "CHANGELOG.md").read_text(encoding="utf-8")
+        hf_seed = (REPO / "starter-kit" / "HANDOFFS.md").read_text(encoding="utf-8")
+        self.assertEqual(len(re.findall(r"(?m)^### 20", cl_seed)), 3,
+                         "the seed must still contain the fenced examples this guards against")
+        self.assertEqual(len(re.findall(r"(?m)^```handoff", hf_seed)), 1)
+        self.assertEqual(records_of(cl_seed, CL), [], "a freshly seeded ledger has no records")
+        self.assertEqual(records_of(hf_seed, HF), [], "a freshly seeded ledger has no records")
+
+    def test_a_fence_blind_scan_would_have_trimmed_the_seed(self):
+        """NARROWED: drop fence-awareness and the day-one hazard reappears."""
+        cl_seed = (REPO / "starter-kit" / "CHANGELOG.md").read_text(encoding="utf-8")
+        naive = [ln for ln in cl_seed.splitlines() if CL.record_start.match(ln)]
+        self.assertEqual(len(naive), 3,
+                         "a fence-blind scanner finds 3 'records' in a file that has none")
+
+
+# =============================================================================================
+# L1 — records-zone concatenation identity
+# =============================================================================================
+
+class TestL1(unittest.TestCase):
+
+    def setUp(self):
+        self.before = [ "### 2026-01-0%d · [ad hoc] r%d\n\nbody %d\n\n" % (i, i, i)
+                        for i in range(1, 6) ]
+
+    def test_green_on_a_clean_partition(self):
+        r = mod.Result("x")
+        ok = mod.assert_L1(self.before, self.before[:2],
+                           [mod.transform_record(x) for x in self.before[2:]], r)
+        self.assertTrue(ok)
+        self.assertNotIn("L1_MISMATCH", r.codes)
+
+    def test_red_when_a_record_is_dropped(self):
+        r = mod.Result("x")
+        ok = mod.assert_L1(self.before, self.before[:2],
+                           [mod.transform_record(x) for x in self.before[3:]], r)
+        self.assertFalse(ok)
+        self.assertIn("L1_MISMATCH", r.codes)
+
+    def test_red_when_a_record_is_duplicated(self):
+        r = mod.Result("x")
+        dup = self.before[2:] + [self.before[4]]
+        ok = mod.assert_L1(self.before, self.before[:2], [mod.transform_record(x) for x in dup], r)
+        self.assertFalse(ok)
+        self.assertIn("L1_MISMATCH", r.codes)
+
+    def test_red_on_the_operand_order_the_design_specifies(self):
+        """The ratified §4.2 formula puts the shard FIRST. These ledgers are newest-on-top, so that
+        order is wrong — and it fails with the CORRECT TOTAL LENGTH, which is why the mutation below
+        matters. This is the defect the first build of this tool shipped and L1 caught."""
+        swapped = "".join(mod.invert_record(mod.transform_record(x)) for x in self.before[2:]) \
+                  + "".join(self.before[:2])
+        original = "".join(self.before)
+        self.assertEqual(len(swapped), len(original), "the swap conserves length — that is the trap")
+        self.assertNotEqual(swapped, original)
+
+    def test_NARROWED_length_only_L1_passes_the_operand_swap(self):
+        """A plausible weaker L1 — compare byte LENGTH — is green on the real defect above."""
+        swapped = "".join(self.before[2:]) + "".join(self.before[:2])
+        original = "".join(self.before)
+        self.assertEqual(len(swapped), len(original))      # narrowed guard: PASSES
+        r = mod.Result("x")                                # full-strength guard: REFUSES
+        mod.assert_L1(self.before, self.before[2:], [mod.transform_record(x) for x in self.before[:2]], r)
+        self.assertIn("L1_MISMATCH", r.codes)
+
+    def test_red_on_an_archive_that_edited_a_retained_record(self):
+        """The shape `7a71df0` had: counts partition, one retained record altered. L1 must refuse
+        it on the CONCATENATION, independently of L3's partition check."""
+        b, a, s = SYNTHETIC_BEFORE, SYNTHETIC_AFTER, SYNTHETIC_SHARD
+        r = mod.Result("x")
+        self.assertFalse(mod.assert_L1(b, a, [mod.transform_record(x) for x in s], r))
+        self.assertIn("L1_MISMATCH", r.codes)
+
+
+# =============================================================================================
+# L2 — zone pinning. The assertion whose absence cost a paragraph.
+# =============================================================================================
+
+class TestL2(unittest.TestCase):
+
+    def setUp(self):
+        self.text = SYNTHETIC_CHANGELOG
+        self.z = mod.classify_zones(self.text, CL, mod.Result("x"))
+
+    def test_green_when_the_footer_stays_live_and_out_of_the_shard(self):
+        r = mod.Result("x")
+        ok = mod.assert_L2(self.z, self.z.front + "PTR\n", self.z.footer,
+                           "shard body with no footer", ["PTR\n"], [], r)
+        self.assertTrue(ok, [f.message for f in r.findings])
+
+    def test_red_when_the_footer_migrates_into_the_shard(self):
+        """The `020ba3f` loss, reproduced: footer gone from live, present in the shard."""
+        r = mod.Result("x")
+        ok = mod.assert_L2(self.z, self.z.front + "PTR\n", "",
+                           "shard body\n" + self.z.footer, ["PTR\n"], [], r)
+        self.assertFalse(ok)
+        self.assertIn("L2_FOOTER_ALTERED", r.codes)
+        self.assertIn("L2_FOOTER_MOVED", r.codes)
+
+    def test_red_when_the_footer_is_DUPLICATED_into_the_shard(self):
+        """Isolates the 'absent from the shard' clause: live keeps it, the shard also gets it. The
+        footer-identical clause alone is green here."""
+        r = mod.Result("x")
+        ok = mod.assert_L2(self.z, self.z.front + "PTR\n", self.z.footer,
+                           "shard body\n" + self.z.footer, ["PTR\n"], [], r)
+        self.assertFalse(ok)
+        self.assertIn("L2_FOOTER_MOVED", r.codes)
+        self.assertNotIn("L2_FOOTER_ALTERED", r.codes)
+
+    def test_NARROWED_footer_identical_only_passes_the_duplication(self):
+        """The plausible weaker L2 — 'is the footer still in the live file?' — is green while the
+        same bytes have ALSO been frozen into a shard that must never carry them."""
+        self.assertEqual(self.z.footer, self.z.footer)            # narrowed guard: PASSES
+        r = mod.Result("x")                                       # full-strength guard: REFUSES
+        mod.assert_L2(self.z, self.z.front + "PTR\n", self.z.footer,
+                      "shard\n" + self.z.footer, ["PTR\n"], [], r)
+        self.assertIn("L2_FOOTER_MOVED", r.codes)
+
+    def test_red_when_front_matter_changes_outside_the_declared_spans(self):
+        tampered = self.z.front.replace("Changelog", "Chnagelog", 1) + "PTR\n"
+        r = mod.Result("x")
+        ok = mod.assert_L2(self.z, tampered, self.z.footer, "shard", ["PTR\n"], [], r)
+        self.assertFalse(ok)
+        self.assertIn("L2_FRONTMATTER_UNDECLARED", r.codes)
+
+    def test_a_declared_regenerated_field_is_permitted_and_confined(self):
+        if not live_handoffs_declares_the_regen_field():
+            self.skipTest("fixture absent: the live root HANDOFFS.md carries no match for "
+                          "HANDOFFS.md's declared regenerated-count field")
+        """Uses the REAL declared field on the REAL front matter — not a synthetic anchor, because
+        a synthetic one tests the test. HANDOFFS.md declares its retained-receipt count regenerated,
+        and that count has already drifted by hand, which is why it is declared at all.
+
+        The probe value must differ from whatever the live count currently reads, computed rather
+        than hardcoded: a hardcoded literal (this test's own prior form used `3`) is exactly the
+        kind of coupling to real, mutable ledger content this repo's own precedent warns about
+        (S63's `test_L2_fixture_loss_actually_happened_and_is_still_unrepaired`) — and it went
+        live here, not hypothetically: S64's own HANDOFFS.md archive set the real count to 3, the
+        very literal this test had hardcoded, making `old == new` and silencing the assertion this
+        test exists to make."""
+        hf_text = (REPO / "HANDOFFS.md").read_text(encoding="utf-8")
+        zh = mod.classify_zones(hf_text, HF, mod.Result("x"))
+        name, rx, _fn = HF.regenerated[0]
+        m = rx.search(zh.front)
+        self.assertIsNotNone(m, "control: the declared field must exist in the live front matter")
+        old = m.group(2)
+        probe = int(old) + 1  # guaranteed to differ from `old`, whatever `old` currently is
+
+        r = mod.Result("x")
+        new_front, reversals = mod.apply_regenerated(zh.front, HF, {"retained": probe}, r)
+        self.assertIn("FRONTMATTER_FIELD_REGENERATED", r.codes)
+        self.assertNotEqual(new_front, zh.front, "control: the field really changed")
+        self.assertEqual(reversals[0][1], old)
+
+        r2 = mod.Result("x")
+        ok = mod.assert_L2(zh, new_front + "PTR\n", zh.footer, "shard", ["PTR\n"], reversals, r2)
+        self.assertTrue(ok, [f.message for f in r2.findings])
+
+    def test_a_regenerated_field_does_not_license_an_edit_elsewhere(self):
+        if not live_handoffs_declares_the_regen_field():
+            self.skipTest("fixture absent: the live root HANDOFFS.md carries no match for "
+                          "HANDOFFS.md's declared regenerated-count field")
+        """NARROWED: the carve-out must not become a blanket permit for front-matter edits."""
+        hf_text = (REPO / "HANDOFFS.md").read_text(encoding="utf-8")
+        zh = mod.classify_zones(hf_text, HF, mod.Result("x"))
+        name, rx, _fn = HF.regenerated[0]
+        old = rx.search(zh.front).group(2)
+        r = mod.Result("x")
+        new_front, reversals = mod.apply_regenerated(zh.front, HF, {"retained": int(old) + 1}, r)
+        tampered = new_front.replace("prepend-only", "prepend-onlyX", 1) + "PTR\n"
+        self.assertNotEqual(tampered, new_front + "PTR\n", "control: the tamper must apply")
+        r2 = mod.Result("x")
+        ok = mod.assert_L2(zh, tampered, zh.footer, "shard", ["PTR\n"], reversals, r2)
+        self.assertFalse(ok)
+        self.assertIn("L2_FRONTMATTER_UNDECLARED", r2.codes)
+
+    def test_red_when_the_pointer_block_is_missing(self):
+        r = mod.Result("x")
+        ok = mod.assert_L2(self.z, self.z.front, self.z.footer, "shard", ["PTR\n"], [], r)
+        self.assertFalse(ok)
+        self.assertIn("L2_POINTER_MISSING", r.codes)
+
+
+# =============================================================================================
+# L3 — record partition by identity, order and bytes.
+# =============================================================================================
+
+class TestL3(unittest.TestCase):
+
+    def setUp(self):
+        self.before = list(SYNTHETIC_BEFORE)
+        self.after = list(SYNTHETIC_AFTER)
+        self.shard = list(SYNTHETIC_SHARD)
+
+    def test_green_on_a_pure_partition_of_the_same_fixture(self):
+        r = mod.Result("x")
+        ok = mod.assert_L3(self.before, self.before[:6], self.before[6:], r)
+        self.assertTrue(ok, [f.message for f in r.findings])
+
+    def test_red_on_the_real_event_that_edited_a_retained_record(self):
+        r = mod.Result("x")
+        ok = mod.assert_L3(self.before, self.after, self.shard, r)
+        self.assertFalse(ok, "the real 7a71df0 archive was not a pure move; L3 must refuse it")
+        self.assertIn("L3_RECORD_ALTERED", r.codes)
+
+    def test_NARROWED_count_only_L3_passes_the_real_event(self):
+        """The plausible weaker L3 — 'do the counts partition?' — is green on the event that
+        actually shipped a co-mingled edit. Counts are exactly what that event preserved."""
+        self.assertEqual(len(self.after) + len(self.shard), len(self.before))   # narrowed: PASSES
+        r = mod.Result("x")                                                     # full: REFUSES
+        mod.assert_L3(self.before, self.after, self.shard, r)
+        self.assertIn("L3_RECORD_ALTERED", r.codes)
+
+    def test_red_on_a_boundary_shift_that_L1_cannot_see(self):
+        """L3's independent value: move a line from the end of one record to the start of the next.
+        The concatenation is unchanged, so L1 is green; the partition is not, so L3 refuses."""
+        recs = ["### 2026-01-01 · [ad hoc] a\n\nalpha\n", "### 2026-01-02 · [ad hoc] b\n\nbeta\n"]
+        shifted = [recs[0][:-len("alpha\n")], "alpha\n" + recs[1]]
+        self.assertEqual("".join(shifted), "".join(recs), "control: bytes are conserved")
+        r1 = mod.Result("x")
+        self.assertTrue(mod.assert_L1(recs, shifted[:1],
+                                      [mod.transform_record(shifted[1])], r1), "L1 is blind here")
+        r3 = mod.Result("x")
+        self.assertFalse(mod.assert_L3(recs, shifted[:1], shifted[1:], r3))
+        self.assertIn("L3_RECORD_ALTERED", r3.codes)
+
+    def test_red_when_order_is_reversed(self):
+        r = mod.Result("x")
+        ok = mod.assert_L3(self.before, self.before[:6][::-1], self.before[6:], r)
+        self.assertFalse(ok)
+        self.assertIn("L3_RECORD_ALTERED", r.codes)
+
+
+# =============================================================================================
+# The transform — the domain predicate IS the contract.
+# =============================================================================================
+
+class TestTransform(unittest.TestCase):
+
+    def test_only_root_relative_targets_are_rebased(self):
+        src = ("see [a](CLAUDE.md) and [b](https://example.com/x) and [c](#frag) and\n"
+               "[d](../up.md) and [e](/abs.md) and [f](docs/x.md#y)\n")
+        out = mod.transform_record(src)
+        self.assertIn("](../../CLAUDE.md)", out)
+        self.assertIn("](../../docs/x.md#y)", out)
+        self.assertIn("](https://example.com/x)", out, "absolute URLs must never be prefixed")
+        self.assertIn("](#frag)", out)
+        self.assertIn("](../up.md)", out)
+        self.assertIn("](/abs.md)", out)
+
+    def test_the_naive_key_would_corrupt_absolute_urls(self):
+        """NARROWED: key on `](` alone, which is what the design measured as corrupting 14 URLs."""
+        src = "[b](https://example.com/x)\n"
+        naive = re.sub(r"\]\(([^)\s]*)\)", lambda m: "](../../%s)" % m.group(1), src)
+        self.assertIn("](../../https://example.com/x)", naive)          # narrowed: CORRUPTS
+        self.assertIn("](https://example.com/x)", mod.transform_record(src))   # full: leaves it
+
+    def test_links_inside_fences_and_code_spans_are_untouched(self):
+        """The code-span target must be ROOT-RELATIVE, or the assertion is inert.
+
+        The first version of this test used `](../../x.md)` inside the span — but `_in_domain`
+        already refuses any `../`-prefixed target, so `code_span_ranges` did no work and the whole
+        span mechanism could be deleted with the suite still green. `](CONTEXT.md)` is in-domain,
+        so only the span exclusion can save it.
+        """
+        src = ("prose [a](CLAUDE.md)\n"
+               "a code span `](CONTEXT.md)` explaining the rebase\n"
+               "```sh\n[b](CLAUDE.md)\n```\n")
+        self.assertTrue(mod._in_domain("CONTEXT.md"),
+                        "control: the span's target must be one the transform WOULD rewrite")
+        out = mod.transform_record(src)
+        self.assertIn("](../../CLAUDE.md)", out, "control: the prose link IS rewritten")
+        self.assertIn("`](CONTEXT.md)`", out, "an inline code span must not be rewritten")
+        self.assertIn("```sh\n[b](CLAUDE.md)\n```", out, "a fenced block must not be rewritten")
+
+    def test_round_trip_is_the_identity_on_a_record_corpus(self):
+        recs = records_of("".join(SYNTHETIC_SHARD), HF)
+        self.assertGreater(len(recs), 10, "control: the corpus must be non-trivial")
+        for rec in recs:
+            self.assertEqual(mod.invert_record(mod.transform_record(rec)), rec)
+
+    def test_a_record_carrying_an_already_relative_target_is_refused(self):
+        r = mod.Result("x")
+        ok = mod.check_invertible(["### 2026-01-01 · [ad hoc] x\n\n[a](../../already.md)\n"], r)
+        self.assertFalse(ok)
+        self.assertIn("TRANSFORM_NOT_INVERTIBLE", r.codes)
+
+
+# =============================================================================================
+# Zones
+# =============================================================================================
+
+class TestZones(unittest.TestCase):
+
+    def test_unclassified_trailing_content_aborts_a_footer_none_family(self):
+        text = ("# H\n\n---\n\n```handoff\nsession: S1\ndate: 2026-01-01\n```\n\n"
+                "prose belonging to S1\n\n---\n\n**A trailing paragraph nobody declared.**\n")
+        r = mod.Result("x")
+        z = mod.classify_zones(text, HF, r)
+        self.assertIsNone(z)
+        self.assertIn("ZONE_UNCLASSIFIED", r.codes)
+        self.assertEqual(r.exit, 2)
+
+    def test_handoff_trailing_prose_belongs_to_its_record(self):
+        text = ("# H\n\n```handoff\nsession: S1\ndate: 2026-01-01\n```\n\nSelf-score 8/10.\n")
+        recs = records_of(text, HF)
+        self.assertEqual(len(recs), 1)
+        self.assertIn("Self-score 8/10.", recs[0],
+                      "23% of the HANDOFFS payload lives outside the fences")
+
+    def test_a_four_backtick_wrapper_hides_its_inner_handoff_fence(self):
+        text = "# H\n\n````\n```handoff\nsession: S1\n```\n````\n"
+        self.assertEqual(records_of(text, HF), [])
+
+
+# =============================================================================================
+# The trigger — the two metrics take different FORMS.
+# =============================================================================================
+
+class TestTrigger(unittest.TestCase):
+
+    def test_the_line_form_transplanted_onto_bytes_is_unreachable(self):
+        """Design §5.2, mechanised: 'cut until back above 30' cannot be satisfied on the byte
+        metric at ANY budget, even trimming to a single record. A trimmer using it would trim to
+        empty and still report the trigger unsatisfied."""
+        slope, floor = 12472, 2025 + 3767
+        for budget in (52927, 65536, 131072, 262144):
+            self.assertLess((budget - floor) / float(slope), 30,
+                            "budget %d must NOT reach 30 units of byte-headroom" % budget)
+
+    def test_the_byte_form_is_a_level_with_hysteresis_and_terminates(self):
+        t = mod.Trigger()
+        t.budget = 65536
+        t.size_bytes = 200000
+        self.assertTrue(t.byte_fires)
+        self.assertFalse(t.stops(40000), "above half budget must not stop")
+        self.assertTrue(t.stops(32000), "at or below half budget must stop")
+
+    def test_the_read_cap_arm_can_stop_and_is_not_vestigial(self):
+        """`read_ok` is the looser arm at the SHIPPED budget, so a test that only exercises the
+        default budget cannot tell whether it is wired at all. Raise the budget past the read cap
+        — which `--budget-bytes` lets an adopter do — and it must be what binds."""
+        t = mod.Trigger()
+        t.budget = 65536
+        self.assertTrue(t.stops(1000), "well under both arms must stop")
+        loose = mod.Trigger()
+        loose.budget = 400000                       # half of this is 200,000 B: byte_ok alone passes
+        self.assertTrue(loose.stops(1000), "under both arms, a raised budget still stops")
+        self.assertFalse(loose.stops(mod.READ_CAP_BYTES + 1),
+                         "past the read cap must NOT stop even when the byte arm is satisfied")
+        self.assertTrue(loose.stops(mod.READ_CAP_BYTES),
+                        "exactly at the read cap must stop — the boundary is inclusive")
+
+    def test_fires_if_either_metric_fires(self):
+        t = mod.Trigger()
+        t.budget = 10 ** 9                          # byte arm cannot fire
+        t.size_bytes = mod.READ_CAP_BYTES + 1
+        self.assertTrue(t.read_fires, "the read metric alone must be able to fire")
+        self.assertTrue(t.fires)
+        t2 = mod.Trigger()
+        t2.budget = 100
+        t2.size_bytes = 500                         # under the read cap, over the budget
+        self.assertLess(t2.size_bytes, mod.READ_CAP_BYTES, "control: the read arm must be quiet")
+        self.assertFalse(t2.read_fires)
+        self.assertTrue(t2.fires, "the byte metric alone must be able to fire")
+
+    def test_the_read_cap_is_derived_and_not_a_written_literal(self):
+        """Phase B's structural promise: no opaque boundary is published. If someone replaces the
+        product with a hardcoded number, this fails."""
+        self.assertEqual(mod.READ_CAP_BYTES,
+                         int(mod.READ_CAP_TOKENS * mod.MIN_BYTES_PER_TOKEN))
+        self.assertFalse(hasattr(mod, "READ_CAP_LINES"),
+                         "the line-denominated cap was removed in Phase B, not renamed")
+        for gone in ("LINE_FIRE_BELOW", "LINE_STOP_ABOVE"):
+            self.assertFalse(hasattr(mod, gone),
+                             "%s was DELETED with the line arm, not re-tuned" % gone)
+
+
+# =============================================================================================
+# End to end, in a scratch repo.
+# =============================================================================================
+
+def sh(cwd, *args):
+    return subprocess.run(list(args), cwd=str(cwd), stdout=subprocess.PIPE,
+                          stderr=subprocess.STDOUT, text=True)
+
+
+FOOTER = ("\n---\n\n**Release history before v3.0:** not re-narrated here — see\n"
+          "[`CLAUDE.md` §Versioning](CLAUDE.md#versioning). This ledger is prepend-only.\n")
+
+
+# ⚠ `body` GREW 3,500 -> 7,000 AT PHASE C2, AND THE REASON IS NOT COSMETIC. These fixtures must be
+# large enough to FIRE the shipped trigger, and C2 raised it from 65,536 B to 196,608 B. At the old
+# size make_repo() produced ~108 KB, which fired the old byte arm and is silent under the new one:
+# 22 tests in this file went red as [NOTHING_TO_DO], every one of them about shard mechanics, SRF,
+# or losslessness rather than about calibration.
+#
+# THE ALTERNATIVE WAS CONSIDERED AND REJECTED, recorded so it is not re-litigated: passing
+# `--budget-bytes 65536` at each call site would have held every downstream number byte-identical
+# and made these tests immune to future recalibration. It was rejected because it would leave the
+# SHIPPED configuration unexercised end-to-end — every trim in this file would run at a budget no
+# adopter has — which is the "a guard you can walk around by picking a parameter" shape this repo
+# already has a learning about. Growing the fixture keeps the default on the tested path.
+#
+# Measured after the change: 123 tests pass, and the fixture is NON-VACUOUS — make_repo() yields
+# 213,704 B against a 196,608 B trigger, --check reports FIRES, and a real --write lands at
+# 93,909 B, inside (READ_CAP_BYTES, CLASS_A_STOP_BYTES]. Retained-record counts moved 9 -> 13; no
+# assertion in this file encodes either number, which is why nothing needed hand-editing.
+def make_repo(tmp, n_records=30, body=7000, footer=False):
+    p = Path(tmp)
+    (p / "docs" / "archive").mkdir(parents=True)
+    entries = "".join(
+        "### 2026-01-%02d · [ad hoc] entry %d\n\n"
+        "see [the runner](SESSION_RUNNER.md), [abs](https://example.com/a) and [frag](#f)\n"
+        "%s\n\n" % (i % 28 + 1, i, "x" * body)
+        for i in range(n_records))
+    (p / "CHANGELOG.md").write_text(
+        "# Changelog\n\nFront matter prose about [the runner](SESSION_RUNNER.md).\n"
+        "Retained entries: **0**.\n\n---\n\n"
+        "## 2026-01\n\n" + entries + (FOOTER if footer else ""), encoding="utf-8")
+    sh(p, "git", "init", "-q", ".")
+    sh(p, "git", "config", "user.email", "t@t")
+    sh(p, "git", "config", "user.name", "T")
+    sh(p, "git", "add", "-A")
+    sh(p, "git", "commit", "-qm", "seed")
+    return p
+
+
+# `hf_body` grew 1,200 -> 34,000 at Phase C2, for the reason stated above make_repo(). Measured:
+# HANDOFFS.md is 205,662 B, over the 196,608 B trigger, and --check reports FIRES.
+def make_handoff_repo(tmp, n_hf_records=6, hf_body=34000, n_cl_records=3, cl_body=50):
+    """A repo holding BOTH ledgers, seeded in ONE commit — HANDOFFS.md fence-kind records with the
+    real declared regen field (`This file currently holds **N**`), plus a minimal CHANGELOG.md
+    (check_P1's ledger_rel_for() is hardcoded to CHANGELOG.md regardless of which file is trimmed,
+    and insert_ledger_entry() writes into it even when trimming HANDOFFS.md — both need it to
+    exist and parse). One commit, not two, so the P1 undocumented-set is empty at trim time: a
+    second commit adding HANDOFFS.md after CHANGELOG.md's own commit would itself be undocumented.
+    """
+    p = Path(tmp)
+    (p / "docs" / "archive").mkdir(parents=True)
+    cl_entries = "".join(
+        "### 2026-01-%02d · [ad hoc] entry %d\n\nbody %s\n\n" % (i % 28 + 1, i, "x" * cl_body)
+        for i in range(n_cl_records))
+    (p / "CHANGELOG.md").write_text(
+        "# Changelog\n\nFront matter.\nRetained entries: **0**.\n\n---\n\n"
+        "## 2026-01\n\n" + cl_entries, encoding="utf-8")
+
+    def hf_rec(i):
+        return (
+            "```handoff\n"
+            "session: S%d\n"
+            "date: 2026-01-%02d\n"
+            "status: complete\n"
+            "active_task: x\n"
+            "what_was_done: %s\n"
+            "next_steps: n\n"
+            "key_files: k\n"
+            "gotchas: g\n"
+            "runtime_smoke: r\n"
+            "changelog_ref: c\n"
+            "commit: %040x\n"
+            "```\n"
+            "Self-score **8/10.** commentary about session %d.\n\n"
+            % (i, n_hf_records - i, "x" * hf_body, i, i)
+        )
+
+    hf_entries = "---\n\n".join(hf_rec(i) for i in range(n_hf_records))
+    (p / "HANDOFFS.md").write_text(
+        "# Handoff Receipts\n\nThis file currently holds **0**.\n\n---\n\n" + hf_entries,
+        encoding="utf-8")
+    sh(p, "git", "init", "-q", ".")
+    sh(p, "git", "config", "user.email", "t@t")
+    sh(p, "git", "config", "user.name", "T")
+    sh(p, "git", "add", "-A")
+    sh(p, "git", "commit", "-qm", "seed")
+    return p
+
+
+def run_trim(repo, *args):
+    return subprocess.run([sys.executable, str(TRIM_PY)] + list(args), cwd=str(repo),
+                          stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+
+
+class TestEndToEnd(unittest.TestCase):
+
+    def test_dry_run_is_the_default_and_writes_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--today", "2026-02-01")
+            self.assertIn("[DRY_RUN]", r.stdout)
+            self.assertEqual(sh(p, "git", "status", "--porcelain").stdout.strip(), "",
+                             "a dry run must leave the tree untouched")
+
+    def test_write_produces_a_shard_a_proof_and_an_uncommitted_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            for code in ("[L1_OK]", "[L2_OK]", "[L3_OK]", "[P1A_OK]", "[WROTE]"):
+                self.assertIn(code, r.stdout, r.stdout)
+            shards = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))
+            self.assertEqual(len(shards), 1)
+            self.assertTrue((p / (str(shards[0].relative_to(p)) + ".verify.sh")).is_file())
+            self.assertEqual(sh(p, "git", "log", "--oneline").stdout.count("\n"), 1,
+                             "the trimmer must never commit")
+
+    def test_the_generated_proof_passes_before_and_after_the_commit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            v = sorted((p / "docs" / "archive").glob("*.verify.sh"))[0]
+            pre = sh(p, "bash", str(v))
+            self.assertIn("OK: L1, L2/front-matter, L3 hold", pre.stdout, pre.stdout)
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "trim")
+            post = sh(p, "bash", str(v))
+            self.assertIn("OK: L1, L2/front-matter, L3 hold", post.stdout, post.stdout)
+            self.assertIn("the trim commit", post.stdout)
+
+    def test_the_proof_goes_RED_when_the_shard_is_tampered_with(self):
+        """The tamper must land on a record that is ACTUALLY IN THE SHARD. The first draft of this
+        test edited 'entry 0' — which is newest-on-top and therefore RETAINED, so the edit was a
+        no-op and the proof passed for the right reason on the wrong file. Hence the control."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            shard = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))[0]
+            before = shard.read_text(encoding="utf-8")
+            victim = re.search(r"(?m)^### .*\[ad hoc\] (entry \d+)$", before)
+            self.assertIsNotNone(victim, "control: the shard must contain a real record heading")
+            after = before.replace(victim.group(1), victim.group(1) + " TAMPERED", 1)
+            self.assertNotEqual(after, before, "control: the tamper must actually change the shard")
+            shard.write_text(after, encoding="utf-8")
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+            self.assertNotEqual(v.returncode, 0)
+
+    def test_the_proof_goes_RED_when_the_live_file_loses_a_retained_record(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            live = p / "CHANGELOG.md"
+            text = live.read_text(encoding="utf-8")
+            heads = re.findall(r"(?m)^### .*$", text)
+            self.assertGreater(len(heads), 2, "control: there must be a retained record to drop")
+            start = text.index(heads[-1])
+            live.write_text(text[:start], encoding="utf-8")
+            v = sh(p, "bash", str(sorted((p / "docs" / "archive").glob("*.verify.sh"))[0]))
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+
+    def test_P1_refuses_when_the_undocumented_set_is_non_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            (p / "src.txt").write_text("unrecorded action\n", encoding="utf-8")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "an action with no ledger entry")
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            self.assertIn("[P1_UNDOCUMENTED]", r.stdout)
+            self.assertNotIn("[WROTE]", r.stdout)
+            self.assertEqual(sh(p, "git", "status", "--porcelain").stdout.strip(), "")
+
+    def test_P1a_keeps_the_trim_from_hiding_itself(self):
+        """After a trim commit the ledger frontier IS that commit, so the undocumented set is
+        empty ONLY because the trim recorded itself. Without the entry the trim's first act would
+        be to advance the frontier past unrecorded history."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            text = (p / "CHANGELOG.md").read_text(encoding="utf-8")
+            self.assertIn("[ad hoc] Ledger trim:", text)
+            self.assertEqual(len(re.findall(r"(?m)^### .*Ledger trim:", text)), 1)
+
+    def test_P1a_fires_when_the_ledger_did_NOT_gain_exactly_one_entry(self):
+        """Drives the post-condition RED directly. Without this the whole check can be deleted and
+        the suite stays green — which is exactly what the mutation harness found."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp, n_records=3, body=10)
+            ledger = p / "CHANGELOG.md"
+            actual = len(records_of(ledger.read_text(encoding="utf-8"), CL))
+            self.assertEqual(actual, 3, "control: the fixture ledger must hold 3 records")
+
+            ok_r = mod.Result("x")
+            self.assertTrue(mod.check_P1a(ledger, CL, actual - 1, ok_r),
+                            "expected == actual-1 means exactly one entry was gained")
+            self.assertIn("P1A_OK", ok_r.codes)
+
+            bad_r = mod.Result("x")
+            self.assertFalse(mod.check_P1a(ledger, CL, actual, bad_r),
+                             "no entry gained must be caught")
+            self.assertIn("P1A_LEDGER_ENTRY", bad_r.codes)
+            self.assertEqual(bad_r.exit, 2)
+
+            two_r = mod.Result("x")
+            self.assertFalse(mod.check_P1a(ledger, CL, actual - 2, two_r),
+                             "TWO entries gained must also be caught, not just zero")
+            self.assertIn("P1A_LEDGER_ENTRY", two_r.codes)
+
+    # --- BL-41: the shard name is not injective, so a collision must be RESOLVED, not refused ----
+    #
+    # The name is a function of a RECORD DATE; the cut is POSITIONAL. Distinct cuts therefore map
+    # to one name, and the write-once refusal then has no escape: `--cut <date>` cannot break the
+    # tie because that date both selects the records AND becomes the key. On the live HANDOFFS.md
+    # every admissible cut yielded `HANDOFFS-through-2026-08-17.md`, so the tool's own advice —
+    # "Disambiguate with --cut" — had no solution and the ledger sat over its ceiling (BL-41).
+    #
+    # What must NOT change: no run may ever overwrite an earlier shard or an earlier proof. That
+    # is the invariant the refusal was protecting, and every test below still asserts it.
+
+    def test_FIXTURE_the_derived_shard_name_really_is_taken_before_the_second_cut(self):
+        """Fixture control. Asserts the COLLISION EXISTS before anything asserts what happens to
+        it — a green disambiguation test proves nothing if the second cut never collided."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "trim")
+            shards = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))
+            self.assertEqual(len(shards), 1, "fixture must start from exactly one shard")
+            key = shards[0].name[len("CHANGELOG-through-"):-3]
+            self.assertTrue(shards[0].exists())
+            # The precondition, stated as an assertion rather than assumed by the next test.
+            self.assertTrue((p / "docs" / "archive" / ("CHANGELOG-through-%s.md" % key)).exists(),
+                            "the name the next cut will derive must already be taken")
+
+    def test_a_colliding_shard_name_is_disambiguated_and_the_earlier_shard_is_untouched(self):
+        """BL-41's fix. The earlier shard's BYTES are the invariant; the refusal was only one way
+        of protecting them, and it protected them by making the tool unusable."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "trim")
+            first = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))[0]
+            key = first.name[len("CHANGELOG-through-"):-3]
+            before = first.read_bytes()
+
+            r = run_trim(p, "--file", "CHANGELOG.md", "--cut", key, "--write", "--today", "2026-02-02")
+
+            self.assertIn("SHARD_NAME_DISAMBIGUATED", r.stdout, r.stdout)
+            self.assertNotIn("[SHARD_EXISTS]", r.stdout, r.stdout)
+            self.assertEqual(first.read_bytes(), before,
+                             "the earlier shard must be byte-identical after the second trim")
+            second = p / "docs" / "archive" / ("CHANGELOG-through-%s-2.md" % key)
+            self.assertTrue(second.exists(), "the disambiguated shard must be written")
+
+    def test_the_disambiguated_shard_holds_THIS_cut_s_records_not_a_copy_of_the_first(self):
+        """A disambiguation that wrote an empty file, or re-wrote the first shard's contents under
+        a free name, would pass the byte-identity test above. Assert the CONTENT moved."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "trim")
+            first = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))[0]
+            key = first.name[len("CHANGELOG-through-"):-3]
+            live_before = (p / "CHANGELOG.md").read_text(encoding="utf-8")
+            spec = mod.LEDGERS["CHANGELOG.md"]
+            moved_out = records_of(live_before, spec)
+
+            run_trim(p, "--file", "CHANGELOG.md", "--cut", key, "--write", "--today", "2026-02-02")
+
+            second = p / "docs" / "archive" / ("CHANGELOG-through-%s-2.md" % key)
+            live_after = (p / "CHANGELOG.md").read_text(encoding="utf-8")
+            kept = records_of(live_after, spec)
+            self.assertTrue(kept, "the live file must still hold records")
+            self.assertLess(len(kept), len(moved_out), "the second cut must actually archive")
+            shard_text = second.read_text(encoding="utf-8")
+            # The oldest record of the PREVIOUS live file is the one this cut moved.
+            oldest = mod.transform_record(moved_out[-1])
+            self.assertIn(oldest.strip()[:200], shard_text,
+                          "the disambiguated shard must contain the records THIS cut archived")
+            self.assertNotIn(first.read_text(encoding="utf-8")[:200], shard_text,
+                             "it must not be a copy of the earlier shard")
+
+    def test_a_stray_proof_with_no_shard_is_also_never_clobbered(self):
+        """The shard and its .verify.sh are written as a pair; an interrupted run can leave the
+        proof behind without its shard. Checking only the SHARD would then silently overwrite a
+        frozen proof — the same corruption the write-once rule exists to exclude, one file over."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r0 = run_trim(p, "--file", "CHANGELOG.md", "--today", "2026-02-01")
+            m = re.search(r"docs/archive/(CHANGELOG-through-[0-9-]+)\.md", r0.stdout)
+            self.assertIsNotNone(m, r0.stdout)
+            stray = p / "docs" / "archive" / (m.group(1) + ".md.verify.sh")
+            stray.write_text("#!/usr/bin/env bash\n# frozen proof, no shard\n", encoding="utf-8")
+            keep = stray.read_bytes()
+
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+
+            self.assertEqual(stray.read_bytes(), keep,
+                             "an existing .verify.sh must never be overwritten")
+            self.assertIn("SHARD_NAME_DISAMBIGUATED", r.stdout, r.stdout)
+
+    def test_NARROWED_shard_only_collision_check_passes_the_shard_case_and_loses_the_proof(self):
+        """The plausible weaker implementation: disambiguate on the SHARD path alone. It resolves
+        an ordinary collision (so it passes the two tests above) and silently clobbers the stray
+        proof — which is why the real check quantifies over BOTH names."""
+        def narrowed_taken(shard_path):
+            return shard_path.exists()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r0 = run_trim(p, "--file", "CHANGELOG.md", "--today", "2026-02-01")
+            m = re.search(r"docs/archive/(CHANGELOG-through-[0-9-]+)\.md", r0.stdout)
+            base = p / "docs" / "archive" / (m.group(1) + ".md")
+            stray = p / "docs" / "archive" / (m.group(1) + ".md.verify.sh")
+            stray.write_text("frozen\n", encoding="utf-8")
+
+            self.assertFalse(narrowed_taken(base),
+                             "the narrowed check sees the name as FREE — and would write over "
+                             "the stray proof")
+            self.assertTrue(mod.shard_name_taken(base),
+                            "the full-strength check must see the pair as taken")
+
+    def test_disambiguation_is_bounded_and_still_REFUSES_at_the_bound(self):
+        """Write-once is retained, not removed. Past the bound the tool refuses exactly as before,
+        so the protection has a floor rather than an unbounded rename loop."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r0 = run_trim(p, "--file", "CHANGELOG.md", "--today", "2026-02-01")
+            m = re.search(r"docs/archive/(CHANGELOG-through-[0-9-]+)\.md", r0.stdout)
+            stem = m.group(1)
+            adir = p / "docs" / "archive"
+            (adir / (stem + ".md")).write_text("taken\n", encoding="utf-8")
+            for i in range(2, mod.SHARD_SUFFIX_MAX + 1):
+                (adir / ("%s-%d.md" % (stem, i))).write_text("taken\n", encoding="utf-8")
+
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+
+            self.assertIn("[SHARD_EXISTS]", r.stdout, r.stdout)
+            self.assertEqual((adir / (stem + ".md")).read_text(encoding="utf-8"), "taken\n",
+                             "the refusal must still leave every existing shard untouched")
+
+    def test_the_bound_refusal_is_FATAL_and_not_merely_reported(self):
+        """THE ONE PLACE THIS FILE ASSERTS ON EXIT STATUS, AND THE DEPARTURE IS DELIBERATE.
+
+        The header rule — assert on named findings, never on the exit code — exists so that adding
+        a check cannot silently re-label an UNRELATED assertion. This assertion is not unrelated:
+        its whole subject is the SEVERITY of one named finding. Dropping `exit_code=2` from the
+        bound refusal changes nothing a finding-only test can see (the function returns before the
+        write either way, so the shard is still untouched), and a scripted caller would read the
+        refusal as success. That mutant survived a 9-mutant round with every finding asserted.
+
+        It can still pass for the wrong reason if some future check exits 2 on this fixture, so it
+        asserts the finding AND the status together, and names the pair here so a reader can tell.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r0 = run_trim(p, "--file", "CHANGELOG.md", "--today", "2026-02-01")
+            m = re.search(r"docs/archive/(CHANGELOG-through-[0-9-]+)\.md", r0.stdout)
+            stem = m.group(1)
+            adir = p / "docs" / "archive"
+            (adir / (stem + ".md")).write_text("taken\n", encoding="utf-8")
+            for i in range(2, mod.SHARD_SUFFIX_MAX + 1):
+                (adir / ("%s-%d.md" % (stem, i))).write_text("taken\n", encoding="utf-8")
+
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+
+            self.assertIn("[SHARD_EXISTS]", r.stdout, r.stdout)
+            self.assertNotEqual(r.returncode, 0,
+                                "a refusal a caller cannot detect is not a refusal")
+
+    def test_a_free_name_is_used_verbatim_and_reports_no_disambiguation(self):
+        """Negative control: always-suffixing would pass every test above. The plain name must
+        still be the name when nothing is in the way."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            self.assertNotIn("SHARD_NAME_DISAMBIGUATED", r.stdout, r.stdout)
+            shards = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))
+            self.assertEqual(len(shards), 1, r.stdout)
+            self.assertNotIn("-2.md", shards[0].name, "an unforced suffix is a bug")
+
+    def test_srf_abstains_out_loud_before_a_first_archive(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--check")
+            self.assertIn("[SRF_UNDEFINED]", r.stdout)
+            self.assertNotIn("[SRF_RED]", r.stdout, "abstention must not block")
+
+    def test_check_never_writes_even_with_write(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--check", "--write")
+            self.assertIn("[CHECK]", r.stdout)
+            self.assertNotIn("[WROTE]", r.stdout)
+            self.assertEqual(sh(p, "git", "status", "--porcelain").stdout.strip(), "")
+
+    def test_batched_write_is_a_usage_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--file", "HANDOFFS.md", "--write")
+            self.assertEqual(r.returncode, 3)
+            self.assertIn("one --file per --write", r.stdout)
+
+    def test_an_unconfigured_file_gets_no_generic_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            (p / "NOTES.md").write_text("### 2026-01-01 · [ad hoc] x\n\nbody\n", encoding="utf-8")
+            r = run_trim(p, "--file", "NOTES.md")
+            self.assertIn("[NO_CONFIG]", r.stdout)
+            self.assertEqual(r.returncode, 3)
+
+    def test_srf_red_refuses_and_force_overrides(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "trim")
+            # Grow the file back past its pre-archive size -> SRF >= 1.00.
+            pre = int(sh(p, "git", "cat-file", "-s",
+                         sh(p, "git", "rev-parse", "HEAD^:CHANGELOG.md").stdout.strip()).stdout)
+            text = (p / "CHANGELOG.md").read_text(encoding="utf-8")
+            grow = "".join("### 2026-03-%02d · [ad hoc] new %d\n\n%s\n\n" % (i % 28 + 1, i, "y" * 3000)
+                           for i in range(40))
+            idx = text.index("### ")
+            (p / "CHANGELOG.md").write_text(text[:idx] + grow + text[idx:], encoding="utf-8")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "growth recorded")
+            self.assertGreater((p / "CHANGELOG.md").stat().st_size, pre,
+                               "control: the file must really be back past its pre-archive size")
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-04-01")
+            self.assertIn("[SRF_RED]", r.stdout, r.stdout)
+            self.assertNotIn("[WROTE]", r.stdout)
+            r2 = run_trim(p, "--file", "CHANGELOG.md", "--write", "--force", "--today", "2026-04-01")
+            self.assertIn("[WROTE]", r2.stdout, r2.stdout)
+
+
+# =============================================================================================
+# BL-27 — the GENERATED .verify.sh has two false-positive triggers on HANDOFFS.md that the
+# internal --check/--write assertions do not share (they have assert_L2's declared-field-reversal
+# exception; the standalone script did not). Reproduced against a real end-to-end HANDOFFS.md trim
+# through the actual subprocess, not just the internal assert_L2 unit — the defect lives entirely
+# in the generated shell/python text, not in the tool's own in-memory checks.
+# =============================================================================================
+
+class TestVerifyShHandoffFalsePositives(unittest.TestCase):
+
+    def test_regenerated_front_matter_field_no_longer_false_fails_verify_sh(self):
+        """Fix 1. The trim's own regenerated receipt-count line changes on every archive by
+        construction — the standalone proof must not read that as data loss."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_handoff_repo(tmp)
+            r = run_trim(p, "--file", "HANDOFFS.md", "--cut", "2", "--write", "--today", "2026-02-01")
+            self.assertIn("[WROTE]", r.stdout, r.stdout)
+            live = (p / "HANDOFFS.md").read_text(encoding="utf-8")
+            self.assertIn("This file currently holds **2**", live,
+                         "control: the regenerated field must actually have changed")
+            shard = sorted((p / "docs" / "archive").glob("HANDOFFS-through-*.md"))[0]
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("OK: L1, L2/front-matter, L3 hold", v.stdout, v.stdout)
+            self.assertEqual(v.returncode, 0)
+
+    def test_an_undeclared_front_matter_edit_still_fails_L2_even_with_the_field_regenerated(self):
+        """NARROWED control for fix 1 — the exemption must not become a blanket permit. An edit
+        OUTSIDE the declared field's own parens, alongside a real regenerated-field change, must
+        still be caught: the same shape as `test_a_regenerated_field_does_not_license_an_edit_elsewhere`,
+        but through the actual generated script rather than the internal assert_L2 unit.
+
+        The tamper must be a full-line REPLACEMENT, not an append — the "missing" check compares
+        by substring (`ln not in afront`), so a tamper that merely appends to a line leaves the
+        original text intact as a substring of the edited one and is invisible to it. That gap is
+        real and pre-existing (open as its own finding, not this session's to fix), but a control
+        built on it would pass for the wrong reason — masked by the very regen-field false-positive
+        this test exists to prove is no longer masking anything.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_handoff_repo(tmp)
+            run_trim(p, "--file", "HANDOFFS.md", "--cut", "2", "--write", "--today", "2026-02-01")
+            live = p / "HANDOFFS.md"
+            text = live.read_text(encoding="utf-8")
+            before = text
+            text = text.replace("# Handoff Receipts", "# TAMPERED", 1)
+            self.assertNotEqual(text, before, "control: the tamper must actually change the file")
+            self.assertNotIn("# Handoff Receipts", text,
+                             "control: the tamper must be a full replacement, not an append -- the "
+                             "old text surviving as a substring of the new line would defeat the "
+                             "'missing' check's own (pre-existing, unrelated) substring comparison")
+            live.write_text(text, encoding="utf-8")
+            shard = sorted((p / "docs" / "archive").glob("HANDOFFS-through-*.md"))[0]
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+            self.assertIn("L2 FRONT MATTER", v.stdout, v.stdout)
+            self.assertNotEqual(v.returncode, 0)
+
+    def test_frontier_record_edit_bundled_into_trim_commit_still_fails_but_is_labelled(self):
+        """Fix 2. This repo's own established practice (S61/S63/S64): a session's frontier receipt
+        is finalized (status: pending -> complete) in the SAME commit as the archive write. The
+        standalone script re-run later must still FAIL (a real loss can have this exact shape) —
+        but must now also print a NOTE naming the known pattern, so a reader does not mistake a
+        legitimate bundled edit for an unqualified loss."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_handoff_repo(tmp)
+            run_trim(p, "--file", "HANDOFFS.md", "--cut", "2", "--write", "--today", "2026-02-01")
+            live = p / "HANDOFFS.md"
+            text = live.read_text(encoding="utf-8")
+            before = text
+            # Record 0 (S0, the newest/frontier — file position 0 is topmost/newest, though dates
+            # descend with i) — simulate its own close-out finalize, bundled into the trim commit.
+            self.assertIn("session: S0", text, "control: the frontier record must be S0")
+            text = text.replace("status: complete\nactive_task: x",
+                                "status: complete\nactive_task: x (finalized)", 1)
+            self.assertNotEqual(text, before, "control: the tamper must actually change record 0")
+            live.write_text(text, encoding="utf-8")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "trim + frontier finalize, bundled")
+            shard = sorted((p / "docs" / "archive").glob("HANDOFFS-through-*.md"))[0]
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+            self.assertIn("NOTE:", v.stdout, v.stdout)
+            self.assertIn("BL-27", v.stdout, v.stdout)
+            self.assertNotEqual(v.returncode, 0, "a bundled edit must still FAIL, never pass silently")
+
+    def test_a_non_frontier_record_edit_bundled_into_trim_commit_gets_no_such_label(self):
+        """NARROWED control for fix 2 — the label must not spread to a record that is not the
+        frontier. Editing the OTHER retained record (position 1, not 0) is real, uncovered data
+        alteration and must fail with no reassuring NOTE."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_handoff_repo(tmp)
+            run_trim(p, "--file", "HANDOFFS.md", "--cut", "2", "--write", "--today", "2026-02-01")
+            live = p / "HANDOFFS.md"
+            text = live.read_text(encoding="utf-8")
+            before = text
+            self.assertIn("session: S1", text, "control: the second retained record must be S1")
+            text = text.replace("session: S1\n", "session: S1-TAMPERED\n", 1)
+            self.assertNotEqual(text, before, "control: the tamper must actually change record 1")
+            live.write_text(text, encoding="utf-8")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "trim + an edit to the wrong record, bundled")
+            shard = sorted((p / "docs" / "archive").glob("HANDOFFS-through-*.md"))[0]
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+            self.assertNotIn("NOTE:", v.stdout, v.stdout)
+            self.assertNotEqual(v.returncode, 0)
+
+
+# =============================================================================================
+# BL-28 — the GENERATED .verify.sh's L2 "missing front-matter line" check is a substring test
+# (`ln not in afront`), not exact-line-set membership. `afront` is the whole front-matter TEXT, so
+# `in` is substring containment: an APPEND-style edit that keeps the original line as a literal
+# prefix of the new one leaves the old text intact as a substring and the check reports no loss.
+# Raised 2026-08-10 (S65) while building BL-27's own narrowed control — that control (above,
+# `test_an_undeclared_front_matter_edit_still_fails_L2_even_with_the_field_regenerated`) had to use
+# a full-line REPLACEMENT tamper specifically because an append would have been invisible to this
+# defect and masked what that test was proving. This is the sibling test that proves the append
+# shape itself is caught, now that the check is fixed.
+# =============================================================================================
+
+class TestVerifyShAppendTamperEvadesSubstringCheck(unittest.TestCase):
+
+    def test_an_append_style_edit_that_keeps_the_original_line_as_a_substring_still_fails_L2(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_handoff_repo(tmp)
+            run_trim(p, "--file", "HANDOFFS.md", "--cut", "2", "--write", "--today", "2026-02-01")
+            live = p / "HANDOFFS.md"
+            text = live.read_text(encoding="utf-8")
+            before = text
+            text = text.replace("# Handoff Receipts", "# Handoff Receipts EDITED", 1)
+            self.assertNotEqual(text, before, "control: the tamper must actually change the file")
+            self.assertIn("# Handoff Receipts", text,
+                         "control: the tamper must be an APPEND -- the original line's text must "
+                         "survive as a literal substring of the new line. That is the exact shape "
+                         "BL-28 names; a full replacement (the sibling test above) is a different "
+                         "shape and does not exercise this defect.")
+            live.write_text(text, encoding="utf-8")
+            shard = sorted((p / "docs" / "archive").glob("HANDOFFS-through-*.md"))[0]
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+            self.assertIn("L2 FRONT MATTER", v.stdout, v.stdout)
+            self.assertNotEqual(v.returncode, 0)
+
+    def test_the_regenerated_field_carve_out_still_works_after_the_fix(self):
+        """NARROWED control — the exact-line-set fix must not turn field_reversible's own carve-out
+        into a false FAIL. The regenerated-count line changes on every archive by construction and
+        must still pass, exactly as `TestVerifyShHandoffFalsePositives` already proves for the
+        pre-fix code; re-asserted here so a fix that over-corrects (e.g. by comparing raw line sets
+        with no field_reversible exemption at all) is caught by this file too."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_handoff_repo(tmp)
+            r = run_trim(p, "--file", "HANDOFFS.md", "--cut", "2", "--write", "--today", "2026-02-01")
+            self.assertIn("[WROTE]", r.stdout, r.stdout)
+            live = (p / "HANDOFFS.md").read_text(encoding="utf-8")
+            self.assertIn("This file currently holds **2**", live,
+                         "control: the regenerated field must actually have changed")
+            shard = sorted((p / "docs" / "archive").glob("HANDOFFS-through-*.md"))[0]
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("OK: L1, L2/front-matter, L3 hold", v.stdout, v.stdout)
+            self.assertEqual(v.returncode, 0)
+
+
+# =============================================================================================
+# BL-36 — the generated proof's INJECTED constant is a 0/1 FLAG, not a count of what the trim
+# commit actually added, so `ar_cmp = ar[INJ:]` skips the wrong number of records and the whole
+# positional comparison shifts. Any trim commit bundled with a second entry to the same ledger
+# fails BY CONSTRUCTION, with zero data loss. Observed on this repo's own shipped artifacts:
+# `CHANGELOG-through-2026-08-02` (commit added 2, INJECTED=1) reports `L3 record count 73 != 72`
+# and `CHANGELOG-through-2026-08-09` (added 3) reports `77 != 75`, while S88's independent
+# identity-keyed re-derivation measured 0 records missing at either trim
+# (docs/audits/2026-08-15-bl36-archive-losslessness.md, Findings #1 and #2).
+#
+# THE REPAIR IS TO MEASURE THE INJECTED SET BY CONTENT, NOT TO RE-PARAMETERIZE THE POSITION.
+# L1/L2/L3 keep their exact semantics: the records the COMMIT introduced are those present in
+# `after ∪ shard` and absent from `before`, computed from record text and removed occurrence-wise
+# before the byte-for-byte comparison runs. That is not circular — it is a different function of
+# the same three artifacts, never the difference L1/L3 are about to assert on (Learning #16).
+#
+# WHAT THIS DELIBERATELY DOES NOT DO: it does not make a record EDITED inside the trim commit
+# pass. Such a record's pre-trim bytes exist nowhere afterwards, so it is genuinely not preserved
+# and BL-27's "stays a loud FAIL" is correct — see TestVerifyShHandoffFalsePositives above, which
+# must stay green. Only ADDITIONS become tolerable, because an added record makes no claim about
+# a record that was already there.
+# =============================================================================================
+
+
+def _insert_records_at_top_of_zone(text, n, tag="bundled extra"):
+    """Prepend n new CHANGELOG-grammar records immediately above the newest existing one."""
+    at = text.index("### ")
+    new = "".join("### 2026-02-01 · [ad hoc] %s %d\n\nbody %d\n\n" % (tag, i, i) for i in range(n))
+    return text[:at] + new + text[at:]
+
+
+class TestVerifyShBundledAddsAreMeasuredNotAssumed(unittest.TestCase):
+
+    def _trim_then_bundle(self, p, mutate, extra=2):
+        """Trim, apply `mutate` to the live ledger, and commit BOTH in one commit — the shape the
+        four failing shipped proofs have. Returns the generated proof's completed process."""
+        r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+        self.assertIn("[WROTE]", r.stdout, r.stdout)
+        live = p / "CHANGELOG.md"
+        before = live.read_text(encoding="utf-8")
+        after = mutate(_insert_records_at_top_of_zone(before, extra))
+        self.assertNotEqual(after, before, "control: the bundled edit must change the live file")
+        live.write_text(after, encoding="utf-8")
+        n_before = len(records_of(before, CL))
+        n_after = len(records_of(after, CL))
+        sh(p, "git", "add", "-A")
+        sh(p, "git", "commit", "-qm", "trim bundled with other ledger writes")
+        shard = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))[0]
+        return sh(p, "bash", str(shard) + ".verify.sh"), n_before, n_after
+
+    def test_a_trim_commit_that_also_adds_records_still_proves_lossless(self):
+        """The BL-36 case itself. Adding entries to the ledger in the trim commit says nothing
+        about whether the archived records survived — and must not be able to fail the proof."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            v, n_before, n_after = self._trim_then_bundle(p, lambda t: t, extra=2)
+            self.assertEqual(n_after - n_before, 2,
+                             "control: the bundle must really have added 2 records to the live file")
+            self.assertIn("OK: L1, L2/front-matter, L3 hold", v.stdout, v.stdout)
+            self.assertEqual(v.returncode, 0, v.stdout)
+
+    def test_the_verdict_does_not_depend_on_HOW_MANY_records_the_commit_added(self):
+        """Kills the whole family of 'bump the constant' mutants. INJECTED=1 happens to be right
+        for a standalone ledger trim, which is why every passing shipped proof has it; the defect
+        only shows once the count is anything else. Three is as legitimate as one."""
+        for extra in (1, 3, 5):
+            with self.subTest(extra=extra), tempfile.TemporaryDirectory() as tmp:
+                p = make_repo(tmp)
+                v, n_before, n_after = self._trim_then_bundle(p, lambda t: t, extra=extra)
+                self.assertEqual(n_after - n_before, extra, "control: the bundle size must be real")
+                self.assertIn("OK: L1, L2/front-matter, L3 hold", v.stdout, v.stdout)
+
+    def test_the_proof_reports_what_the_commit_added_rather_than_staying_silent(self):
+        """A proof that tolerates additions must SAY which ones, or it has quietly widened what it
+        excuses. Audit Finding #4: under the shipped tool the busier ledger's bundling shape got no
+        explanation at all."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            v, _b, _a = self._trim_then_bundle(p, lambda t: t, extra=2)
+            # 3, not 2: the trimmer writes its own `Ledger trim:` entry into CHANGELOG.md as part
+            # of the trim, so a bundle of 2 extras lands 3 new records in the commit. That third
+            # one is exactly what the old INJECTED=1 constant modelled — correctly, and only ever
+            # when it was alone.
+            self.assertIn("added by the trim commit: 3", v.stdout, v.stdout)
+            self.assertIn("bundled extra 0", v.stdout,
+                          "the added records must be named, not just counted")
+            self.assertIn("Ledger trim:", v.stdout,
+                          "the trim's own entry is an added record like any other")
+
+    def test_NARROWED_tolerating_ADDS_must_not_tolerate_a_LOSS(self):
+        """The plausible weak implementation — 'ignore any count mismatch' — passes the test above
+        and this one too. Dropping a retained record in the same commit must still be caught."""
+        def drop_oldest_retained(text):
+            heads = re.findall(r"(?m)^### .*$", text)
+            self.assertGreater(len(heads), 3, "control: there must be a retained record to drop")
+            return text[:text.index(heads[-1])]
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            v, _b, _a = self._trim_then_bundle(p, drop_oldest_retained, extra=2)
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+            self.assertIn("missing", v.stdout.lower(), v.stdout)
+            self.assertNotEqual(v.returncode, 0, "a bundled ADD must never launder a real loss")
+
+    def test_NARROWED_tolerating_ADDS_must_not_tolerate_a_REORDER(self):
+        """The other plausible weak implementation — compare record MULTISETS and drop the
+        byte-concatenation entirely. Multisets are order-blind, so a ledger silently reordered in
+        the trim commit would pass. L1 still carries the ordering claim; this pins that."""
+        def swap_two_retained(text):
+            z = mod.classify_zones(text, CL, mod.Result("x"))
+            recs = z.records()
+            self.assertGreater(len(recs), 4, "control: there must be two retained records to swap")
+            # The LAST two, and the control below is load-bearing: the first records in this file
+            # are the ones the commit ADDED (2 bundled extras, then the trimmer's own entry), and
+            # those are dropped before the ordering comparison runs. Swapping two of THEM is
+            # correctly invisible, so a test that did it would pass while proving nothing — which
+            # is what the first draft of this test did.
+            for r in (recs[-1], recs[-2]):
+                self.assertIn("[ad hoc] entry ", r.splitlines()[0],
+                              "control: both swapped records must be pre-existing retained ones, "
+                              "not records this commit added")
+            recs[-1], recs[-2] = recs[-2], recs[-1]
+            return z.front + "".join(recs) + z.footer
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            v, _b, _a = self._trim_then_bundle(p, swap_two_retained, extra=2)
+            self.assertIn("FAIL:", v.stdout, v.stdout)
+            self.assertNotEqual(v.returncode, 0, "reordering is not losslessness")
+
+    def test_the_template_no_longer_bakes_a_positional_INJECTED_constant(self):
+        """Coupling guard, not a presence grep: the tests above all run through the generated
+        script, so they would still pass if a constant were baked in AND happened to be right.
+        This pins that the mechanism itself is gone from the shipped template, which is what makes
+        a future 'just set INJECTED=2' regression impossible rather than merely unlikely."""
+        src = TRIM_PY.read_text(encoding="utf-8")
+        self.assertIn("VERIFY_TEMPLATE", src, "control: the template must still be here to check")
+        template = src.split("VERIFY_TEMPLATE = r\"\"\"", 1)[1].split("\n\"\"\"", 1)[0]
+        self.assertGreater(len(template), 2000, "control: the extracted template must be the real one")
+        self.assertNotIn("@@INJECTED@@", template)
+        self.assertNotIn("ar[INJ:]", template)
+
+
+# =============================================================================================
+# Regression tests for the defects an adversarial review found in the first build of this tool.
+# Each one existed BECAUSE the corresponding guard was wired to the wrong operand and no test
+# noticed. They mutate the WRITE PATH — not the predicate — because mutating the predicate is
+# exactly what the first mutation harness did, and it scored 13/13 while all three assertions
+# were tautologies at their only production call site.
+# =============================================================================================
+
+class TestWritePathIsActuallyGated(unittest.TestCase):
+
+    def _run_in_proc(self, repo, **patches):
+        """Run evaluate() in-process with parts of the write path mutated."""
+        saved = {k: getattr(mod, k) for k in patches}
+        for k, v in patches.items():
+            setattr(mod, k, v)
+        cwd = os.getcwd()
+        try:
+            os.chdir(str(repo))
+            opts = type("O", (), dict(write=True, check=False, cut=None, budget_bytes=40000,
+                                      force=False, today="2026-02-01"))()
+            r = mod.Result(Path("CHANGELOG.md"))
+            mod.evaluate(Path("CHANGELOG.md"), opts, r)
+            return r
+        finally:
+            os.chdir(cwd)
+            for k, v in saved.items():
+                setattr(mod, k, v)
+
+    def test_control_the_unmutated_write_path_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = self._run_in_proc(p)
+            self.assertIn("L1_OK", r.codes, [f.message for f in r.findings])
+            self.assertIn("L3_OK", r.codes)
+            self.assertIn("WROTE", r.codes)
+
+    def test_a_shard_that_silently_drops_a_record_is_REFUSED_before_the_write(self):
+        """The defect: assertions were wired to records[:k] + records[k:] == records, an identity.
+        A shard body missing its oldest record was written with [L1_OK] [L2_OK] [L3_OK] [WROTE]."""
+        real = mod.build_shard
+        drop = lambda spec, live, shard, recs, span, key: real(spec, live, shard, recs[:-1], span, key)
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = self._run_in_proc(p, build_shard=drop)
+            self.assertNotIn("WROTE", r.codes, "a record-losing trim must never be written")
+            self.assertIn("L1_MISMATCH", r.codes)
+            self.assertIn("L3_RECORD_COUNT", r.codes)
+            self.assertEqual(sh(p, "git", "status", "--porcelain").stdout.strip(), "",
+                             "nothing may reach the working tree")
+
+    def test_a_trim_that_drops_the_footer_is_REFUSED(self):
+        """Proves L2 is wired to the ARTIFACT, not to the input. With `assert_L2` handed the
+        before-footer as its after-footer, this passes with [L2_OK] and the footer is destroyed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp, footer=True)
+            z = mod.classify_zones((p / "CHANGELOG.md").read_text(encoding="utf-8"),
+                                   CL, mod.Result("x"))
+            self.assertTrue(z.footer.strip(), "control: the fixture must have a footer to drop")
+            r = self._run_in_proc(p, assemble_live=lambda f, ret, foot: f + "".join(ret))
+            self.assertNotIn("WROTE", r.codes, "a footer-dropping trim must never be written")
+            self.assertIn("L2_FOOTER_ALTERED", r.codes, [f.message for f in r.findings])
+            self.assertEqual(sh(p, "git", "status", "--porcelain").stdout.strip(), "")
+
+    def test_control_a_footered_ledger_trims_cleanly(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp, footer=True)
+            r = self._run_in_proc(p)
+            self.assertIn("WROTE", r.codes, [f.message for f in r.findings])
+            self.assertIn("L2_OK", r.codes)
+
+    def test_the_recorded_size_is_the_size_of_the_file_actually_written(self):
+        """The entry states the live file's post-trim size, and the entry is IN that file."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--budget-bytes", "40000",
+                     "--today", "2026-02-01")
+            text = (p / "CHANGELOG.md").read_text(encoding="utf-8")
+            m = re.search(r"Live file [\d,]+ B → ([\d,]+) B", text)
+            self.assertIsNotNone(m, "control: the entry must state a post-trim size")
+            claimed = int(m.group(1).replace(",", ""))
+            actual = len(text.encode("utf-8"))
+            self.assertEqual(claimed, actual,
+                             "the frozen record must not be short by the length of its own entry")
+
+
+class TestReviewRegressions(unittest.TestCase):
+
+    def test_a_cut_key_that_would_nest_the_shard_is_refused(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            sh(p, "git", "tag", "rel/v1.0")
+            self.assertEqual(sh(p, "git", "rev-parse", "--verify", "rel/v1.0").returncode, 0,
+                             "control: the ref must exist, or CUT_UNKNOWN_REF fires first")
+            r = run_trim(p, "--file", "CHANGELOG.md", "--cut", "@rel/v1.0",
+                         "--budget-bytes", "40000", "--write", "--today", "2026-02-01")
+            self.assertIn("[CUT_KEY_UNSAFE]", r.stdout, r.stdout)
+            self.assertFalse(list((p / "docs" / "archive").rglob("*.md")),
+                             "no shard may be created outside the flat namespace")
+
+    def test_a_same_month_trim_works(self):
+        """Every synthetic fixture crosses a month boundary (2026-01 records, --today 2026-02-01),
+        so `month_heading` was never empty and the empty declared-insertion path was unreachable.
+        The real CHANGELOG.md is same-month, and it broke there. Cover both."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--budget-bytes", "40000",
+                         "--today", "2026-01-31")
+            self.assertNotIn("[LEDGER_MONTH_BOUNDARY]", r.stdout,
+                             "control: this run must NOT cross a month boundary")
+            self.assertNotIn("[L2_DECLARED_INSERT_MISSING]", r.stdout, r.stdout)
+            self.assertIn("[L2_OK]", r.stdout, r.stdout)
+            self.assertIn("[WROTE]", r.stdout, r.stdout)
+            v = sh(p, "bash", str(sorted((p / "docs" / "archive").glob("*.verify.sh"))[0]))
+            self.assertIn("OK:", v.stdout, v.stdout)
+
+    def test_the_month_boundary_is_reported_not_silently_misfiled(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--budget-bytes", "40000",
+                         "--today", "2026-02-01")
+            self.assertIn("[LEDGER_MONTH_BOUNDARY]", r.stdout,
+                          "a trim in a new month must say so; the fixture is all 2026-01")
+            self.assertIn("[L2_OK]", r.stdout, "and the new heading must not trip L2")
+
+    def test_the_proof_catches_a_front_matter_line_deleted_after_the_trim(self):
+        """Design §4.2's L2 has a front-matter half; the first proof script had none, and printed
+        'L1, L2 and L3 hold' after running zero L2 assertions on both real ledgers."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--budget-bytes", "40000",
+                     "--today", "2026-02-01")
+            live = p / "CHANGELOG.md"
+            text = live.read_text(encoding="utf-8")
+            self.assertIn("Front matter prose", text, "control: the line must be there to delete")
+            live.write_text(text.replace("Front matter prose about [the runner](SESSION_RUNNER.md).",
+                                         "", 1), encoding="utf-8")
+            v = sh(p, "bash", str(sorted((p / "docs" / "archive").glob("*.verify.sh"))[0]))
+            self.assertIn("L2 FRONT MATTER lost", v.stdout, v.stdout)
+            self.assertNotEqual(v.returncode, 0)
+
+    def test_the_proof_names_the_clauses_it_actually_ran(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--budget-bytes", "40000",
+                     "--today", "2026-02-01")
+            v = sh(p, "bash", str(sorted((p / "docs" / "archive").glob("*.verify.sh"))[0]))
+            self.assertIn("checked: L1, L2/front-matter, L3", v.stdout)
+            self.assertNotIn("L2/footer", v.stdout,
+                             "this fixture has no footer, so the footer clause must NOT be claimed")
+
+
+    def test_a_footered_ledger_keeps_its_footer_live_and_out_of_the_shard(self):
+        """W7: with no footer in any end-to-end fixture, L2's footer clauses were unreachable from
+        integration — the tool could be handed the BEFORE footer as its AFTER footer and no test
+        would notice. This fixture has one, shaped like the real pre-v3.0 scope footer that the
+        `020ba3f` archive actually lost."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp, footer=True)
+            z = mod.classify_zones((p / "CHANGELOG.md").read_text(encoding="utf-8"),
+                                   CL, mod.Result("x"))
+            self.assertIn("Release history before v3.0", z.footer,
+                          "control: the fixture must actually HAVE a footer zone")
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--budget-bytes", "40000",
+                         "--today", "2026-02-01")
+            self.assertIn("[L2_OK]", r.stdout, r.stdout)
+            live = (p / "CHANGELOG.md").read_text(encoding="utf-8")
+            shard = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))[0]
+            body = shard.read_text(encoding="utf-8")
+            self.assertIn("Release history before v3.0", live, "the footer is pinned to live")
+            self.assertNotIn("Release history before v3.0", body, "and must not reach the shard")
+            after = mod.classify_zones(live, CL, mod.Result("x"))
+            self.assertEqual(after.footer, z.footer, "byte-identical, not merely present")
+            v = sh(p, "bash", str(shard) + ".verify.sh")
+            self.assertIn("L2/footer", v.stdout, "the proof must now RUN the footer clause")
+            self.assertIn("OK:", v.stdout, v.stdout)
+
+    def test_a_footered_ledger_refuses_when_the_footer_would_migrate(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp, footer=True)
+            z = mod.classify_zones((p / "CHANGELOG.md").read_text(encoding="utf-8"),
+                                   CL, mod.Result("x"))
+            r = mod.Result("x")
+            ok = mod.assert_L2(z, z.front + "PTR\n", "", "shard\n" + z.footer, ["PTR\n"], [], r)
+            self.assertFalse(ok)
+            self.assertIn("L2_FOOTER_ALTERED", r.codes)
+            self.assertIn("L2_FOOTER_MOVED", r.codes)
+
+    def test_the_transform_is_exercised_end_to_end(self):
+        """The e2e fixtures previously had zero links inside records, so `transform_record` was the
+        identity in every integration test and the proof's inverse could be deleted unnoticed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            run_trim(p, "--file", "CHANGELOG.md", "--write", "--budget-bytes", "40000",
+                     "--today", "2026-02-01")
+            shard = sorted((p / "docs" / "archive").glob("CHANGELOG-through-*.md"))[0]
+            body = shard.read_text(encoding="utf-8")
+            self.assertIn("](../../SESSION_RUNNER.md)", body, "root-relative targets must rebase")
+            self.assertIn("](https://example.com/a)", body, "absolute URLs must not")
+            self.assertIn("](#f)", body, "fragments must not")
+
+    def test_the_footer_moved_clause_sees_through_the_rebase(self):
+        """A footer swept into the records zone is transformed on its way into the shard, so a
+        verbatim substring test misses it. The real 020ba3f footer contains exactly such a link."""
+        z = mod.classify_zones(SYNTHETIC_CHANGELOG, CL, mod.Result("x"))
+        self.assertIn("](", z.footer, "control: the fixture footer must contain a rebasable link")
+        rebased = mod.transform_record(z.footer)
+        self.assertNotEqual(rebased, z.footer, "control: the rebase must actually change it")
+        self.assertNotIn(z.footer.strip(), rebased, "control: verbatim substring no longer matches")
+        r = mod.Result("x")
+        ok = mod.assert_L2(z, z.front + "PTR\n", z.footer, "shard\n" + rebased, ["PTR\n"], [], r)
+        self.assertFalse(ok, "the transformed footer must still be detected in the shard")
+        self.assertIn("L2_FOOTER_MOVED", r.codes)
+
+    def test_the_trigger_needs_no_baseline_to_decide(self):
+        """What replaced the abstention machinery. The line RATE needed a baseline commit to
+        compute records-per-line, and abstained out loud when it could not get one — three
+        distinct abstention paths. Both arms are LEVELS now, so a fresh Trigger with no history
+        is already answerable, and there is nothing left to abstain about."""
+        t = mod.Trigger()
+        self.assertTrue(t.stops(10), "a level needs no baseline")
+        for gone in ("line_headroom", "line_abstains", "line_fires"):
+            self.assertFalse(hasattr(t, gone), "%s went with the line arm" % gone)
+
+    def test_srf_reports_both_boundaries_and_the_refusal_uses_the_most_recent(self):
+        """The design's one explicitly-labelled departure from H3. Every other fixture creates a
+        single archive event, so most-recent and largest-drop coincide and the choice is untested.
+        Here the two events are built directly, with deliberately different drops."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp, n_records=40, body=3000)
+            arch = p / "docs" / "archive"
+
+            def event(name, keep):
+                """Shrink the live file to `keep` records and add a shard in the same commit."""
+                z = mod.classify_zones(read_live(p), CL, mod.Result("x"))
+                recs = z.records()
+                (arch / name).write_text("# shard\n\n" + "".join(recs[keep:]), encoding="utf-8")
+                (p / "CHANGELOG.md").write_text(z.front + "".join(recs[:keep]) + z.footer,
+                                                encoding="utf-8")
+                sh(p, "git", "add", "-A")
+                sh(p, "git", "commit", "-qm", "archive " + name)
+
+            def read_live(repo):
+                return (repo / "CHANGELOG.md").read_text(encoding="utf-8")
+
+            event("CHANGELOG-through-2026-01-10.md", 8)     # event 1: the LARGE drop
+            # regrow a little, then a second, SMALLER drop
+            z = mod.classify_zones(read_live(p), CL, mod.Result("x"))
+            grow = "".join("### 2026-03-%02d · [ad hoc] g%d\n\n%s\n\n" % (i % 28 + 1, i, "y" * 800)
+                           for i in range(6))
+            (p / "CHANGELOG.md").write_text(z.front + grow + "".join(z.records()) + z.footer,
+                                            encoding="utf-8")
+            sh(p, "git", "add", "-A")
+            sh(p, "git", "commit", "-qm", "growth")
+            event("CHANGELOG-through-2026-03-06.md", 10)    # event 2: the SMALLER drop
+
+            events = mod.archive_events(p, CL)
+            self.assertEqual(len(events), 2, "control: the fixture must create TWO archive events")
+            # Ordering must follow the COMMIT GRAPH, not %ct (ties) and not sha (arbitrary).
+            newer = sh(p, "git", "rev-list", "--topo-order", "HEAD").stdout.split()
+            self.assertLess(newer.index(events[1][0]), newer.index(events[0][0]),
+                            "archive_events must return oldest-first by commit-graph position")
+            drops = [pre - post for _sha, pre, post, _rel in events]
+            self.assertNotEqual(drops[0], drops[1],
+                                "control: the drops must differ, or nothing is being chosen between")
+            self.assertGreater(drops[0], drops[1],
+                               "control: the LARGEST drop must be the OLDER event, so the two "
+                               "boundary policies genuinely disagree")
+
+            # Regrow past both boundaries so BOTH SRFs are positive — otherwise the ratio is
+            # meaningless and the tool correctly declines to print one, and the test would be
+            # asserting on a branch it never reaches.
+            z = mod.classify_zones(read_live(p), CL, mod.Result("x"))
+            regrow = "".join("### 2026-05-%02d · [ad hoc] r%d\n\n%s\n\n" % (i % 28 + 1, i, "z" * 2500)
+                             for i in range(45))
+            (p / "CHANGELOG.md").write_text(z.front + regrow + "".join(z.records()) + z.footer,
+                                            encoding="utf-8")
+            out = run_trim(p, "--file", "CHANGELOG.md", "--check").stdout
+            self.assertNotIn("non-positive", out,
+                             "control: both SRFs must be positive, or no ratio is printed")
+            self.assertIn("vs the most recent archive", out, out)
+            self.assertIn("H3's largest-drop boundary", out, out)
+            self.assertIn("policy addition on top of H3", out,
+                          "the departure must be labelled as a departure, per design §5.3")
+            # And the two reported values must actually differ — otherwise the label is decoration.
+            m = re.search(r"SRF ([\d.]+) vs the most recent archive \w+; ([\d.-]+) vs H3", out)
+            self.assertIsNotNone(m, out)
+            self.assertNotEqual(m.group(1), m.group(2),
+                                "the two boundaries must yield different SRFs in this fixture")
+
+
+# =============================================================================================
+# GRAMMAR_MISMATCH — a file the grammar cannot read must not be reported as a file with nothing
+# in it. UAT finding F1 (docs/planning/uat-2026-08-04-six-adopters.md §4).
+#
+# The defect these pin: evaluate() answered `[NO_RECORDS] ... nothing to archive. (A freshly
+# seeded ledger looks exactly like this, and must not be trimmed.)` AT EXIT 0 for a 597,717 B
+# ledger holding 130 dated entries and a 1,239,085 B ledger keying entries on table rows, because
+# neither
+# uses the declared `### YYYY-MM-DD · [tag]` heading. A 1.2 MB ledger and a 324 B fresh seed
+# produced byte-identical output and the same exit status, and the message actively reassured.
+#
+# EVERY FIXTURE HERE IS A LITERAL, ON PURPOSE. The shapes are copied from real adopter ledgers
+# and each one's real-world source and measurements are named in its docstring, but no test reads
+# a sibling repository: a suite that does is green or red depending on which checkouts happen to
+# sit beside this one, which is not a property of this code. The two seed fixtures come from
+# `show("HEAD:...")`, not from the working tree — a working-tree read measures a file nobody
+# shipped, and during the design review for this very change an agent left an uncommitted edit in
+# `starter-kit/CHANGELOG.md` that would have silently redefined the control.
+#
+# ON ASSERTING `Result.exit` HERE. This file's own rule is "assert on named findings, never on
+# the exit code," and design §6.3 states its reason: the exit code "is a union over every check
+# the tool runs." That union is `main()`'s `worst = max(...)` across `--file` arguments
+# (methodology_trim.py:1629-1635). `Result.exit` is per-evaluation, and in this branch evaluate()
+# returns immediately, so the union is over exactly one check — which each test asserts by
+# checking `len(r.codes) == 1` beside it. The exit status is pinned because it is half of what
+# F1 reports: a mutant that keeps the code and drops `exit_code=3` produces identical `codes`,
+# and asserting codes alone lets exactly the reported defect back in.
+# =============================================================================================
+
+SEED_CL = "HEAD:starter-kit/CHANGELOG.md"
+SEED_HF = "HEAD:starter-kit/HANDOFFS.md"
+
+
+def one_file_repo(tmp, name, data):
+    """A scratch git repo holding exactly one ledger. Bytes in, never a template."""
+    p = Path(tmp)
+    (p / name).write_bytes(data.encode("utf-8") if isinstance(data, str) else data)
+    sh(p, "git", "init", "-q", ".")
+    sh(p, "git", "config", "user.email", "t@t")
+    sh(p, "git", "config", "user.name", "T")
+    sh(p, "git", "add", "-A")
+    sh(p, "git", "commit", "-qm", "seed")
+    return p
+
+
+def ev(repo, name, **optkw):
+    """evaluate() in-process against `repo`. Mirrors TestWritePathIsActuallyGated._run_in_proc."""
+    kw = dict(write=False, check=False, cut=None, budget_bytes=None, force=False,
+              today="2026-08-04")
+    kw.update(optkw)
+    cwd = os.getcwd()
+    try:
+        os.chdir(str(repo))
+        r = mod.Result(Path(name))
+        mod.evaluate(Path(name), type("O", (), kw)(), r)
+        return r
+    finally:
+        os.chdir(cwd)
+
+
+def evaluate_text(case, name, data, **optkw):
+    with tempfile.TemporaryDirectory() as tmp:
+        return ev(one_file_repo(tmp, name, data), name, **optkw)
+
+
+# The two shapes F1 found in the wild, reduced to literals. Neither matches
+# `^### \d{4}-\d{2}-\d{2} · \[` — the first uses a U+2014 em dash where the grammar wants a
+# U+00B7 middle dot plus a bracketed source tag; the second keys entries on table rows under
+# `## YYYY-MM` group headings and has no dated `###` heading at all.
+MISMATCH_EMDASH = "# Changelog\n\nThe action ledger.\n\n" + "".join(
+    "### 2026-07-%02d — did a thing (Session %d)\n\n- Change: something real.\n\n" % (i % 28 + 1, i)
+    for i in range(12))
+
+MISMATCH_TABLE = "# Changelog\n\n## 2026-08\n\n| Item | Date | Notes |\n|------|------|-------|\n" + \
+    "".join("| **Did a thing %d** | 2026-08-%02d | Session %d. Notes. |\n" % (i, i % 28 + 1, i)
+            for i in range(12))
+
+
+class TestGrammarMismatchFixtureControls(unittest.TestCase):
+    """Prove each fixture IS what the tests below assume, before anything is asserted about code.
+
+    Without these, every assertion downstream can pass for the wrong reason — a fixture that
+    quietly stopped being a mismatch would make the mismatch tests green by accident.
+    """
+
+    def test_the_seed_fixtures_are_reachable_and_are_the_shipped_seeds(self):
+        for ref in (SEED_CL, SEED_HF):
+            text = show(ref)
+            self.assertIsNotNone(text, "%s is unreachable — history changed" % ref)
+            self.assertIn(mod_seed_sentinel(), text,
+                          "%s must still carry the seed sentinel — the fixtures below build on it" % ref)
+
+    def test_the_seed_fixtures_hold_zero_records_AND_zero_probe_hits(self):
+        """The seed is only a control if BOTH halves hold: no records, and nothing that looks like one."""
+        cl = show(SEED_CL)
+        self.assertEqual(records_of(cl, CL), [], "a freshly seeded ledger has no records")
+        self.assertEqual(probe_hits_of(cl, CL), [],
+                         "the shipped CHANGELOG seed must produce zero content-probe hits — if a "
+                         "future edit adds a dated heading to its prose, fix the seed, not the probe")
+
+    def test_the_mismatch_fixtures_really_do_fail_the_declared_grammar(self):
+        """Both fixtures must hold zero records under the grammar AND real content under the probe."""
+        for label, data, want_hits in (("em dash", MISMATCH_EMDASH, 12),
+                                       ("table rows", MISMATCH_TABLE, 12)):
+            self.assertEqual(records_of(data, CL), [], "%s fixture must parse to zero records" % label)
+            self.assertEqual(len(probe_hits_of(data, CL)), want_hits,
+                             "%s fixture must carry %d probe-visible lines" % (label, want_hits))
+
+    def test_the_mismatch_fixtures_are_UNDER_both_size_signals(self):
+        """This is what makes them tests of the PROBE rather than tests of the size rule.
+
+        Both real files F1 names are over the byte ceiling, so a probe-free implementation would
+        catch them and ship the probe decorative. Two real adopter ledgers are not:
+        `claims-model-starter.wiki/CHANGELOG.md` (28,300 B / 269 lines / 11 probe hits) and
+        `feedback-loop-comparison/CHANGELOG.md` (7,067 B / 41 lines / 4 hits), both under both
+        limits and both misreported as empty by the shipped tool. These literals stand in for them.
+        """
+        for label, data in (("em dash", MISMATCH_EMDASH), ("table rows", MISMATCH_TABLE)):
+            self.assertLess(len(data.encode("utf-8")), mod.SEED_PLAUSIBLE_MAX_BYTES,
+                            "%s fixture must be under the byte ceiling" % label)
+            self.assertLess(len(data.splitlines()), mod.SEED_PLAUSIBLE_MAX_LINES,
+                            "%s fixture must be under the line ceiling" % label)
+
+
+class TestGrammarMismatch(unittest.TestCase):
+
+    # --- the genuine-seed half: must stay exit 0 -------------------------------------------
+
+    def test_the_shipped_CHANGELOG_seed_is_still_reported_as_a_fresh_seed(self):
+        r = evaluate_text(self, "CHANGELOG.md", show(SEED_CL))
+        self.assertEqual(r.codes, ["NO_RECORDS"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 0, "a day-one adopter must not be told their ledger is broken")
+
+    def test_the_shipped_HANDOFFS_seed_is_still_reported_as_a_fresh_seed(self):
+        r = evaluate_text(self, "HANDOFFS.md", show(SEED_HF))
+        self.assertEqual(r.codes, ["NO_RECORDS"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 0)
+
+    def test_a_hand_rolled_empty_ledger_with_no_sentinel_is_still_exit_0(self):
+        """Copied from ../airqino/CHANGELOG.md, a real 324 B seed that is NOT ours.
+
+        It carries no sentinel, so the exemption cannot save it — only the absence of every
+        signal does. This is the case that fails first if a size floor is tightened carelessly.
+        """
+        data = ("# Changelog\n\nAll notable changes to this project are documented here.\n"
+                "Format loosely follows [Keep a Changelog](https://keepachangelog.com/).\n\n"
+                "When completing work, remove the item from `BACKLOG.md` and add an entry here.\n\n"
+                "## [Unreleased]\n\n"
+                "<!-- Add entries here as work is completed. Group by month when the list grows. -->\n")
+        self.assertNotIn(mod_seed_sentinel(), data, "control: this fixture has no sentinel")
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["NO_RECORDS"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 0)
+
+    def test_dated_PROSE_in_a_sealed_seed_does_not_trip_the_probe(self):
+        """Two independent guards, and this asserts BOTH are needed.
+
+        A design-review agent added exactly this sentence to the shipped seed while probing this
+        change. The anchored probe ignores it (it is not heading- or row-shaped) AND the sentinel
+        exemption would cover it anyway. Belt and braces, because the seed is a file adopters get.
+        """
+        data = show(SEED_CL).replace(
+            "## How to add an entry",
+            "For instance an entry dated 2026-01-15 sits above one dated 2026-01-14.\n\n"
+            "## How to add an entry", 1)
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["NO_RECORDS"], [f.message for f in r.findings])
+
+    # --- the mismatch half: must refuse, loudly ---------------------------------------------
+
+    def test_an_em_dash_ledger_under_both_size_limits_is_refused_by_the_probe_alone(self):
+        """RED against the shipped tool, which answers [NO_RECORDS] at exit 0.
+
+        Shape of ../model_project_constructor/CHANGELOG.md (597,717 B, 130 entries), reduced to a
+        size where ONLY the probe can fire.
+        """
+        r = evaluate_text(self, "CHANGELOG.md", MISMATCH_EMDASH)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+        self.assertEqual(len(r.codes), 1)
+        self.assertEqual(r.exit, 3, "a file the grammar cannot read is not a file with nothing in it")
+
+    def test_a_table_row_ledger_under_both_size_limits_is_refused_by_the_probe_alone(self):
+        """Shape of ../wsfct/CHANGELOG.md — 1,239,085 B, entries as table rows under 8 `## YYYY-MM`
+        group headings (`grep -cE '^## [0-9]{4}-[0-9]{2}$'` = 8), 87 probe-visible lines."""
+        r = evaluate_text(self, "CHANGELOG.md", MISMATCH_TABLE)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 3)
+
+    def test_the_refusal_names_the_evidence_instead_of_reassuring(self):
+        """F1's core complaint was the WORDING, not only the code: the message reassured.
+
+        The refusal has to carry what a reader needs to act — how big the file is, how many lines
+        the probe saw, where the first one is, and what the grammar actually wants — and must not
+        repeat the fresh-seed reassurance.
+        """
+        r = evaluate_text(self, "CHANGELOG.md", MISMATCH_EMDASH)
+        msg = r.findings[0].message
+        self.assertNotIn("freshly seeded", msg, "the mismatch must not reuse the seed reassurance")
+        self.assertNotIn("nothing to archive", msg)
+        # Anchored to the label, not a bare "12": the byte and line counts also contain "12", so a
+        # substring check passed a mutant that deleted the count entirely.
+        self.assertIn("content probe: 12", msg, "the probe hit count must be stated")
+        self.assertRegex(msg, r"\b5\b|\bline 5\b|:5\b", "the first unparsed line must be located")
+        self.assertIn("2026-07-01 — did a thing", msg, "the first unparsed line must be quoted")
+        self.assertIn(CL.record_start.pattern, msg, "the declared grammar must be shown")
+
+    def test_the_quoted_line_is_bounded(self):
+        """A real table-row ledger stores 900+ character rows; ZONE_UNCLASSIFIED bounds at 400."""
+        long_row = "| **x** | 2026-08-01 | " + ("y" * 4000) + " |\n"
+        r = evaluate_text(self, "CHANGELOG.md", "# Changelog\n\n" + long_row)
+        self.assertIn("GRAMMAR_MISMATCH", r.codes)
+        self.assertLess(len(r.findings[0].message), 1200,
+                        "an unbounded quote turns one finding into a screenful")
+
+    # --- the size signals, each isolated ----------------------------------------------------
+
+    def test_a_file_over_the_byte_ceiling_is_refused_with_zero_probe_hits(self):
+        """Isolates the byte signal: no dates anywhere, so only size can fire."""
+        data = "# Changelog\n\n" + ("z" * (mod.SEED_PLAUSIBLE_MAX_BYTES + 1)) + "\n"
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 3)
+
+    def test_a_file_of_exactly_the_byte_ceiling_is_NOT_refused(self):
+        """The `>` edge. Without this, `>` and `>=` are indistinguishable."""
+        head = "# Changelog\n\n"
+        data = head + ("z" * (mod.SEED_PLAUSIBLE_MAX_BYTES - len(head)))
+        self.assertEqual(len(data.encode("utf-8")), mod.SEED_PLAUSIBLE_MAX_BYTES,
+                         "control: the fixture must be EXACTLY the ceiling, not near it")
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["NO_RECORDS"], [f.message for f in r.findings])
+
+    def test_a_file_over_the_read_cap_is_refused_even_though_it_is_under_budget(self):
+        """Isolates the line signal: 2,402 short lines, 33 KB, no dates.
+
+        No file in the audited portfolio has this shape — zero records AND over 2,000 lines — so
+        this signal has no real-world fixture and is pinned synthetically. It exists because the
+        `Read` truncation it guards is the whole reason the trimmer exists.
+        """
+        data = "# Changelog\n\n" + "".join("- bullet %04d\n" % i for i in range(2400))
+        self.assertLess(len(data.encode("utf-8")), mod.SEED_PLAUSIBLE_MAX_BYTES,
+                        "control: must be UNDER the byte ceiling, or this tests the wrong signal")
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+
+    def test_a_file_of_exactly_the_seed_plausibility_line_ceiling_is_NOT_refused(self):
+        data = "".join("line %04d\n" % i for i in range(mod.SEED_PLAUSIBLE_MAX_LINES))
+        self.assertEqual(len(data.splitlines()), mod.SEED_PLAUSIBLE_MAX_LINES, "control: exactly the ceiling")
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["NO_RECORDS"], [f.message for f in r.findings])
+
+    # --- the sentinel exemption, and its limits ---------------------------------------------
+
+    def test_a_sealed_seed_that_grew_past_the_byte_ceiling_is_refused(self):
+        """Size was never exemptible, and still is not now that nothing is."""
+        data = show(SEED_CL) + ("\nz" * mod.SEED_PLAUSIBLE_MAX_BYTES)
+        self.assertIn(mod_seed_sentinel(), data, "control: the fixture still carries the marker")
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+
+    def test_a_receipt_ledger_that_kept_its_sentinel_while_filling_up_is_still_refused(self):
+        """The receipt ledger's half of the conjunction, and it is not hypothetical.
+
+        ../church_growth/HANDOFFS.md carries METHODOLOGY-SEED-SENTINEL today alongside 19 real
+        receipts — an adopter who simply never deleted the comment. That file happens to parse, so
+        it never reaches this branch; one that did NOT parse would be handed a permanent silent
+        exit 0 by a sentinel nobody removed. The seed's own rule is the fix: fresh means the token
+        AND no `session:` blocks below. Two producer mutants (dropping this negation, and keying it
+        on ```handoff instead) survived until this test existed.
+        """
+        data = ("# Handoff Receipts\n\n<!-- " + mod_seed_sentinel() + ": fresh receipt ledger -->\n\n" +
+                "".join("## Session %d — 2026-08-%02d\n\nsession: S%d\ndate: 2026-08-%02d\nDid a thing.\n\n"
+                        % (i, i % 28 + 1, i, i % 28 + 1) for i in range(8)))
+        self.assertIn(mod_seed_sentinel(), data, "control: the sentinel really is present")
+        self.assertEqual(records_of(data, HF), [], "control: zero records under the fence grammar")
+        self.assertGreater(len(probe_hits_of(data, HF)), 0, "control: the probe must fire")
+        r = evaluate_text(self, "HANDOFFS.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 3)
+
+    def test_a_receipt_ledger_in_the_wrong_shape_is_refused_by_the_probe(self):
+        """The receipt ledger's PROBE, exercised behaviourally rather than by a fixture control.
+
+        An earlier revision of this class lost this test in an edit, leaving `drop HANDOFFS probe`
+        killable only by another test's control assertion — coverage by accident. Shape: receipts as
+        dated headings instead of ```handoff fences, with NO out-of-fence `session:` lines, so the
+        negation is silent and only the probe can fire. No sentinel, so nothing else is in play.
+        """
+        data = ("# Handoff Receipts\n\nReceipts below.\n\n" +
+                "".join("## Session %d — 2026-08-%02d\n\nDid a thing.\n\n" % (i, i % 28 + 1)
+                        for i in range(8)))
+        self.assertEqual(records_of(data, HF), [], "control: zero records under the fence grammar")
+        self.assertEqual(negations_of(data, HF), 0,
+                         "control: the NEGATION must be silent, or this tests the wrong signal")
+        self.assertGreater(len(probe_hits_of(data, HF)), 0, "control: the probe is the live signal")
+        self.assertLess(len(data.encode("utf-8")), mod.SEED_PLAUSIBLE_MAX_BYTES)
+        self.assertLess(len(data.splitlines()), mod.SEED_PLAUSIBLE_MAX_LINES)
+        r = evaluate_text(self, "HANDOFFS.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 3)
+
+    def test_bare_session_blocks_with_no_headings_are_refused_by_the_negation_alone(self):
+        """The gap that existed while `negations` was computed and then thrown away.
+
+        A receipt ledger written as bare `session:` blocks — no fences for the grammar, and no
+        dated headings for the content probe — sat under both size limits and reported NO_RECORDS
+        at exit 0, which is F1 intact in the very file the probe had just been extended to cover.
+        The seed's own freshness test already knew better: it asks whether any `session:` block has
+        been recorded below, and here the answer is yes.
+        """
+        data = ("# Handoff Receipts\n\nReceipts below.\n\n" +
+                "".join("session: S%d\ndate: 2026-08-%02d\nstatus: complete\nDid a thing.\n\n"
+                        % (i, i % 28 + 1) for i in range(8)))
+        self.assertEqual(records_of(data, HF), [], "control: zero records under the fence grammar")
+        self.assertEqual(probe_hits_of(data, HF), [],
+                         "control: the PROBE must find nothing, or this tests the wrong signal")
+        self.assertLess(len(data.encode("utf-8")), mod.SEED_PLAUSIBLE_MAX_BYTES)
+        self.assertLess(len(data.splitlines()), mod.SEED_PLAUSIBLE_MAX_LINES)
+        r = evaluate_text(self, "HANDOFFS.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+        self.assertEqual(r.exit, 3)
+
+    def test_a_documentation_example_quoting_the_sentinel_cannot_seal_a_real_ledger(self):
+        """The sentinel check is fence-aware, like both signals beside it.
+
+        A ledger that merely QUOTES the token inside a fenced example — documenting the seed
+        format, say — would otherwise be sealed by its own documentation and silenced forever.
+        """
+        data = ("# Changelog\n\nHow a fresh ledger is marked:\n\n```\n<!-- "
+                + mod_seed_sentinel() + ": fresh ledger -->\n```\n\n"
+                + "".join("## Release %d — 2026-06-%02d\n\n- did a thing\n\n" % (i, i % 28 + 1)
+                          for i in range(6)))
+        self.assertIn(mod_seed_sentinel(), data, "control: the token IS in the file")
+        self.assertGreater(len(probe_hits_of(data, CL)), 0, "control: the probe fires")
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+
+    def test_a_seed_that_gained_a_real_entry_in_the_wrong_grammar_is_refused(self):
+        """The sentinel is a conjunction, exactly as the seed's own comment states it.
+
+        `starter-kit/CHANGELOG.md:10` says the file is fresh "While this line is present AND there
+        are no dated (### YYYY-MM-DD) entries below." An adopter who starts writing entries in
+        their own grammar without deleting the comment has a mismatch, not a fresh ledger.
+        """
+        data = show(SEED_CL) + "\n### 2026-07-27 — did a thing\n\n- Change: x\n"
+        self.assertIn(mod_seed_sentinel(), data, "control: the sentinel is still present")
+        r = evaluate_text(self, "CHANGELOG.md", data)
+        self.assertEqual(r.codes, ["GRAMMAR_MISMATCH"], [f.message for f in r.findings])
+
+    # --- narrowed variants: what makes each clause load-bearing ------------------------------
+
+    def test_NARROWED_a_size_only_implementation_misses_both_real_shapes(self):
+        """Delete the probe and the two shapes F1 found survive at adopter-plausible sizes.
+
+        This is the test that makes `content_probe` load-bearing rather than decorative: both
+        files F1 actually names are over the byte ceiling, so size alone would have "fixed" F1
+        while leaving ../claims-model-starter.wiki (28,300 B) and ../feedback-loop-comparison
+        (7,067 B) — both real, both misreported today — exactly as broken.
+        """
+        for data in (MISMATCH_EMDASH, MISMATCH_TABLE):
+            size_only = (len(data.encode("utf-8")) > mod.SEED_PLAUSIBLE_MAX_BYTES
+                         or len(data.splitlines()) > mod.SEED_PLAUSIBLE_MAX_LINES)
+            self.assertFalse(size_only, "a size-only rule would report this mismatch as empty")
+
+    def test_NARROWED_a_fence_blind_probe_would_refuse_our_own_shipped_seed(self):
+        """Drop fence-awareness from the probe and day one breaks for every adopter."""
+        cl = show(SEED_CL)
+        blind = [ln for ln in cl.splitlines() if mod.LEDGERS["CHANGELOG.md"].content_probe
+                 and mod.LEDGERS["CHANGELOG.md"].content_probe.search(ln)]
+        self.assertGreater(len(blind), 0,
+                           "control: the seed DOES contain probe-shaped lines inside its fences")
+        self.assertEqual(probe_hits_of(cl, CL), [],
+                         "fence-aware, those same lines must be invisible")
+
+    def test_NARROWED_an_unanchored_probe_would_flag_dated_prose(self):
+        """`search(r'\\d{4}-\\d{2}-\\d{2}')` anywhere on the line is too loose.
+
+        Measured on the real population: the anchored form loses no detection (147/87/11/4 hits on
+        the four mismatched adopter ledgers) while dropping to 0 on ordinary dated prose.
+        """
+        prose = "For instance an entry dated 2026-01-15 sits above one dated 2026-01-14.\n"
+        self.assertRegex(prose, r"\d{4}-\d{2}-\d{2}", "control: the line does carry a date")
+        self.assertIsNone(mod.LEDGERS["CHANGELOG.md"].content_probe.search(prose),
+                          "an anchored probe must ignore prose that merely mentions a date")
+
+
+
+class TestPhaseC2ClassAThreshold(unittest.TestCase):
+    """Phase C2 — the Class A archive threshold, and DEFAULT_BUDGET_BYTES raised to meet it.
+
+    WHAT THIS CLASS IS DEFENDING AGAINST, stated because it is subtle and it nearly shipped.
+    Before C2 the read arm's FIRE and its STOP were the same constant, READ_CAP_BYTES. The plan
+    describes option A2 as "replace the read arm's threshold" — singular — and an implementer who
+    moved only `read_fires` would get a trigger that fires in the right place and a `choose_cut`
+    that still cuts back to 56,750 B. Nothing in the suite before this class asserted what a trim
+    cuts back TO, so that half-application would have been GREEN. Every assertion below that
+    touches `read_stop_at` exists for that reason.
+    """
+
+    # --- the constants, against FROZEN LITERALS ----------------------------------------------
+    # Learning #43: an assertion whose operands both come from the module under test is an
+    # identity. `CLASS_A_STOP_BYTES == int(DEFAULT_BUDGET_BYTES * BYTE_STOP_FRACTION)` is TRUE and
+    # is asserted below as an intentional coincidence — but it cannot be the only check, because
+    # both sides move together when the budget moves. So each number is also pinned to a literal.
+
+    def test_the_three_constants_are_the_ratified_values(self):
+        """KILLS: any of the three moving without a session deciding to move it."""
+        self.assertEqual(mod.CLASS_A_FIRE_BYTES, 196_608, "192 KiB — the Class A fire point")
+        self.assertEqual(mod.CLASS_A_STOP_BYTES, 98_304, "96 KiB — the Class A stop")
+        self.assertEqual(mod.DEFAULT_BUDGET_BYTES, 196_608,
+                         "option C1 raised this to 192 KiB; at 65,536 the byte arm pre-empts the "
+                         "Class A arm and option A2 is inert (plan §5, §10 dragon 1)")
+
+    def test_the_fire_stop_coincidence_is_intentional_not_accidental(self):
+        """The byte arm and the Class A read arm land on the same two numbers today.
+
+        That is a real convergence and it is asserted so that moving ONE of them is a visible
+        decision rather than a silent divergence. It is deliberately NOT expressed by deriving one
+        constant from the other in the source: the two arms answer different questions (context
+        tax vs. distance from the hard refusal), and a derivation would assert they are one
+        question. Both operands here are pinned to literals above, so this is not an identity."""
+        self.assertEqual(int(mod.DEFAULT_BUDGET_BYTES * mod.BYTE_STOP_FRACTION),
+                         mod.CLASS_A_STOP_BYTES,
+                         "the byte arm's hysteresis stop and the Class A read stop coincide by "
+                         "design; if you moved one on purpose, update this test and say why")
+
+    def test_the_class_a_arm_sits_below_the_hard_refusal_with_real_margin(self):
+        """Plan §3 caveat 1: fire BELOW READ_REFUSE_BYTES, never at it. A trigger set at the
+        refusal parks the file on the edge where degradation stops being graceful."""
+        self.assertLess(mod.CLASS_A_FIRE_BYTES, mod.READ_REFUSE_BYTES)
+        self.assertEqual(mod.READ_REFUSE_BYTES - mod.CLASS_A_FIRE_BYTES, 65_536,
+                         "64 KiB of margin under the refusal")
+        self.assertGreater(mod.CLASS_A_FIRE_BYTES, mod.READ_CAP_BYTES,
+                           "control: the Class A arm must be LOOSER than the one-read cap, or "
+                           "this phase changed nothing")
+
+    # --- the fire/stop pair is per class, and BOTH halves moved ------------------------------
+
+    def test_read_fire_at_and_read_stop_at_are_both_class_aware(self):
+        """KILLS the half-application this class exists for: moving the fire and not the stop."""
+        a = mod.Trigger(); a.class_a = True
+        b = mod.Trigger(); b.class_a = False
+        self.assertEqual(a.read_fire_at, mod.CLASS_A_FIRE_BYTES)
+        self.assertEqual(a.read_stop_at, mod.CLASS_A_STOP_BYTES)
+        self.assertEqual(b.read_fire_at, mod.READ_CAP_BYTES)
+        self.assertEqual(b.read_stop_at, mod.READ_CAP_BYTES)
+        self.assertNotEqual(a.read_stop_at, b.read_stop_at,
+                            "if these are equal the stop half was never wired")
+
+    def test_a_class_a_trim_cuts_back_to_96_KiB_not_to_the_one_read_cap(self):
+        """THE ASSERTION THAT WOULD HAVE CAUGHT A FIRE-ONLY CHANGE.
+
+        With the stop half unwired, stops() falls back to READ_CAP_BYTES and a size of exactly
+        96 KiB returns False — the trim keeps cutting, down to 56,750 B, silently."""
+        t = mod.Trigger(); t.class_a = True; t.budget = mod.DEFAULT_BUDGET_BYTES
+        self.assertTrue(t.stops(mod.CLASS_A_STOP_BYTES),
+                        "exactly at the Class A stop must stop — the boundary is inclusive")
+        self.assertFalse(t.stops(mod.CLASS_A_STOP_BYTES + 1), "one byte over must not stop")
+        self.assertGreater(mod.CLASS_A_STOP_BYTES, mod.READ_CAP_BYTES,
+                           "control: 96 KiB is ABOVE the one-read cap, so a fire-only "
+                           "implementation would answer False here")
+
+    def test_the_default_is_the_conservative_arm(self):
+        """A Trigger nobody classified must get the TIGHTER threshold. Forgetting to classify has
+        to err toward firing early, never toward silence."""
+        t = mod.Trigger()
+        self.assertFalse(t.class_a, "class_a must default False")
+        self.assertEqual(t.read_fire_at, mod.READ_CAP_BYTES)
+        self.assertEqual(t.read_stop_at, mod.READ_CAP_BYTES)
+
+    def test_no_ledger_can_stop_above_the_hard_refusal_at_any_budget(self):
+        """Plan §9's C2 criterion, and the `--budget-bytes` guard restated at the new value.
+
+        The knob is adopter-facing; a raised budget must not quietly let a file stop above the
+        read arm's stop. Exercised at absurd budgets, where the byte arm alone would allow it."""
+        for budget in (mod.DEFAULT_BUDGET_BYTES, 512 * 1024, 4 * 1024 * 1024, 10 ** 9):
+            for class_a in (True, False):
+                t = mod.Trigger(); t.class_a = class_a; t.budget = budget
+                self.assertFalse(t.stops(mod.READ_REFUSE_BYTES),
+                                 "budget=%d class_a=%s: stopping AT the hard refusal must be "
+                                 "impossible" % (budget, class_a))
+                self.assertFalse(t.stops(mod.CLASS_A_STOP_BYTES + 1),
+                                 "budget=%d class_a=%s: the read arm must cap the byte arm"
+                                 % (budget, class_a))
+
+    # --- the ROOT scoping (operator decision 3) ----------------------------------------------
+
+    @staticmethod
+    def _seed(tmp, rel_paths, body):
+        """A git repo holding the SAME bytes at several paths. Uses the module's own helpers so
+        this class stays on the file's idiom (`sh`, `Path`, TemporaryDirectory)."""
+        d = Path(tmp)
+        sh(d, "git", "init", "-q", ".")
+        for rel in rel_paths:
+            p = d / rel
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(body, encoding="utf-8")
+        return d
+
+    def test_is_root_class_a_is_a_path_question_not_a_basename_question(self):
+        """OPERATOR DECISION, Phase C2. LEDGERS is resolved by BASENAME at any depth
+        (`LEDGERS.get(path.name)`), so a nested CHANGELOG.md gets a spec and a fully evaluated
+        trigger. Only a ROOT ledger earns the relaxed arm — otherwise any */CHANGELOG.md anywhere
+        silently inherits a threshold 3.38x the one-read cap without ever being classified."""
+        with tempfile.TemporaryDirectory() as tmp:
+            d = self._seed(tmp, ["CHANGELOG.md", "docs/x/CHANGELOG.md",
+                                 "starter-kit/CHANGELOG.md"], "x")
+            spec = mod.LEDGERS["CHANGELOG.md"]
+            root = d.resolve()
+            self.assertTrue(mod.is_root_class_a(root, d / "CHANGELOG.md", spec))
+            self.assertFalse(mod.is_root_class_a(root, d / "docs/x/CHANGELOG.md", spec),
+                             "a nested ledger must NOT get the relaxed arm")
+            self.assertFalse(mod.is_root_class_a(root, d / "starter-kit/CHANGELOG.md", spec),
+                             "this repo's own distributed SEED is the live instance of this case")
+
+    def test_is_root_class_a_returns_False_rather_than_raising_on_a_foreign_path(self):
+        """It routes to the tighter arm on anything it cannot resolve, and does not explode."""
+        with tempfile.TemporaryDirectory() as tmp:
+            spec = mod.LEDGERS["CHANGELOG.md"]
+            self.assertFalse(mod.is_root_class_a(Path(tmp).resolve(),
+                                                 Path("/nowhere/CHANGELOG.md"), spec))
+
+    def test_root_and_nested_ledgers_of_IDENTICAL_SIZE_get_opposite_verdicts(self):
+        """THE DISCRIMINATING CASE, and the only one that proves the scoping does anything.
+
+        Both files hold the same bytes. At a size BETWEEN the two thresholds the root one must be
+        quiet and the nested one must fire. A test at 256 KB would see both fire and prove
+        nothing; a test at 10 KB would see both stay quiet and prove nothing."""
+        front = "# L\n\nfront\n\n---\n\n## 2026-08\n\n"
+        rec = lambda i: ("### 2026-08-%02d \u00b7 [ad hoc] r%d\n\n" % ((i % 28) + 1, i)
+                         + "- filler line giving this record realistic bulk\n" * 40 + "\n")
+        body = front + "".join(rec(i) for i in range(47))
+        size = len(body.encode("utf-8"))
+        self.assertGreater(size, mod.READ_CAP_BYTES,
+                           "control: the fixture must be OVER the one-read cap")
+        self.assertLess(size, mod.CLASS_A_FIRE_BYTES,
+                        "control: and UNDER the Class A arm, or the case is not discriminating")
+        with tempfile.TemporaryDirectory() as tmp:
+            d = self._seed(tmp, ["CHANGELOG.md", "docs/x/CHANGELOG.md"], body)
+            spec = mod.LEDGERS["CHANGELOG.md"]
+            rt = d.resolve()
+            root = mod.Trigger(); root.size_bytes = size
+            root.class_a = mod.is_root_class_a(rt, d / "CHANGELOG.md", spec)
+            nest = mod.Trigger(); nest.size_bytes = size
+            nest.class_a = mod.is_root_class_a(rt, d / "docs/x/CHANGELOG.md", spec)
+            self.assertTrue(root.class_a, "control: the root file must classify as Class A")
+            self.assertFalse(nest.class_a, "control: the nested file must not")
+            self.assertFalse(root.read_fires, "the ROOT ledger must be quiet at this size")
+            self.assertTrue(nest.read_fires, "the NESTED one, same bytes, must fire")
+
+    def test_END_TO_END_a_real_write_lands_between_the_cap_and_the_class_a_stop(self):
+        """THE STRONGEST FORM OF THIS CLASS'S CENTRAL ASSERTION, and the only one that exercises
+        the whole path — trigger, choose_cut, stops(), and the write — at the SHIPPED defaults.
+
+        The resulting size is the tell. A correct C2 lands it in the band
+        (READ_CAP_BYTES, CLASS_A_STOP_BYTES]. An implementation that moved `read_fires` and left
+        `read_ok` on READ_CAP_BYTES lands it at or below 56,750 instead, and every OTHER assertion
+        in this file would still be green — the trim happened, the shard is lossless, the proof
+        passes. Only the resting SIZE distinguishes them."""
+        with tempfile.TemporaryDirectory() as tmp:
+            p = make_repo(tmp)
+            before = (p / "CHANGELOG.md").stat().st_size
+            self.assertGreater(before, mod.CLASS_A_FIRE_BYTES,
+                               "control: the fixture must actually fire, or this proves nothing")
+            r = run_trim(p, "--file", "CHANGELOG.md", "--write", "--today", "2026-02-01")
+            self.assertEqual(r.returncode, 0, r.stdout)
+            after = (p / "CHANGELOG.md").stat().st_size
+            self.assertLessEqual(after, mod.CLASS_A_STOP_BYTES,
+                                 "a Class A trim must reach the 96 KiB stop")
+            self.assertGreater(after, mod.READ_CAP_BYTES,
+                               "IT MUST NOT KEEP CUTTING TO 56,750 B — that is the signature of a "
+                               "fire-only change, where stops() still reads READ_CAP_BYTES")
+
+    # --- the shipped ledgers, and the ---check row -------------------------------------------
+
+    def test_the_check_row_reports_the_threshold_actually_in_force(self):
+        """A row that prints READ_CAP_BYTES for a file the trigger no longer keys on is arithmetic
+        about a threshold nothing uses. The one-read cap is still MENTIONED for Class A — the
+        property is real — but it must not be presented as the fault condition."""
+        body = "# L\n\nfront\n\n---\n\n## 2026-08\n\n" + (
+            "### 2026-08-01 \u00b7 [ad hoc] r\n\n" + "- x\n" * 40 + "\n") * 47
+        with tempfile.TemporaryDirectory() as tmp:
+            d = self._seed(tmp, ["CHANGELOG.md", "docs/x/CHANGELOG.md"], body)
+            sh(d, "git", "add", "-A")
+            sh(d, "git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "i")
+            root = run_trim(d, "--file", "CHANGELOG.md", "--check").stdout
+            nest = run_trim(d, "--file", "docs/x/CHANGELOG.md", "--check").stdout
+            self.assertIn("Class A archive threshold", root)
+            self.assertIn("{:,}".format(mod.CLASS_A_FIRE_BYTES), root)
+            self.assertNotIn("Class A archive threshold", nest,
+                             "a nested ledger must not be told it has the relaxed arm")
+            self.assertIn("one-read cap", nest)
+            self.assertIn("{:,}".format(mod.READ_CAP_BYTES), nest)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
**Base: `read-set-budgets`, not `main`.** Second of four PRs staged there for selective testing.
It follows #76 and must land before the `FRAMEWORK_APPARATUS.md` extraction, for a measured reason
given at the end.

## What this does

Ships the ledger trimmer — `starter-kit/methodology_trim.py`, the tool that bounds `CHANGELOG.md`
and `HANDOFFS.md` growth by archiving the oldest records into a frozen shard and proving the move
lossless (L1 records-zone concatenation, L2 zone pinning, L3 record partition).

| Item | Class |
|---|---|
| `starter-kit/methodology_trim.py` (+ its `bin/_manifest.py` row, 25 → 26) | **distributed** |
| `tools/test_methodology_trim.py` (123 tests) + the `bin/tests.sh` line that runs them | canonical-only |
| `starter-kit/CHANGELOG.md`, `starter-kit/HANDOFFS.md` | **distributed** seeds — the trimmer's contract is stated there |
| dashboard exclusion + signature entries, both twins | canonical + distributed twin |

The manifest row lands **with** its file, so sources-listed equals files-present at every step.

## The part worth reviewing: the tests were coupled to my fork's history

`tools/test_methodology_trim.py` drove L1/L2/L3 from two commits in the fork's own history —
`020ba3f` (a CHANGELOG archive that carried the scope footer out of the live file) and `7a71df0`
(a HANDOFFS archive that bundled a record edit with the move). **Neither is reachable in any other
clone.** Ported unchanged, 19 of 123 tests fail here — including *all* of `TestL2` and *all* of
`TestL3`. An adopter who installs the trimmer could never run its tests either.

I replaced them with fixtures reproducing the **structural properties**, not the bytes:

- **`SYNTHETIC_CHANGELOG`** — front matter, records, and a non-empty footer carrying a rebasable
  `](link)`. The link is load-bearing: without one, the footer-moved clause is only ever tested in
  its verbatim form and the `transform_record` path goes uncovered.
- **`SYNTHETIC_BEFORE/_AFTER/_SHARD`** — a **25 = 6 + 19** partition in which one *retained* record
  was edited. Counts partition; content does not. That is exactly what made `7a71df0` the event
  worth testing against.

**The original docstrings warned that "a synthetic one tests the test", and that objection is
answered rather than waved away.** Three mutants of the code under test were run against the new
fixtures and each was killed:

| Mutant | Tests failing |
|---|---|
| `L2_FOOTER_MOVED` never emitted | **6** |
| `L3_RECORD_ALTERED` never emitted | **4** |
| `L1_MISMATCH` never emitted | **5** |

The three fixture-control tests were rewritten to assert the synthetic fixtures genuinely carry the
properties the suite relies on — including a control that a whole-file grep cannot distinguish "the
footer is present" from "a record merely quotes it", which is the insight the fork-history version
carried and the reason zones exist at all.

**Two tests remain guarded and skip here, deliberately.** The declared-regenerated-field tests use
the *real* count in the live root `HANDOFFS.md`, and their whole point is that the count really
drifted by hand. A synthetic anchor there would test the test. They skip on a repository that
declares no retention policy, and the precondition is read from the raw file — never through
`classify_zones`, which is the code under test.

## Verification

Run in `git clone --no-local --single-branch`, with `020ba3f` and `7a71df0` unreachable and
`docs/archive/` absent — i.e. genuinely upstream-like, not a worktree that would resolve them.

| | Result |
|---|---|
| Base (`read-set-budgets`) | **113 passed, 1 failed** |
| This branch | **114 passed, 1 failed** |
| Delta | **+1 passing, zero added failures** |
| `tools/test_methodology_trim.py` alone | **123 tests, exit 0**, 2 skipped |
| `tools/test_methodology_dashboard.py` | **211 tests, exit 0** |
| Manifest self-consistency | **26 listed, 26 present** |

The one failure is the same `Test 9` #76 declared: `bin/sync --source=github` reads `main`, and this
branch's newest manifest rows name files not yet there. It heals when the branch merges to `main`.

## ⚠ For anyone testing this branch

**Do not verify with `bin/sync --source=github`** — it is pinned to `main` (`bin/sync:93` sends no
`?ref=`; `:162` is literally `commits/main`), so it syncs `main`'s files, looks clean, and has tested
nothing. Use `--source=local`.

## Why this must precede the apparatus extraction

Measured, not assumed: the dashboard's canonical-only tests abort with **13 errors** when
`methodology_trim.py` is absent — *"the canonical repo must locate its own trimmer, or the present
branch is not under test at all"* — and **0** with it.

## Disclosures

- The dashboard's `_FRAMEWORK_FILE_SIGNATURES` entry carries its **own** `TRIM_VERSION` pattern. The
  shared `_VERSION_RE` matches `DASHBOARD_VERSION` only; reusing it would fall through to the
  signature path on every scan, which is the silent-skip defect that table's own comment describes.
- `CHECKLIST_EXEMPT` gains the trimmer with the rationale used in the fork: sync installs it
  automatically, so its presence measures sync rather than adoption, and scoring it would re-cut
  `METHODOLOGY_MAX` and move every already-compliant adopter's percentage for a change they did not
  make.
- The two distributed seeds grow substantially (`HANDOFFS.md` 5,314 → 11,442 B, `CHANGELOG.md`
  3,622 → 12,893 B). They state the trimmer's contract, and the suite asserts against them.

---

_Authored by an AI agent under the operator's direction; every figure re-derived in a clean clone.
Review before relying on it for human-facing work._
