### PR TITLE
Ship the context-budget gate: token ceilings, class totals, and a root config for this repository (read-set budgets, 4 of 4)

### DIFF
--- a/.context-budget.json
+++ b/.context-budget.json
@@ -1,0 +1,99 @@
+{
+  "_": "THIS REPOSITORY'S OWN context budget -- the canonical methodology repo dogfooding starter-kit/context_budget.py on itself. Provisioned from starter-kit/context-budget.json (the SEED adopters receive) and then calibrated to THIS tree at cea3068 (read-set-budgets after PR #78). Every ceiling below states its derivation in the neighbouring _ key; numbers marked PROPOSAL are the fork's choices offered to the maintainer, not measurements. THE TOOL IS NOT AT THIS REPO'S ROOT: bin/_manifest.py installs it at ADOPTER roots; canonically it lives only at starter-kit/context_budget.py. Invoke it as `python3 starter-kit/context_budget.py` -- find_root() walks up via .git and reads this file. DO NOT RUN `install-hook` HERE. On a fresh clone core.hooksPath is unset, so install-hook WRITES .git/hooks/pre-commit exec'ing <root>/context_budget.py, which does not exist at this root, and every commit after that fails with `can't open file`; recover with `rm .git/hooks/pre-commit`. With `git config core.hooksPath .githooks` set (BOOTSTRAP Step 10) it declines instead, because that hook is the FM #27 ledger gate. The budget gate therefore MEASURES here: run `python3 starter-kit/context_budget.py --precommit` by hand before a commit that touches a budgeted file, or chain it into .githooks/pre-commit as a separate, deliberate change. Refusing to run without this file (exit 3, `refuses to invent budgets`) is the tool's own 1.0.0 behaviour, unchanged by the 1.2.0 port.",
+
+  "_precommit_scope": "`--precommit` sizes the INDEX against HEAD for each declared file and class; it evaluates NEITHER the `structure` patterns NOR `max_lines` below. Those run in the bare and --json modes only, where a pattern that stops matching reports `instrument-failed`. Bare and --json runs CREATE .context-budget-history.jsonl on the first run and append to it only when the measurement changes (the file reappears on every later run); --precommit, --selftest, --calibrate and --help write nothing.",
+
+  "read_cap_tokens": 25000,
+  "_read_cap_tokens": "The per-read cap in TOKENS: the number in the Claude Code Read tool's own refusal message (`File content (N tokens) exceeds maximum allowed tokens (25000)`), first observed 2026-08-26 and re-confirmed 2026-09-03 on Claude Code 2.1.259 (`claude --version`). Reproduce it in one action: Read any file larger than the cap with an explicit `limit` that spans it -- the tool returns no content and prints that message, whose parenthesised number is this key's value; a Read without a limit returns a partial view whose banner names the same cap. The tool's module default READ_CAP_TOKENS carries the same value, so this key restates the default rather than changing it; the seed edit in this same PR declares it for adopters. It is a fact about the harness, not a policy: if yours differs, set this key and every derived ceiling below follows.",
+
+  "bytes_per_token": 2.93,
+  "_bytes_per_token": "INHERITED FROM THE SEED, NOT MEASURED ON THIS REPO. It is the fallback density for any file below that declares none of its own -- on this config that is THREE files -- CLAUDE.md (about 20,193 tok against a derived, clamped 25,000), starter-kit/SESSION_RUNNER.md (about 17,813 tok against a derived 18,222) and starter-kit/SAFEGUARDS.md (about 5,251 tok against a derived 6,777), because read-set is a whole-read class and neither member declares a density -- all judged at 2.93 until --calibrate is adopted (`--json` shows density_source config on each); the two ledgers carry measured per-file densities and the Learnings table gets no token verdict. `python3 starter-kit/context_budget.py --calibrate` fits this repo's own value from its session transcripts; it PROPOSES and writes nothing -- edit this key if the fit is admitted (R^2 >= 0.50, positive slope).",
+
+  "fixed_harness_tokens": 35700,
+  "_fixed_harness_tokens": "INHERITED FROM THE SEED, NOT MEASURED ON THIS REPO, and READ BY NOTHING in context_budget.py 1.2.0 (grep it); carried for seed parity so a future consumer finds the seed's value. Same remedy if one appears: --calibrate.",
+
+  "growth_run": 10,
+  "_growth_run": "INHERITED FROM THE SEED, NOT DERIVED. It cannot be calibrated on day one: this repo has no .context-budget-history.jsonl until this config's first bare run, so the series the trigger reads is empty. Decide whether to track that file once it exists (the fork tracks it, deliberately; see .gitignore).",
+
+  "calibrate_against": "CLAUDE.md",
+  "_calibrate_against": "The resident file --calibrate fits session tokens against, and the regressor the two TestFitGateEndToEnd tests use on a machine that has this checkout's transcripts. Running --calibrate and adopting or rejecting its fit is the maintainer's step after merge; the build session does not run it (it would skip in a clean clone -- no transcripts under the clone's slug).",
+
+  "classes": {
+    "resident": {
+      "total_bytes": 59168,
+      "_": "Resident is a ONE-FILE class in this repo -- CLAUDE.md is the only artifact the harness injects in full before the session starts; there is no root SESSION_RUNNER.md (the runner is the distributed starter-kit/SESSION_RUNNER.md) and no root SESSION_NOTES.md (continuity lives in HANDOFFS.md). So this total equals CLAUDE.md's own ceiling by construction. That is deliberate and it is NOT a check that cannot fail: the per-file ceiling cannot see a SECOND resident file being added, and this one can. Agent-level memory (~/.claude/projects/.../MEMORY.md) is genuinely resident too but is per-operator and per-machine, outside this repo, and not a reviewable diff -- deliberately excluded. PROPOSAL: PINNED AT ARRIVAL SIZE (git cat-file -s cea3068:CLAUDE.md = 59,168 B), a ratchet, not a defended budget: growth is refused, shrink passes. The seed's 34,000 B total would read `over` by 25,168 B on day one for a reason unrelated to the read-set work; the pin states the true size and leaves the target to the maintainer."
+    },
+    "read-set": {
+      "total_bytes": 56750,
+      "warn_bytes": 51000,
+      "derive_from_read_cap": true,
+      "_": "THE PHASE 0 MANDATORY READ -- starter-kit/SESSION_RUNNER.md, the procedure itself (`Follow it step by step`, its line 3; CLAUDE_TEMPLATE.md orders it read), plus starter-kit/SAFEGUARDS.md, which its step 1 orders read in full. This class exists SEPARATELY from read-mandated because that label here covers the ledgers, which are per-file rows with no aggregate by design; totalling them with the procedure pair would produce a number that partitions nothing. total_bytes is typed here only as a restatement: derive_from_read_cap makes the run-time value READ_CAP_BYTES - adopter_reserve_bytes = 25,000 x 2.27 - 0 = 56,750, and a typed value that disagrees with the derivation is reported as a config defect rather than silently honoured. adopter_reserve_bytes is 0 here, deliberately: the least favourable assumption for the framework's own numbers (a shortfall at reserve zero cannot be blamed on the reserve). The seed's own CLAUDE.md max_bytes, 28,000 B -- the always-read file the framework does not own -- is the documented candidate (the authoring fork's governing design names it); set it and the derived total becomes 28,750 B, putting the pair 38,831 B over. The reserve is the adopter's to declare, not this repo's. The pair is 52,195 + 15,386 = 67,581 B on cea3068 -- 10,831 B OVER on arrival, which is the number this branch exists to make visible and refuse. warn_bytes 51,000 is a PROPOSAL, the fork's own choice (the seed has no read-set class; its warn_bytes are 30,000 and 24,000), not derived: ~10% under the total so the class warns before it refuses -- and INERT while the class is over, as it is today (`over` shadows `warn`, and the class arm in --precommit reads only the ceiling); it informs nobody until the pair is under 56,750 B. NOTE ON THE AGGREGATE ARM: because the two per-file ceilings below partition this total exactly, no class breach can precede a per-file breach on THIS config -- the class arm is redundant by construction today and earns its keep the day the partition is broken (a third member, a raised per-file ceiling, a reserve). Its witness is the shipped --selftest, not this repo's rows."
+    }
+  },
+
+  "files": [
+    {
+      "path": "CLAUDE.md",
+      "class": "resident",
+      "max_lines": 200,
+      "max_bytes": 59168,
+      "structure": [
+        { "pattern": "^## Versioning", "expect_min": 1,
+          "why": "Twelve links in this repo's CHANGELOG.md and one test fixture (tools/test_methodology_trim.py) resolve to CLAUDE.md#versioning on cea3068; a compaction that removes or renames the heading breaks them silently. (CLAUDE.md itself states no such rule here -- that sentence exists only in the fork's copy.) Evaluated by the bare run only, not by --precommit." }
+      ],
+      "_": "max_lines 200 is THIS FRAMEWORK'S OWN PUBLISHED NUMBER, not an invention: starter-kit/BOOTSTRAP.md ('Keep CLAUDE.md lean') says Claude Code targets roughly 200 lines and tells adopters to extract before that budget is crowded. The file is 126 lines on cea3068 (the tool counts 127: it keeps the empty string after the final newline, but the check (context_budget.py:366) is a strict >, so 200 fires at wc -l 200, when the tool counts 201), so this arm is green on arrival. max_bytes is a PROPOSAL, PINNED AT ARRIVAL SIZE -- see classes.resident. NO warn_bytes: a warning threshold below a pin set at the current size would fire on every run and inform nobody. NO protected_fence, deliberately: the seed's budget:protected fence does not exist in this file, and declaring it would report `over` for a missing fence -- a red manufactured by this config rather than a real defect. Adding the fence is an edit to CLAUDE.md, raised separately. TOKEN ARM, UNDECLARED BUT LIVE: with max_bytes set and no max_tokens, token_ceiling() derives 59,168 / 2.27 = 26,065 tok and clamps it to the 25,000 read cap; config_defects() reports only a DECLARED max_tokens above the cap, so this clamp is silent. The verdict (about 20,193 tok, ok) is computed at the seed's 2.93 B/tok -- this is one of the three files on this config using that fallback, with the two read-set members; at the 2.27 floor the same bytes read 26,065, over. Left as is, deliberately: no max_tokens declared; re-judge after --calibrate."
+    },
+    {
+      "path": "starter-kit/SESSION_RUNNER.md",
+      "class": "read-set",
+      "max_bytes": 41364,
+      "_": "THE CEILING IS THE CLASS TOTAL MINUS ITS SIBLING'S: 56,750 - 15,386 = 41,364, so the two per-file ceilings SUM to read-set.total_bytes exactly and the class ceiling is a PARTITION rather than a second, unrelated number. This file is 52,195 B on cea3068, so it is 10,831 B OVER on arrival: every commit that grows it is refused and every commit that shrinks it passes. A ratchet, not a wall. Being over on arrival is the point."
+    },
+    {
+      "path": "starter-kit/SAFEGUARDS.md",
+      "class": "read-set",
+      "max_bytes": 15386,
+      "_": "THE CEILING IS THIS FILE'S CURRENT SIZE (git cat-file -s cea3068:starter-kit/SAFEGUARDS.md = 15,386 B; blob f0964195, byte-identical on fork main and upstream), a deliberate no-growth pin: it is the smaller, stabler half, so the whole 10,831 B of headroom debt sits on SESSION_RUNNER.md, the file the series wants shrunk. At exactly 15,386 B the file is AT its ceiling, not over: `new > ceil` is strict, so today's content passes and the next byte does not. PROPOSAL -- the split of the partition is a choice."
+    },
+    {
+      "path": "CHANGELOG.md",
+      "class": "read-mandated",
+      "max_bytes": 65536,
+      "max_tokens": 25000,
+      "bytes_per_token": 2.4674,
+      "structure": [
+        { "pattern": "^### \\d{4}-\\d{2}-\\d{2} · \\[", "expect_min": 5,
+          "why": "the entry anchor methodology_trim.py's CHANGELOG LedgerSpec keys records on (record_start), and the heading shape whose source tag the ledger's own front-matter audit grep counts. If it stops matching, the file has been restructured and every size check here is measuring something else." }
+      ],
+      "_": "Phase 0 step 6 orders this ledger reconciled every session and its newest entries read. max_tokens 25,000 is the read cap itself -- a file past it cannot be read whole. bytes_per_token 2.4674 was MEASURED on the fork's CHANGELOG.md on 2026-08-29 (same ledger format; re-measure here by the doubled-file method described under FRAMEWORK_LEARNINGS.md); at that density 91,365 B is about 37,000 tokens, so a whole read of this file truncates today. At this density the token arm binds BEFORE the byte ceiling: 25,000 x 2.4674 = 61,685 B, so 65,536 B fires first only if a re-measured density exceeds 65,536 / 25,000 = 2.6214 B/tok. max_bytes 65,536 is a PROPOSAL: the fork's ledger ceiling since 2026-08-15, and DECOUPLED from methodology_trim.py since 2026-08-26 -- that tool's DEFAULT_BUDGET_BYTES is 196,608 B (3x this number) and on cea3068 `python3 starter-kit/methodology_trim.py --file CHANGELOG.md --check` reports `trigger does not fire`. The two answer different questions: this ceiling asks what Phase 0 pays to read the file; the trimmer's asks whether archiving is worth doing. Bringing the file under this ceiling means `python3 starter-kit/methodology_trim.py --file CHANGELOG.md --budget-bytes 65536` (dry-run first, then --write) on a reconciled tree -- and THIS FILE FIRST: a HANDOFFS.md trim writes its own entry here, refused while this file is over -- or moving this number. The trimmer stops at half the budget and appends one entry per trim. While the file is over it, --precommit refuses any commit that grows it -- including a ledger entry -- and passes any that shrinks it."
+    },
+    {
+      "path": "HANDOFFS.md",
+      "class": "read-mandated",
+      "max_bytes": 65536,
+      "max_tokens": 25000,
+      "bytes_per_token": 2.3648,
+      "structure": [
+        { "pattern": "^```handoff", "expect_min": 1,
+          "why": "receipts are fenced blocks -- the shape bin/check-handoff validates and methodology_trim.py's HANDOFFS LedgerSpec keys on. Zero matches means the receipts are no longer receipts." }
+      ],
+      "_": "Phase 0 step 6 reads the newest receipt and reconciles the frontier; Phase 3A scores the predecessor's handoff, which in this repo (no root SESSION_NOTES.md) is that receipt. Same ceilings and same PROPOSAL status as CHANGELOG.md. bytes_per_token 2.3648 was MEASURED on the fork's HANDOFFS.md on 2026-08-29 (same receipt format); at that density 70,182 B is about 29,700 tokens, over the read cap -- at the seed's 2.93 it would read as under, which is why the measured density is carried rather than the fallback. At 2.3648 the token arm binds at 59,120 B, before the 65,536 B byte ceiling. The trimmer's trigger does not fire at 70,182 B either; the remedy command is the same as CHANGELOG.md's with `--file HANDOFFS.md`."
+    },
+    {
+      "path": "starter-kit/FRAMEWORK_LEARNINGS.md",
+      "class": "on-demand",
+      "max_bytes": 73728,
+      "bytes_per_token": 2.8897,
+      "structure": [
+        { "pattern": "^\\| *[0-9]+ *\\|", "expect_min": 5,
+          "why": "the Learnings table's own row shape, which bin/check-learnings parses for contiguity. A shape check is cheap and two malformed rows once stood for ~40 sessions before anything looked." }
+      ],
+      "_": "ON-DEMAND, so NO max_tokens by design: the read cap binds a file read WHOLE, and this file is read in PART -- measured over 80 transcripts on the fork, read whole once and in part 243 times, and a partial read returns whole ROWS. The unit actually paid is the row, and the primary guard is bin/check-learnings' ROW_BUDGET_BYTES = 1,500 B per row (canonical-only), whose two independent bases that checker restates in its own comment; this entry is the long-form home that comment points at. bytes_per_token 2.8897 was MEASURED 2026-08-29 on blob b21854cc -- the exact blob cea3068 carries (46 rows, 56,673 B) -- by the doubled-file method: `cat F F > x.md`, Read x.md with a spanning `limit`, halve the token count the refusal reports (an over-cap explicit limit returns no content and costs nothing). max_bytes 73,728 is a PROPOSAL, the fork's ceiling: derived on 2026-08-26 at the pre-compaction density 3.0300 as the size that stays inside one read even if every new byte is 20% denser. At today's 2.8897 it sits 1,486 B ABOVE the one-read cliff (25,000 x 2.8897 = 72,242 B), so read it as a growth signal, not a guarantee of one read; a re-derivation at today's density would land near 70,000 B. NO max_line_bytes: a per-row cap set anywhere useful is red on day one against rows nobody may edit."
+    }
+  ],
+
+  "_deliberate_exclusions": "Measured on cea3068 and left out on purpose, with the numbers a future session needs: README.md 74,636 B, ITERATIVE_METHODOLOGY.md 55,976 B, FRAMEWORK_APPARATUS.md 15,493 B, HOW_TO_USE.md 55,528 B, starter-kit/BOOTSTRAP.md 28,211 B. Large, but read on demand and by humans (or by an adopter at setup), not mandated at Phase 0; the two the series shrank (ITERATIVE_METHODOLOGY.md via #78, its apparatus into FRAMEWORK_APPARATUS.md) now each fit one read, which is the argument, not their size. Adding any of these means declaring a ceiling nobody has defended yet, which is policy, not provisioning.",
+
+  "synced": [],
+  "_synced": "DELIBERATELY EMPTY. The seed ships two synced entries (SESSION_RUNNER.md, SAFEGUARDS.md) that drift-check an adopter's local copy against a canonical checkout. THIS REPO IS THAT CANONICAL: pointing path and canonical at the same file would compare a blob to itself, an identity no change can falsify. Here those two files are editable, so a SIZE finding is actionable -- which is why they carry per-file ceilings in files[] under read-set instead. check_synced() is drift-only and never enters an aggregate; a max_bytes written into a synced entry would look configured and refuse nothing."
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
 .DS_Store
 dashboard.html
+# NOTE: dashboard_history.jsonl is deliberately NOT ignored. Unlike dashboard.html
+# (regenerated in full every run), it is append-only, non-regenerable project-health
+# history, so it can be tracked to survive machine loss and clone (the authoring fork does).
+# NOTE: .context-budget-history.jsonl is deliberately NOT ignored either, for the same
+# reason plus one of its own — context_budget.py's growth-run trigger reads the series,
+# which survives a fresh clone only if tracked. It appends only when a measurement changes,
+# so tracking it does not put a diff in every commit.
 tools/__pycache__/
 starter-kit/__pycache__/
 bin/__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,24 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
   the date of the change, two where a reference to the fork's numbered `bin/tests.sh` block became a
   description of this tree's. The fork's own root config, its measurement history, its dashboard
   series and its ledgers are **deliberately excluded**.
+- **This repository declares its own budget** — a root `.context-budget.json`, in a second commit so
+  the policy file is reviewable apart from the code. It **pins** `CLAUDE.md` at its arrival size
+  (59,168 B: growth refused, shrink passes), **derives** the `read-set` total from the read cap at run
+  time (25,000 tok × 2.27 B/tok = 56,750 B) and splits it 41,364 / 15,386 across `SESSION_RUNNER.md`
+  / `SAFEGUARDS.md`, so all 10,831 B of debt sits on the file the series wants shrunk, and
+  **declares** the two ledgers Phase 0 reads at 65,536 B and 25,000 tokens each and
+  `FRAMEWORK_LEARNINGS.md` at 73,728 B — the derivation `bin/check-learnings` already cites this
+  file for. Every number's `_` key says how it was derived; five values are marked PROPOSAL, and the
+  calibration constants are the seed's (`--calibrate` proposes and writes nothing). Day one: the bare
+  run exits 2 with six findings — `SESSION_RUNNER.md` and the pair over by 10,831 B, both ledgers over
+  in bytes and in tokens — none of them new. This file is also what turns the wired `bin/tests.sh`
+  row green: without a root config the tool exits 3 and the unit module's selftest test fails. The
+  gate is **not wired** into `.githooks/pre-commit`: run `--precommit` by hand, and never
+  `install-hook` at this root (the config's `_` key says why). Run by hand, this PR's own two commits
+  fail it — exit 3 on the first (no config yet), exit 2 on this one (this bullet grows a ledger
+  already over its ceiling). `.gitignore` gains the comments explaining why neither measurement history
+  (the dashboard's, this tool's) is ignored; this tool's appears on the first bare run and is yours to
+  track or not.
 
 ### 2026-09-02 · [ad hoc] The flight manual sheds its apparatus into a read-on-demand sibling
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,52 @@ Reverse-chronological, newest on top; prepend-only. Promote to `## YYYY-MM` sect
 
 ---
 
+### 2026-09-03 · [ad hoc] The context-budget gate ships — ceilings in tokens, class totals, and the repairs beneath them
+
+- **Change:** `starter-kit/context_budget.py` `1.0.0` → `1.2.0` (29,549 → 73,040 B), shipped as the
+  end state of nine fork commits (seven that went through the fork's own review rounds, plus two
+  comment-only rewords made for this port) rather than a replay — the tests arrive as one file, and
+  every intermediate state of the tool before its reviewed end state fails them. Ceilings may now be declared in **tokens** (`max_tokens`, against `read_cap_tokens`
+  25,000 — the number in the Read tool's own refusal message); a whole-read file with only `max_bytes`
+  gets a ceiling derived at the 2.27 B/token floor and clamped at the cap; **class totals**
+  (`resident`, `read-set`) are summed and gated in the bare run and in `--precommit`;
+  `config_defects()` reports a declared `max_tokens` above the cap and a typed class total that
+  disagrees with its derivation; `calibrate()` walks first-parent history, compares timezone-aware
+  stamps and refuses a fit below R² 0.50 instead of printing noise; the index is sized with
+  `git cat-file -s` (the old path was 1 B short on LF, more on CRLF, and raised on non-UTF-8 content);
+  the ledger row names the ceiling that fired in its own unit and reports bytes, not lines, when
+  nothing fired. Exit codes are unchanged (`0/1/2/3`), and so is the refusal to run at a root with no
+  `.context-budget.json` (exit 3).
+- **What it buys.** [#76](https://github.com/KJ5HST/methodology/pull/76) and
+  [#78](https://github.com/KJ5HST/methodology/pull/78) shed bytes; this one **refuses growth**. On this branch the Phase 0
+  mandatory pair is 52,195 + 15,386 = **67,581 B against the 56,750 B one-read cap — over by
+  10,831 B, exactly what [#76](https://github.com/KJ5HST/methodology/pull/76)'s table left.** Nothing here shrinks it. Once a root config declares
+  the pair, `--precommit` refuses any commit that grows either file and passes any that shrinks one.
+- **The tests travel with the tool.** `tools/test_context_budget.py` — 116 tests, canonical-only
+  (not in `bin/_manifest.py`, like the trimmer's), every git fixture a scratch repository — plus one
+  `bin/tests.sh` row wiring it, immediately after the trimmer's. Until that row `calibrate()`'s
+  arithmetic had no test anywhere: the existing `== Test: context_budget.py ==` block covers
+  install-hook, sync distribution and the selftest gates, all of which stay green while the fit
+  returns noise. Two tests fit this repository's own session transcripts against `CLAUDE.md` and
+  **skip**, by design, on a machine without them.
+- **The seed follows the tool.** `starter-kit/context-budget.json` gains `read_cap_tokens`, a
+  `max_tokens` on each of its two whole-read entries and a note on the on-demand entry saying why it
+  gets none (+6 lines) — documentation of keys the new tool reads. It is a seed-once file: no
+  adopter's existing config changes on sync.
+- **Scanner:** untouched. Both dashboard twins already list `context_budget.py` and
+  `.context-budget.json` as framework-installed files and score neither.
+- **Verification:** clean clone of `cea3068`, measured at the branch head with the root config in
+  place. `python3 tools/test_context_budget.py` — 116 run, OK, 2 skipped; `--selftest` 52 PASS /
+  0 FAIL; `bin/tests.sh` **115 passed / 1 failed** against **114 / 1** on the untouched base — one
+  row added, zero status flips; the failure on both is Test 9 (`bin/sync --source=github` reads
+  `main`, where three manifest sources are absent until this branch merges). `bin/check-links`,
+  `bin/check-learnings`, `bin/check-handoff` and `bin/check-handoff --all` each 0.
+- **Provenance:** ported from `rmsharp/methodology` `main` — the tool byte-identical (blob
+  `d91677b5`), the test module differing in six lines: four where a fork-relative identifier became
+  the date of the change, two where a reference to the fork's numbered `bin/tests.sh` block became a
+  description of this tree's. The fork's own root config, its measurement history, its dashboard
+  series and its ledgers are **deliberately excluded**.
+
 ### 2026-09-02 · [ad hoc] The flight manual sheds its apparatus into a read-on-demand sibling
 
 - **Change:** the six contiguous apparatus sections of `ITERATIVE_METHODOLOGY.md` — Knowledge

--- a/bin/tests.sh
+++ b/bin/tests.sh
@@ -242,6 +242,15 @@ if python3 "$METHODOLOGY/tools/test_methodology_trim.py" >/dev/null 2>&1; then
 else
     fail "ledger trimmer unit tests failed"
 fi
+# Same argument as the trimmer's, one tool over. The context_budget.py block below covers the
+# budget gate's install/sync/selftest surface; until this line its calibrate() had no test of
+# its ARITHMETIC at all, and returned noise on any repo that had merged another lineage of
+# its regressor while every row here stayed green.
+if python3 "$METHODOLOGY/tools/test_context_budget.py" >/dev/null 2>&1; then
+    pass "context budget gate unit tests green"
+else
+    fail "context budget gate unit tests failed"
+fi
 
 echo "== Test 19: dashboard twins byte-identical + same DASHBOARD_VERSION =="
 diff -q "$METHODOLOGY/tools/methodology_dashboard.py" "$STARTER/methodology_dashboard.py" >/dev/null \

--- a/starter-kit/context-budget.json
+++ b/starter-kit/context-budget.json
@@ -1,6 +1,9 @@
 {
   "_": "SEED CONFIG — copied to your project root as .context-budget.json on first sync, then yours to own. Every ceiling below is a starting point, not a law. Replace each one with a number you can defend from a measurement of YOUR project, and record the derivation in the neighbouring _ key. Re-derive the calibration with: python3 context_budget.py --calibrate",
 
+  "read_cap_tokens": 25000,
+  "_read_cap_tokens": "The agent read cap, in TOKENS — the unit the limit is actually denominated in. A whole-file read past this is refused or truncated. This is a fact about your harness, not a policy you choose: verify it rather than inheriting it. A `max_tokens` above this is rejected as a config defect, because no file could satisfy it. WHY THIS KEY EXISTS: a ceiling written in BYTES is `tokens x density`, and density is a property of your CONTENT — so every edit that changes how densely a file is written silently moves a byte ceiling, and nothing goes red. On the fork where this tool's 1.2.0 was developed (rmsharp/methodology) a declared byte ceiling certified `ok` a file the read tool REFUSES, and four of five ceilings converted to more than the cap. Declaring the ceiling in tokens makes that unrepresentable.",
+
   "bytes_per_token": 2.93,
   "_bytes_per_token": "How many bytes of dense markdown cost one token. 2.93 was calibrated on one project by a natural experiment: a commit moved 156,574 B out of CLAUDE.md and the next session's opening context fell 53,520 tokens. Run --calibrate to derive your own; do not inherit this number if you can measure it.",
 
@@ -25,6 +28,7 @@
       "path": "CLAUDE.md",
       "class": "resident",
       "max_bytes": 28000,
+      "max_tokens": 12334,
       "warn_bytes": 24000,
       "protected_fence": "budget:protected",
       "protected_min_bytes": 800,
@@ -35,6 +39,7 @@
       "class": "read-mandated",
       "max_lines": 400,
       "max_bytes": 120000,
+      "max_tokens": 25000,
       "max_line_bytes": 280,
       "structure": [
         { "pattern": "^## ACTIVE TASK", "max": 1,
@@ -46,6 +51,7 @@
     },
     {
       "path": "LEARNINGS.md",
+      "_max_tokens": "DELIBERATELY ABSENT. The read cap binds a file read WHOLE; a file read in PART is not bound by it — measured over 80 transcripts, one such file was read whole once and in part 243 times, and a partial read returns whole ROWS. So on-demand files get no token verdict, and their budget belongs on the unit actually read (a row, a record, a section). Giving this file a max_tokens would be a budget on the wrong unit, which is not conservative — it is unmeasured.",
       "class": "on-demand",
       "max_bytes": 60000,
       "_": "Optional — delete this entry if your project keeps learnings in CLAUDE.md per Phase 3C. A file a pointer sends you to open whole still has a budget: on the source project this reached 215,750 B and was measured, across 51 transcripts, to have been opened exactly once."

--- a/starter-kit/context_budget.py
+++ b/starter-kit/context_budget.py
@@ -35,9 +35,10 @@ import os
 import re
 import subprocess
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-VERSION = "1.0.0"
+VERSION = "1.2.0"
 CONFIG_NAME = ".context-budget.json"
 HISTORY_NAME = ".context-budget-history.jsonl"
 
@@ -46,6 +47,222 @@ RED = "\033[31m"; YEL = "\033[33m"; GRN = "\033[32m"; CYN = "\033[36m"
 W = 74
 
 CLEAN, WARN, BREACH, USAGE = 0, 1, 2, 3
+
+# === THE READ CAP, AND WHY THE CEILING IS DENOMINATED IN TOKENS ===
+#
+# A size ceiling exists to keep a file readable. "Readable" is denominated in TOKENS --
+# the agent read tool refuses a range over READ_CAP_TOKENS -- while a ceiling written in
+# BYTES is `tokens x density`, and density is a property of the CONTENT. So every edit
+# that changes how densely the file is written silently moves a byte ceiling, and nothing
+# goes red. Measured on the authoring fork of this tool: a declared 73,728 B ceiling
+# certified `ok` a file the read tool REFUSES at 25,486 tokens, and four of five declared
+# ceilings converted to more than the cap. Declaring the ceiling in tokens makes that
+# class of defect unrepresentable rather than merely fixed once.
+READ_CAP_TOKENS = 25_000
+
+# The FLOOR of a measured 2.2705-3.0300 B/token band, not its mean. Dividing bytes by the
+# floor MAXIMISES the token estimate, so a ceiling derived from it is conservative: it can
+# never certify an unreadable file as fine. Direction matters here and is easy to invert --
+# a LOWER B/token yields a HIGHER token count. Only ever use this to DERIVE a ceiling when
+# no measured density is available; never as a measurement of a file you can meter.
+MIN_BYTES_PER_TOKEN = 2.27
+
+# The cap re-denominated onto bytes: 25,000 x 2.27 = 56,750 B. COMPUTED, never written --
+# the same expression starter-kit/methodology_trim.py:129 uses, so the two tools cannot
+# drift apart by someone editing a literal in one of them. It answers "does ONE Read
+# deliver this whole file?", which is a different question from the per-call token limit
+# and is why both constants exist rather than one.
+READ_CAP_BYTES = int(READ_CAP_TOKENS * MIN_BYTES_PER_TOKEN)
+
+# Learning #34: "A file-size ceiling only bites when the file is read WHOLE ... measured
+# over 80 transcripts, one such file was read whole once and in part 243 times, and a
+# partial read returns whole ROWS. The cost was per-row; the guard was per-file. A budget
+# on the wrong unit is not conservative, it is unmeasured." So the read cap is applied ONLY
+# to classes the protocol orders read whole. An on-demand file gets no token verdict at
+# all -- its budget belongs on the unit actually read (a row, a record, a section).
+WHOLE_READ_CLASSES = ("resident", "read-mandated", "read-set")
+
+# "read-set" is the Phase 0 MANDATORY READ -- the runner plus the safeguards file, the pair
+# every session is ordered to read IN FULL before any work. It is a separate class from
+# "read-mandated" because a project's read-mandated ledgers are typically far larger than the
+# procedure pair, and a total over the union of the two partitions nothing. Adding it here is
+# additive: no shipped config declares this class yet, so no adopter's verdict moves until
+# they declare it themselves.
+
+# A density is measured against a particular content. Once the file has drifted this far
+# from the size it was measured at, the derived ceiling is no longer justified: report a
+# warn rather than a confident ok, and say so. This is the signal whose absence let a
+# stale ceiling report `ok` for two days after the compaction that invalidated it.
+DENSITY_DRIFT_WARN = 0.25
+
+
+def file_density(cfg, spec):
+    """(bytes_per_token, source). Per-file measured beats the config global beats the
+    floor. Returns the source so output can say which, rather than presenting a derived
+    number and a measured one in the same voice."""
+    d = spec.get("bytes_per_token")
+    if d:
+        return float(d), "measured"
+    g = (cfg or {}).get("bytes_per_token")
+    if g:
+        return float(g), "config"
+    return MIN_BYTES_PER_TOKEN, "floor"
+
+
+def token_ceiling(cfg, spec):
+    """(max_tokens, derived). An explicit max_tokens governs. Otherwise derive one from
+    max_bytes at the conservative floor so an un-migrated config keeps working AND gains
+    the guard with no edit. Either way the result is clamped at the read cap: a ceiling
+    above it cannot be satisfied by any file, so honouring it would be honouring nonsense.
+    None when the spec declares no ceiling of either kind."""
+    cap = int((cfg or {}).get("read_cap_tokens", READ_CAP_TOKENS))
+    mt = spec.get("max_tokens")
+    if mt:
+        return min(int(mt), cap), False
+    mb = spec.get("max_bytes")
+    if mb:
+        return min(int(mb / MIN_BYTES_PER_TOKEN), cap), True
+    return None, False
+
+
+def class_spec(cfg, name):
+    """The declared budget for one class, or {} when the config declares none.
+
+    `cfg["classes"]["resident"]` was a DIRECT key access at two sites, so a config that
+    declares no `classes` key raised KeyError -- and an adopter's hand-written config is
+    exactly the one that will lack it. Both sites move together or the crash relocates
+    rather than closing. Returning {} rather than None keeps every caller a `.get()`.
+    """
+    return ((cfg or {}).get("classes") or {}).get(name) or {}
+
+
+def framework_share(cfg):
+    """(share, reserve, cap) — the DERIVED ceiling for a read set, and its inputs.
+
+        framework_share := READ_CAP_BYTES - adopter_reserve_bytes
+
+    where READ_CAP_BYTES is this module's constant unless the config overrides
+    `read_cap_tokens`, in which case the cap is re-derived from it at the same floor and
+    returned as `cap_bytes` so callers report the number in force, not the constant.
+
+    THE CEILING IS DERIVED, NOT PICKED. A number someone typed drifts from the cap it is
+    supposed to be a partition of and nothing notices; a number computed from the cap
+    cannot. `adopter_reserve_bytes` is the share of one read reserved for the ADOPTER's own
+    always-read files, which the framework does not own and cannot size. Reserve zero is
+    the honest first ship: it credits the framework with the whole read, which is the
+    LEAST favourable assumption for the framework's own numbers, so a shortfall measured
+    at reserve zero cannot be blamed on the reserve.
+    """
+    # READ_CAP_BYTES is the default, so the identity in the docstring is the one that
+    # runs. A project that overrides `read_cap_tokens` gets its own cap re-derived at the
+    # same floor -- reported as `cap_bytes` so a caller can name the number actually in
+    # force rather than printing the module constant beside a different value.
+    cap = (cfg or {}).get("read_cap_tokens")
+    cap_bytes = READ_CAP_BYTES if cap is None else int(int(cap) * MIN_BYTES_PER_TOKEN)
+    reserve = int((cfg or {}).get("adopter_reserve_bytes", 0) or 0)
+    return cap_bytes - reserve, reserve, cap_bytes
+
+
+def class_ceiling(cfg, spec):
+    """(ceiling, derived). A class either DECLARES total_bytes or DERIVES it from the cap.
+
+    Returning `derived` lets a caller say which it is rather than presenting a computed
+    number and a typed one in the same voice — the same distinction file_density() draws
+    between a measured density and the floor."""
+    if (spec or {}).get("derive_from_read_cap"):
+        share, _reserve, _cap = framework_share(cfg)
+        return share, True
+    return (spec or {}).get("total_bytes"), False
+
+
+def class_totals(cfg, results):
+    """[{class, bytes, total_bytes, warn_bytes, status}] for every DECLARED class.
+
+    Two per-file ceilings do not sum. Bytes can move from SAFEGUARDS.md into
+    SESSION_RUNNER.md with both rows green while the Phase 0 read is unchanged, so the
+    thing the cap is actually about -- the total a session must read -- goes unguarded
+    unless something totals it. This is that something, and it is generalised over N
+    classes rather than hardcoded to `resident`: a project whose read set is a different
+    class, or which declares three, gets the same arm with no code change.
+
+    ORDER IS DETERMINISTIC AND `resident` LEADS. Not dict order, which would make the
+    output depend on how the config happened to be typed; and resident first because that
+    is where it has always printed, which is what keeps the rendered line byte-identical
+    for every config that declares only that one.
+
+    A class DECLARED with no member files totals 0 rather than vanishing -- a class that
+    silently disappears when its files are renamed is a gate that stops gating without
+    saying so. Rows whose path is parenthesised are this function's own output from an
+    earlier call and are excluded, or a second call would count them twice.
+    """
+    declared = (cfg or {}).get("classes") or {}
+    # `resident` is always reported, declared or not. The tool computes it unconditionally
+    # -- it is the header's number and the growth-run series' subject -- so it always HAS a
+    # total; whether a CEILING was declared for it is a separate question, answered by
+    # total_bytes being None. Dropping the line when the config omits the class would make
+    # a config that declares nothing quieter than one that declares a ceiling it passes.
+    names = sorted(set(declared) | {"resident"}, key=lambda n: (n != "resident", n))
+    out = []
+    for name in names:
+        spec = class_spec(cfg, name)
+        total = sum(r.get("bytes", 0) for r in results
+                    if r.get("class") == name and not r.get("aggregate"))
+        ceil, _derived = class_ceiling(cfg, spec)
+        warn = spec.get("warn_bytes")
+        status = "ok"
+        # `is not None`, never truthiness: a DECLARED total_bytes of 0 is a ceiling that
+        # nothing can satisfy, and reading it as "undeclared" disables the gate while the
+        # config plainly declares one.
+        if ceil is not None and total > ceil:
+            status = "over"
+        elif warn is not None and total > warn:
+            status = "warn"
+        out.append({"class": name, "bytes": total, "total_bytes": ceil,
+                    "warn_bytes": warn, "status": status})
+    return out
+
+
+def config_defects(cfg, defaults=None):
+    """Ceilings that cannot be satisfied by any file. Reported, never silently clamped --
+    a clamp would fix the symptom and leave the operator believing a number that is not
+    in force. Returns a list of human-readable strings; empty means clean."""
+    cap = int((defaults or cfg or {}).get("read_cap_tokens", READ_CAP_TOKENS))
+    out = []
+    for spec in (cfg or {}).get("files", []):
+        mt = spec.get("max_tokens")
+        if mt and int(mt) > cap:
+            out.append(f"{spec.get('path')}: max_tokens {int(mt):,} exceeds the "
+                       f"{cap:,}-token read cap by {int(mt)-cap:,} — no file can satisfy it")
+
+    # --- the reserve identity, checked where it can actually fail --------------------
+    # framework_share := READ_CAP_BYTES - adopter_reserve_bytes. NOT a module-scope
+    # assert: a module-scope assert runs at IMPORT, so it would fire in every test that
+    # merely imports this file, and a mutant that violated it would die with a traceback
+    # BEFORE the code under test ran -- scored killed by the crash rather than by the
+    # behaviour. Checked here, per config, at run time, where a wrong value is reachable.
+    share, reserve, cap_bytes = framework_share(defaults or cfg or {})
+    if reserve < 0:
+        out.append(f"adopter_reserve_bytes {reserve:,} is negative — a reserve is a share "
+                   f"of the read cap, not a credit against it")
+    elif share <= 0:
+        out.append(f"adopter_reserve_bytes {reserve:,} leaves a framework share of "
+                   f"{share:,} B against a {cap_bytes:,} B read cap — no file can satisfy "
+                   f"a ceiling of zero or less")
+    for name, cspec in sorted(((cfg or {}).get("classes") or {}).items()):
+        cspec = cspec or {}
+        if not cspec.get("derive_from_read_cap"):
+            continue
+        written = cspec.get("total_bytes")
+        if written is not None and int(written) != share:
+            # Reported, never silently honoured OR silently overwritten: the derived value
+            # is what is in force, and an operator reading the config would otherwise
+            # believe the number they typed.
+            out.append(f"class {name}: total_bytes {int(written):,} disagrees with the "
+                       f"derived framework share {share:,} B "
+                       f"(read cap {cap_bytes:,} B - adopter_reserve_bytes "
+                       f"{reserve:,}) — the DERIVED value is in force, not the written one")
+    return out
+
 
 
 # === PLUMBING ===
@@ -63,6 +280,23 @@ def run(argv, cwd=None):
         return 124, "", "timeout"
     except OSError as e:
         return 126, "", str(e)
+
+
+def blob_bytes(root, rev):
+    """Size of a git blob in BYTES, asked of git. None when `rev` does not resolve.
+
+    NEVER `len(run(["git", "show", rev]).encode())`. run() returns `p.stdout.strip()`,
+    so any content ending in a newline measures one byte short: on the authoring fork a
+    54,363 B starter-kit/SESSION_RUNNER.md came back as 54,362 from that expression. A size
+    gate that miscounts bytes is the wrong thing to build on -- and the error is silent,
+    self-consistent, and in the direction that makes an over-budget file look smaller.
+
+    `git cat-file -s` reports the object's recorded size and never decodes it, so it is
+    also correct for content that is not valid UTF-8, where `text=True` would have
+    replaced bytes and changed the length. Same idiom as size_history() already uses.
+    """
+    rc, size, _ = run(["git", "cat-file", "-s", rev], cwd=root)
+    return int(size) if rc == 0 and size.isdigit() else None
 
 
 def expand(root, p):
@@ -92,8 +326,11 @@ def load_config(root):
 
 # === MEASUREMENT ===
 
-def measure_file(root, spec):
-    """One budgeted file. status ∈ ok | warn | over | unmeasured."""
+def measure_file(root, spec, cfg=None):
+    """One budgeted file. status ∈ ok | warn | over | unmeasured.
+
+    `cfg` is optional so existing callers keep working; without it the token arm
+    falls back to the conservative floor rather than silently not running."""
     path = expand(root, spec["path"])
     out = {"path": spec["path"], "abs": path, "class": spec.get("class", "resident"),
            "findings": [], "status": "ok"}
@@ -111,6 +348,7 @@ def measure_file(root, spec):
     out["bytes"] = len(data)
     out["lines"] = len(lines)
     out["max_bytes"] = spec.get("max_bytes")
+    out["max_lines"] = spec.get("max_lines")
     out["warn_bytes"] = spec.get("warn_bytes")
 
     def over(msg, kind):
@@ -135,6 +373,37 @@ def measure_file(root, spec):
             worst = max(long, key=lambda t: t[1])
             over(f"{len(long)} line(s) exceed {cap} B — worst is line {worst[0]} at "
                  f"{worst[1]:,} B. A line ceiling alone just creates longer lines.", "line_bytes")
+
+    # --- the token arm: the unit the read cap is actually denominated in ---------
+    # Applied ONLY to classes the protocol orders read WHOLE (Learning #34). An
+    # on-demand file is read in part, so its whole-file token count is not the cost
+    # it pays and is deliberately not computed -- a verdict on the wrong unit is
+    # worse than no verdict, because it reads as though someone measured something.
+    if out["class"] in WHOLE_READ_CLASSES:
+        max_tok, derived = token_ceiling(cfg, spec)
+        if max_tok:
+            bpt, dsrc = file_density(cfg, spec)
+            out["tokens"] = int(out["bytes"] / bpt)
+            out["max_tokens"] = max_tok
+            out["density"] = bpt
+            out["density_source"] = dsrc
+            out["ceiling_derived"] = derived
+            if out["tokens"] > max_tok:
+                over(f"≈{out['tokens']:,} tokens exceeds the {max_tok:,}-token ceiling by "
+                     f"{out['tokens']-max_tok:,} — at {bpt:.4f} B/token ({dsrc})"
+                     + (f", derived from max_bytes at the {MIN_BYTES_PER_TOKEN} floor"
+                        if derived else ""), "tokens")
+            # A density is only justified near the size it was measured at. Past the
+            # drift threshold say so, rather than reporting an ok nobody can defend.
+            mb = spec.get("measured_bytes")
+            if mb and out["status"] == "ok":
+                drift = abs(out["bytes"] - int(mb)) / float(mb)
+                if drift > DENSITY_DRIFT_WARN:
+                    out["findings"].append({"kind": "density", "msg":
+                        f"density {bpt:.4f} B/token was measured at {int(mb):,} B; the file "
+                        f"is now {out['bytes']:,} B ({drift*100:.0f}% drift). The token "
+                        f"figure above is provisional — re-measure before trusting it."})
+                    out["status"] = "warn"
 
     # structure: a declared pattern matching FEWER records than expected is an
     # instrument failure, not a pass (learning #22 / #26a).
@@ -263,12 +532,13 @@ def growth_run(history, snapshot, limit):
 
 REMEDIES = {
  "bytes": [
-  ("Move", "Relocate the section to the module document that owns it "
-           "(server/, mobile/*/, database/ each have a CLAUDE.md). Resident context is "
-           "for what a session needs BEFORE it knows the task."),
+  ("Move", "Relocate the section into the document that owns it — a module- or "
+           "subsystem-level doc a session opens only once it knows the task. Resident "
+           "context is for what a session needs BEFORE it knows the task."),
   ("Compute", "Replace any hand-maintained count or list with the command that "
               "produces it. A count written into a read-often file is a future lie — "
-              "10 of 11 rows of one table here were wrong when it was finally measured."),
+              "on the project this was measured, 10 of 11 rows of one such table were "
+              "wrong by the time anyone checked."),
   ("Archive", "git already conserves every byte. Cut the content and leave "
               "`git show <sha>:<file>` — retrieval by original line number, zero new bytes."),
   ("Delete", "If another file says the same thing, delete this copy and link to it."),
@@ -308,13 +578,21 @@ def status_colour(s):
             "instrument-failed": RED, "unmeasured": CYN}.get(s, "")
 
 
-def render(root, results, synced, run_len, run_hit, cfg, snapshot):
+def render(root, results, synced, run_len, run_hit, cfg, snapshot, totals=None,
+           defects=()):
     print(f"\n{D}{'─'*W}{R}")
     worst = "ok"
     order = {"ok": 0, "unmeasured": 1, "warn": 2, "instrument-failed": 3, "over": 4}
-    for r in results + synced:
+    for r in list(results) + list(synced) + list(totals or []):
         if order[r["status"]] > order[worst]:
             worst = r["status"]
+    # A config defect is an instrument failure and main() exits BREACH on one, so the
+    # headline has to say so. It was computed over `results + synced` alone while defects
+    # were deliberately kept out of `results`, which put a green OK on the most-read line
+    # of a run that exits 2. The class totals join for the same reason: a class past its
+    # warn line had its status computed and then read by nothing.
+    if defects and order["instrument-failed"] > order[worst]:
+        worst = "instrument-failed"
     c = status_colour(worst)
     print(f"  {B}context budget{R}  {c}{B}{worst.upper()}{R}   "
           f"{D}resident {snapshot['resident_bytes']:,} B "
@@ -326,23 +604,47 @@ def render(root, results, synced, run_len, run_hit, cfg, snapshot):
         if r["status"] == "unmeasured":
             print(f"  {name:<34s}{'—':>12s}{'—':>12s}  {CYN}unmeasured{R} {D}({r['reason']}){R}")
             continue
-        size = f"{r['bytes']:,} B" if r["class"] != "read-mandated" else f"{r['lines']:,} ln"
-        ceil = (f"{r['max_bytes']:,} B" if r["class"] != "read-mandated"
-                else f"{cfg_lookup(cfg, r['path'], 'max_lines') or '—'} ln")
+        size, ceil = ledger_dimension(r)
         cc = status_colour(r["status"])
         print(f"  {name:<34s}{size:>12s}{str(ceil):>12s}  {cc}{r['status']}{R}")
     for r in synced:
         cc = status_colour(r["status"])
         print(f"  {short(r['path']):<34s}{'synced':>12s}{'canonical':>12s}  {cc}{r['status']}{R}")
 
-    tot = cfg["classes"]["resident"]
+    # One total per DECLARED class, resident first. For a config that declares only
+    # resident -- which is every instrumented adopter today -- this loop emits exactly the
+    # one line it always did, byte for byte, including the growth-run suffix. Only the
+    # undeclared-ceiling case is new, and it says so rather than crashing.
     print(f"{D}{'─'*W}{R}")
-    print(f"  resident total {B}{snapshot['resident_bytes']:,} B{R} / "
-          f"{tot['total_bytes']:,} B ceiling   "
-          f"{D}growth run {run_len}/{cfg.get('growth_run', 10)}{R}")
+    for ct in (totals if totals is not None else class_totals(cfg, results)):
+        ceil = ct["total_bytes"]
+        ceil_s = f"{ceil:,} B ceiling" if ceil else "no ceiling declared"
+        # The growth run is a series over `resident_bytes` in the history file, so it is
+        # reported on the resident row and nowhere else. Printing it beside a class it was
+        # not computed over would put a true number in a place that makes it false.
+        run_s = (f"   {D}growth run {run_len}/{cfg.get('growth_run', 10)}{R}"
+                 if ct["class"] == "resident" else "")
+        # The status is PRINTED, not merely computed. A class between its warn line and
+        # its ceiling used to set status="warn" that nothing read: render showed only
+        # bytes and ceiling, and main()'s exit code saw class rows only when they were
+        # OVER. The declared warn_bytes therefore produced no warning anywhere, in a tool
+        # whose whole subject is numbers that are declared and not honoured.
+        st = "" if ct["status"] == "ok" else f"  {status_colour(ct['status'])}{ct['status']}{R}"
+        print(f"  {ct['class']} total {B}{ct['bytes']:,} B{R} / {ceil_s}{st}{run_s}")
+
+    # Config defects print SEPARATELY from file findings and are not a results row: a row
+    # must be able to show the figure behind its own verdict (ledger_dimension), and a
+    # ceiling that cannot be satisfied has no size to show. They are also the worst thing
+    # on screen -- an unsatisfiable ceiling means every verdict below it is measured
+    # against a number that is not in force -- so they print first.
+    if defects:
+        print(f"{D}{'─'*W}{R}")
+        print(f"  {RED}{B}config defect{R} — a ceiling that is not in force")
+        for m in defects:
+            print(f"    · {m}")
 
     findings = [(r, f) for r in results + synced for f in r["findings"]]
-    if not findings and not run_hit:
+    if not findings and not run_hit and not defects:
         print(f"{D}{'─'*W}{R}\n  {GRN}nothing over budget{R}\n")
         return
     print(f"{D}{'─'*W}{R}")
@@ -367,93 +669,287 @@ def short(path, width=34):
     return ("…/" + tail)[-width:]
 
 
-def cfg_lookup(cfg, path, key):
-    for s in cfg.get("files", []):
-        if s["path"] == path:
-            return s.get(key)
-    return None
+def ledger_dimension(r):
+    """(size, ceiling) for one ledger row — reported in the dimension that ACTUALLY FIRED.
+
+    A read-mandated file now defaults to BYTES, and that changed on 2026-08-26.
+    It defaulted to lines because lines were the unit the surrounding trim rule was written
+    in -- never because the cap came in lines. It does not: the agent read cap is
+    TOKEN-denominated, and tokens track bytes, not lines. Measured across the fleet, the
+    B/line spread over these very files is 8.6x against 1.33x for B/token, so a line figure
+    is the one least able to explain a read-cap verdict. The trim rule has since been
+    re-denominated onto bytes as well (methodology_trim.py READ_CAP_BYTES), so the default
+    here and the unit the rule is written in agree again -- on the other axis.
+    (Reproduction: rmsharp/methodology, docs/planning/read-cap-premise-correction-plan.md, App. A.)
+
+    The BYTE ceiling was already able to be the one that fires, and a row reading
+    `359 ln / 1,200 ln  over` then pointed at a ceiling that did not, while the 72,449 B
+    behind the verdict appeared only in the prose further down. A ledger row that cannot
+    show the figure behind its own verdict is precisely the read-past-it failure this tool
+    exists to interrupt.
+
+    The first size finding still decides the dimension; only the nothing-fired default
+    moved. `bytes` is appended before `lines` in measure_file, so a file over both reports
+    bytes. A `max_lines` ceiling that fires is still reported in lines -- the ceilings are
+    not being removed here, only the default when neither has fired.
+
+    A TOKEN ceiling can now fire too, and when it does the row reports tokens -- the unit
+    this docstring already argued the cap is denominated in, back when bytes were the best
+    available proxy for it. Bytes are appended before tokens in measure_file, so a file
+    over both still reports bytes; tokens surface exactly in the case bytes cannot explain,
+    which is a file UNDER its byte ceiling and OVER the read cap. That case is not
+    hypothetical: it is the shipped defect this arm was added for.
+    """
+    fired = next((f["kind"] for f in r.get("findings", [])
+                  if f["kind"] in ("bytes", "lines", "tokens")), None)
+    if fired == "tokens":
+        return (f"≈{r['tokens']:,} tok",
+                f"{r['max_tokens']:,} tok" if r.get("max_tokens") else "—")
+    if (fired or "bytes") == "lines":
+        return (f"{r['lines']:,} ln",
+                f"{r['max_lines']:,} ln" if r.get("max_lines") else "—")
+    return (f"{r['bytes']:,} B",
+            f"{r['max_bytes']:,} B" if r.get("max_bytes") else "—")
 
 
 # === CALIBRATE ===
+
+# A fit whose regressor explains less than half the variance in opening context is
+# not a measurement of bytes-per-token — it is the slope of a cloud. The floor is
+# the majority-of-variance line, chosen because it is statable without reference to
+# any one project's result rather than tuned to admit a particular fit. Override per
+# project with "calibrate_min_r2" in the config.
+MIN_R2 = 0.50
+
+_ISO = re.compile(r"^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2}):(\d{2})"
+                  r"(?:\.(\d+))?(Z|z|[+-]\d{2}:?\d{2})?$")
+
+
+def parse_iso(s):
+    """ISO-8601 → aware datetime, or None if it does not parse.
+
+    Timestamps reach this tool from two sources that do not agree on format: git
+    `%cI` emits a numeric offset that moves with the season (`-05:00` and `-04:00`
+    both occur in the authoring repository's history), while session transcripts end in
+    `Z`. Ordering those AS STRINGS is not chronological — `2026-08-01T19:42:50-05:00`
+    is really `2026-08-02T00:42:50Z` but string-sorts *before* `2026-08-01T21:25:28Z`,
+    which scores that session against the wrong file size. Every comparison in this
+    section is therefore between aware datetimes.
+
+    A timestamp carrying no offset at all is read as UTC. That is an assumption, not
+    a measurement — neither real source emits one — and it is stated here rather than
+    left to whatever a comparison happened to do with it.
+    """
+    m = _ISO.match(s.strip()) if s else None
+    if not m:
+        return None
+    y, mo, d, h, mi, sec, frac, off = m.groups()
+    micro = int(frac.ljust(6, "0")[:6]) if frac else 0
+    tz = timezone.utc
+    if off and off not in ("Z", "z"):
+        digits = off[1:].replace(":", "")
+        tz = timezone((1 if off[0] == "+" else -1)
+                      * timedelta(hours=int(digits[:2]), minutes=int(digits[2:4])))
+    try:
+        return datetime(int(y), int(mo), int(d), int(h), int(mi), int(sec), micro, tz)
+    except ValueError:
+        return None                      # e.g. month 13 — matched the shape, not a date
+
+
+def size_history(root, target, first_parent=True):
+    """(history, skipped, error) — `target`'s size over time on ONE line of development.
+
+    `git log -- <path>` walks ALL merged ancestry. On a repository that has merged
+    another lineage of the same file — every fork that syncs an upstream, which is
+    the workflow this methodology documents — two unrelated size series interleave
+    by commit date and "the size of X at time T" stops being a function. Measured on
+    this framework's own fork: all-ancestry yields 54 size records against
+    `--first-parent`'s 42, and the fit's R² falls from 0.81 to 0.05. So this asks the
+    question actually being asked: how large was this file, *here*, on this branch.
+
+    `first_parent=False` exists only so the regression test can exhibit that defect
+    against a fixture repository. Nothing in the tool passes it.
+
+    `skipped` counts commits whose timestamp did not parse, so a silently shrinking
+    sample is reported rather than inferred.
+    """
+    argv = ["git", "log", "--format=%H %cI"]
+    if first_parent:
+        argv.append("--first-parent")
+    argv += ["--", target]
+    rc, log, err = run(argv, cwd=root)
+    if rc:
+        return None, 0, err
+    hist, skipped = [], 0
+    for line in log.split("\n"):
+        if not line.strip():
+            continue
+        sha, _, iso = line.partition(" ")
+        when = parse_iso(iso)
+        if when is None:
+            skipped += 1
+            continue
+        rc2, size, _ = run(["git", "cat-file", "-s", f"{sha}:{target}"], cwd=root)
+        if rc2 == 0 and size.isdigit():
+            hist.append((when, int(size)))
+    hist.sort(key=lambda t: t[0])
+    return hist, skipped, None
+
+
+def size_at(hist, when):
+    """The size in effect at `when` — the last record at or before it, not the nearest.
+
+    Requires `hist` chronologically sorted, which is why it may stop at the first
+    record past `when`: that early exit is only correct under the ordering
+    size_history establishes, and breaking it would break this.
+    """
+    best = None
+    for t, size in hist:
+        if t <= when:
+            best = size
+        else:
+            break
+    return best
+
+
+def linfit(pts):
+    """Ordinary least squares over [(x, y)] → (slope, intercept, r2).
+
+    Returns None when the regressor has no variance: no line is determined, and
+    inventing one would be the same error this tool exists to catch. `r2` is None —
+    never 0.0, never 1.0 — when the response has no variance to explain, because an
+    undefined statistic rendered as a number is indistinguishable from a measured one.
+    """
+    n = len(pts)
+    sx = sum(p[0] for p in pts); sy = sum(p[1] for p in pts)
+    sxx = sum(p[0]**2 for p in pts); sxy = sum(p[0]*p[1] for p in pts)
+    den = n*sxx - sx*sx
+    if den == 0:
+        return None
+    slope = (n*sxy - sx*sy) / den
+    inter = (sy - slope*sx) / n
+    my = sy/n
+    ss_tot = sum((p[1]-my)**2 for p in pts)
+    ss_res = sum((p[1] - (inter + slope*p[0]))**2 for p in pts)
+    return slope, inter, (1 - ss_res/ss_tot if ss_tot else None)
+
+
+def calibration_verdict(slope, r2, floor):
+    """None if the fit supports a bytes-per-token constant, else why it does not.
+
+    Separated from the printing so it can be observed refusing. The slope test is
+    not redundant with the R² test: a tight fit with a NEGATIVE slope has a high R²
+    and still means "more bytes, fewer tokens", whose reciprocal is not a conversion.
+    """
+    if slope is None or slope <= 0:
+        return (f"the slope is {slope:.4f} — more bytes fitting FEWER tokens is not a "
+                f"conversion, and its reciprocal is not bytes-per-token")
+    if r2 is None:
+        return "R² is undefined — opening context never varied, so nothing was explained"
+    if r2 < floor:
+        return (f"R² = {r2:.4f} is below the {floor:.2f} floor — the regressor explains "
+                f"{r2*100:.0f}% of the variance in opening context")
+    return None
+
 
 def calibrate(root, cfg):
     """Re-derive bytes-per-token by regressing each session's opening context against
     the size of the resident file at that moment. Writes nothing. A tool whose thesis
     is 'store a fact as the command that produces it' must not carry its own constant
-    as an unmeasured literal."""
+    as an unmeasured literal.
+
+    It must equally not hand back a constant it cannot support. Below the floor the
+    fit is printed in full and the derived number is REFUSED: printing `1/slope`
+    beside R² = 0.05 with the same confidence as R² = 0.81 is exactly the
+    read-past-it failure (FM #28) this tool was built to interrupt, committed by the
+    tool itself. An adopter has no second instrument to catch it with.
+    """
     slug = "-" + str(Path(root).resolve()).strip("/").replace("/", "-")
     tdir = Path.home() / ".claude" / "projects" / slug
     if not tdir.exists():
         print(f"{CYN}no transcripts at {tdir} — cannot calibrate{R}")
         return WARN
     target = cfg.get("calibrate_against", "CLAUDE.md")
-    rc, log, err = run(["git", "log", "--format=%H %cI", "--", target], cwd=root)
-    if rc:
+    hist, skipped, err = size_history(root, target)
+    if hist is None:
         print(f"{RED}git log failed: {err}{R}")
         return USAGE
-    hist = []
-    for line in log.split("\n"):
-        if not line.strip():
-            continue
-        sha, iso = line.split(None, 1)
-        rc2, size, _ = run(["git", "cat-file", "-s", f"{sha}:{target}"], cwd=root)
-        if rc2 == 0 and size.isdigit():
-            hist.append((iso.strip(), int(size)))
-    hist.sort()
+    if skipped:
+        print(f"{YEL}{skipped} commit timestamp(s) for {target} did not parse and were "
+              f"dropped from the history{R}")
     if len(hist) < 3:
         print(f"{CYN}only {len(hist)} sizes of {target} in history — not enough{R}")
         return WARN
 
-    def size_at(iso):
-        best = None
-        for when, size in hist:
-            if when <= iso:
-                best = size
-        return best
-
-    pts = []
+    pts, undated = [], 0
     for f in sorted(tdir.glob("*.jsonl")):
         first_ts = first_ctx = None
         try:
-            for line in open(f, errors="ignore"):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    rec = json.loads(line)
-                except ValueError:
-                    continue
-                if first_ts is None and rec.get("timestamp"):
-                    first_ts = rec["timestamp"]
-                u = (rec.get("message") or {}).get("usage") or {}
-                if u:
-                    first_ctx = (u.get("input_tokens", 0) + u.get("cache_read_input_tokens", 0)
-                                 + u.get("cache_creation_input_tokens", 0))
-                    break
+            # `with`, because this loop BREAKS out on the first usage record — one
+            # descriptor per transcript was being left to the garbage collector, and a
+            # project with hundreds of them can exhaust the process limit before the fit
+            # is ever reached.
+            with open(f, errors="ignore") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except ValueError:
+                        continue
+                    if first_ts is None and rec.get("timestamp"):
+                        first_ts = rec["timestamp"]
+                    u = (rec.get("message") or {}).get("usage") or {}
+                    if u:
+                        first_ctx = (u.get("input_tokens", 0)
+                                     + u.get("cache_read_input_tokens", 0)
+                                     + u.get("cache_creation_input_tokens", 0))
+                        break
         except OSError:
             continue
         if first_ts and first_ctx:
-            s = size_at(first_ts)
+            when = parse_iso(first_ts)
+            if when is None:
+                undated += 1
+                continue
+            s = size_at(hist, when)
             if s:
                 pts.append((s, first_ctx))
+    if undated:
+        print(f"{YEL}{undated} transcript(s) had an unparseable opening timestamp and were "
+              f"dropped{R}")
     if len(pts) < 4:
         print(f"{CYN}only {len(pts)} usable sessions — not enough to fit{R}")
         return WARN
-    n = len(pts)
-    sx = sum(p[0] for p in pts); sy = sum(p[1] for p in pts)
-    sxx = sum(p[0]**2 for p in pts); sxy = sum(p[0]*p[1] for p in pts)
-    den = n*sxx - sx*sx
-    if den == 0:
+    fitted = linfit(pts)
+    if fitted is None:
         print(f"{CYN}no variation in {target} size across sessions — cannot fit{R}")
         return WARN
-    slope = (n*sxy - sx*sy) / den
-    inter = (sy - slope*sx) / n
-    my = sy/n
-    ss_tot = sum((p[1]-my)**2 for p in pts)
-    ss_res = sum((p[1] - (inter + slope*p[0]))**2 for p in pts)
-    r2 = 1 - ss_res/ss_tot if ss_tot else float("nan")
-    print(f"\n  n={n} sessions, regressor = bytes({target})")
-    print(f"  opening_tokens ≈ {inter:,.0f} + {slope:.4f} × bytes      R² = {r2:.4f}")
+    slope, inter, r2 = fitted
+
+    print(f"\n  n={len(pts)} sessions, regressor = bytes({target}), "
+          f"{len(hist)} sizes on this branch")
+    print(f"  opening_tokens ≈ {inter:,.0f} + {slope:.4f} × bytes      "
+          f"R² = {'undefined' if r2 is None else f'{r2:.4f}'}")
+
+    floor = cfg.get("calibrate_min_r2", MIN_R2)
+    refused = calibration_verdict(slope, r2, floor)
+    if refused:
+        print(f"\n  {RED}{B}no constant recommended{R} — {refused},")
+        print(f"  so 1/slope is an artefact of the scatter rather than a measurement.")
+        print(f"\n  {B}What to check, cheapest first:{R}")
+        print(f"    1. Is {target} the right regressor? It has to be BOTH auto-loaded into")
+        print(f"       every session AND actually varying in size over the window. Set")
+        print(f'       "calibrate_against" in {CONFIG_NAME}.')
+        print(f"    2. Does this project's opening context come mostly from elsewhere —")
+        print(f"       other resident files, tool schemas, agent-level memory? Then no")
+        print(f"       single file's byte count will track it, and none should be expected to.")
+        print(f"    3. Did {target} really vary here? {len(hist)} recorded sizes on this branch.")
+        print(f"\n  {D}the fit is printed above in full so you can judge it yourself; "
+              f"nothing was written{R}\n")
+        return WARN
+
     print(f"  ⇒ {1/slope:.2f} bytes/token   (config carries {cfg.get('bytes_per_token')})")
     print(f"  ⇒ fixed harness floor ≈ {inter:,.0f} tokens\n")
     print(f"  {D}writes nothing — edit {CONFIG_NAME} yourself if you want to adopt these{R}\n")
@@ -504,27 +1000,99 @@ def install_hook(root):
 def precommit(root, cfg):
     """Relative rule: refuse only when the staged file is over ceiling AND larger than
     HEAD. A commit that reduces an over-budget file must never be blocked, or the tool
-    prevents its own remedy."""
+    prevents its own remedy. The same rule governs the class-aggregate arm below."""
     bad = []
+    # Surfaced here too, or the hook enforces ceilings while silently disagreeing with the
+    # config about what they are. Printed rather than added to `bad`: a config defect is
+    # not a file that grew, and the relative rule has nothing to say about it.
+    for m in config_defects(cfg):
+        print(f"{YEL}context-budget: config defect — {m}{R}")
+    staged, head = {}, {}
     for spec in cfg.get("files", []):
-        path = expand(root, spec["path"])
-        if not os.path.exists(path) or os.path.isabs(spec["path"]):
-            continue  # files outside the repo are not staged by this commit
-        rc, staged, _ = run(["git", "show", f":{spec['path']}"], cwd=root)
-        if rc:
-            continue  # not staged
-        new = len(staged.encode())
-        rc2, head, _ = run(["git", "show", f"HEAD:{spec['path']}"], cwd=root)
-        old = len(head.encode()) if rc2 == 0 else 0
+        if os.path.isabs(spec["path"]):
+            continue  # files outside the repo are not part of this commit
+        # A COMMIT CONTAINS THE INDEX, NOT THE WORKTREE, and this loop must be driven by
+        # the index or the aggregate below is wrong in BOTH directions. The worktree test
+        # that used to stand here (`if not os.path.exists(path): continue`) ran BEFORE any
+        # bookkeeping, which meant:
+        #   * a member removed by `git rm` was dropped from the HEAD side as well as the
+        #     staged side, so deleting a member -- the most direct remedy for an
+        #     over-budget class -- was not credited and the survivors read as pure growth.
+        #     Measured: a 4,200 -> 1,300 B reduction was REFUSED, reported as 1,200 -> 1,300.
+        #   * a member staged with content but absent from the worktree was skipped
+        #     entirely and counted as ZERO, so an index holding 1,800 B against a 1,000 B
+        #     ceiling PASSED.
+        # Both are the same line, and both are the failure the relative rule exists to
+        # prevent. `git cat-file -s :path` reads the INDEX and does not care whether the
+        # worktree copy still exists, which is exactly the question a pre-commit hook asks.
+        new = blob_bytes(root, f":{spec['path']}")
+        old = blob_bytes(root, f"HEAD:{spec['path']}")
+        if new is None and old is None:
+            continue  # not tracked on either side — nothing this commit can be judged on
+        cls = spec.get("class", "resident")
+        staged[cls] = staged.get(cls, 0) + (new or 0)
+        if new is None:
+            continue  # deleted: there is no per-file verdict to give, only the aggregate
+        old = old or 0
         ceil = spec.get("max_bytes")
         if ceil and new > ceil and new > old:
-            bad.append((spec["path"], old, new, ceil))
+            bad.append((spec["path"], old, new, ceil, "B", f"{ceil:,} B"))
+            continue
+        # The token ceiling gates here too, or the tool reports in one unit and refuses
+        # in another. Same relative rule: a commit that SHRINKS an over-budget file is
+        # never blocked, so the gate can never prevent its own remedy.
+        if spec.get("class", "resident") in WHOLE_READ_CLASSES:
+            max_tok, _derived = token_ceiling(cfg, spec)
+            if max_tok:
+                bpt, _src = file_density(cfg, spec)
+                ntok, otok = int(new / bpt), int(old / bpt)
+                if ntok > max_tok and ntok > otok:
+                    bad.append((spec["path"], otok, ntok, max_tok, "tok",
+                                f"{max_tok:,} tok"))
+
+    # THE BASELINE IS HEAD'S OWN DECLARATION, NOT TODAY'S.
+    # `head` must answer "what did this class contain at HEAD?", and only HEAD's config can
+    # say. Summing HEAD blob sizes over the CURRENT member list silently drops the bytes of
+    # any member that LEAVES the class in this commit — renamed with the config updated to
+    # match, or reclassified — so a rename that shrinks a class read as pure growth and was
+    # refused. Falls back to the current list when HEAD has no config (the first commit that
+    # adds one), which is the only case where there is no prior declaration to consult.
+    head = {}
+    rc_cfg, head_cfg_raw, _ = run(["git", "show", f"HEAD:{CONFIG_NAME}"], cwd=root)
+    head_files = cfg.get("files", [])
+    if rc_cfg == 0:
+        try:
+            head_files = (json.loads(head_cfg_raw) or {}).get("files", head_files)
+        except ValueError:
+            pass          # unparseable HEAD config — fall back rather than guess
+    for spec in head_files:
+        if os.path.isabs(spec.get("path", "")):
+            continue
+        prev = blob_bytes(root, f"HEAD:{spec['path']}")
+        if prev is None:
+            continue
+        cls = spec.get("class", "resident")
+        head[cls] = head.get(cls, 0) + prev
+
+    # --- the class-aggregate arm ---------------------------------------------------
+    # PER-FILE CEILINGS DO NOT SUM. Bytes can move out of SAFEGUARDS.md and into
+    # SESSION_RUNNER.md leaving both rows green while the Phase 0 read is unchanged, so
+    # the quantity the cap is actually about goes unguarded unless something totals it.
+    # main() reports that total; without this arm the tool would ship an aggregate that
+    # REPORTS AND CANNOT REFUSE, which is half a gate. Same relative rule throughout.
+    for name, cspec in sorted((cfg.get("classes") or {}).items()):
+        ceil, _derived = class_ceiling(cfg, cspec)
+        if ceil is None:
+            continue  # `not ceil` would treat a DECLARED total_bytes of 0 as undeclared
+        new_t, old_t = staged.get(name, 0), head.get(name, 0)
+        if new_t > ceil and new_t > old_t:
+            bad.append((f"({name} total)", old_t, new_t, ceil, "B", f"{ceil:,} B"))
     if not bad:
         return CLEAN
     print(f"\n{RED}{B}context-budget: REFUSED{R}")
-    for path, old, new, ceil in bad:
-        print(f"  {B}{path}{R}  {old:,} -> {new:,} B   ceiling {ceil:,} B")
-        print(f"    +{new-old:,} B this commit, {new-ceil:,} B over.")
+    for path, old, new, ceil, unit, ceil_s in bad:
+        print(f"  {B}{path}{R}  {old:,} -> {new:,} {unit}   ceiling {ceil_s}")
+        print(f"    +{new-old:,} {unit} this commit, {new-ceil:,} {unit} over.")
     print(f"\n  Cheapest legal actions:")
     for i, (name, how) in enumerate(REMEDIES["bytes"], 1):
         print(f"    {i}. {B}{name}{R} — {how}")
@@ -585,6 +1153,132 @@ def selftest(root, cfg):
     rc, _, _ = run(["definitely-not-a-real-binary-xyz"])
     check("a missing binary surfaces as rc=127, never as empty success", rc == 127)
 
+    # --- calibration: the comparisons, the arithmetic, and the gate on the result ---
+    # This exact pair is the one the authoring fork of this tool was mis-fitted on.
+    # The second check is the CONTROL: it asserts the string comparison really does
+    # give the wrong answer here, so the first check is not passing for free.
+    early = parse_iso("2026-08-01T19:42:50-05:00")        # = 2026-08-02T00:42:50Z
+    later = parse_iso("2026-08-01T21:25:28Z")
+    check("a -05:00 stamp later in UTC compares as later", early > later)
+    check("...and comparing that same pair AS STRINGS is the wrong answer",
+          "2026-08-01T19:42:50-05:00" < "2026-08-01T21:25:28Z")
+    check("both offset signs land on the same instant",
+          parse_iso("2026-08-01T19:42:50-05:00") == parse_iso("2026-08-02T02:42:50+02:00"))
+    check("fractional seconds with Z parse", parse_iso("2026-08-01T21:25:28.417Z") is not None)
+    check("a non-timestamp is None, never a silent default", parse_iso("not-a-date") is None)
+    check("date-shaped but impossible is None too", parse_iso("2026-13-01T00:00:00Z") is None)
+
+    h = [(parse_iso("2026-01-01T00:00:00Z"), 100), (parse_iso("2026-01-03T00:00:00Z"), 300)]
+    check("size_at gives the size in EFFECT, not the nearest record",
+          size_at(h, parse_iso("2026-01-03T18:00:00Z")) == 300
+          and size_at(h, parse_iso("2026-01-02T18:00:00Z")) == 100)
+    check("size_at before all history is None, never the first size",
+          size_at(h, parse_iso("2025-06-01T00:00:00Z")) is None)
+
+    f = linfit([(x, 3*x + 7) for x in (1, 2, 3, 4)])
+    check("linfit recovers a known slope and intercept exactly",
+          f and abs(f[0]-3) < 1e-9 and abs(f[1]-7) < 1e-9 and abs(f[2]-1) < 1e-9)
+    check("linfit refuses a regressor with no variance", linfit([(5, 1), (5, 2), (5, 3)]) is None)
+    f = linfit([(1, 9), (2, 9), (3, 9)])
+    check("R² is undefined — not 1.0 — when the response never varies", f and f[2] is None)
+    f = linfit([(1, 50), (2, 10), (3, 90), (4, 20)])
+    check("a scatter fits with a low R²", f and f[2] < MIN_R2)
+
+    check("a fit above the floor is accepted", calibration_verdict(0.36, 0.81, MIN_R2) is None)
+    check("a fit exactly AT the floor is accepted",
+          calibration_verdict(0.36, MIN_R2, MIN_R2) is None)
+    check("a low-R² fit is refused, however confident the number looks",
+          calibration_verdict(0.07, 0.05, MIN_R2) is not None)
+    check("a NEGATIVE slope is refused however good the fit",
+          calibration_verdict(-0.36, 0.99, MIN_R2) is not None)
+    check("an undefined R² is refused, not treated as perfect",
+          calibration_verdict(0.36, None, MIN_R2) is not None)
+
+    # The ledger row must name the ceiling that fired. A read-mandated file over its
+    # BYTE ceiling reported as `359 ln / 1,200 ln` points at the ceiling that did not.
+    row = {"class": "read-mandated", "lines": 359, "max_lines": 1200,
+           "bytes": 72449, "max_bytes": 65536, "status": "over",
+           "findings": [{"kind": "bytes", "msg": "x"}]}
+    check("the row shows the ceiling that fired, not the class default",
+          ledger_dimension(row) == ("72,449 B", "65,536 B"))
+    check("with nothing fired, a read-mandated row now reports BYTES (since 2026-08-26)",
+          ledger_dimension({**row, "findings": [], "status": "ok"}) == ("72,449 B", "65,536 B"))
+    check("a LINE finding still reports lines -- only the default moved, not the dispatch",
+          ledger_dimension({**row, "findings": [{"kind": "lines", "msg": "x"}]})
+          == ("359 ln", "1,200 ln"))
+    check("an undeclared ceiling renders as — rather than crashing",
+          ledger_dimension({"class": "resident", "bytes": 10, "lines": 1,
+                            "findings": []}) == ("10 B", "—"))
+
+    check("the byte remedies name no directory from the tool's home project",
+          not any(s in REMEDIES["bytes"][0][1] for s in ("server/", "mobile/", "database/")))
+
+    # --- the class aggregate. Every gate must be observed FAILING, not just passing, and
+    # this is the only coverage of the new arm that reaches an adopter at all.
+    pair = {"classes": {"pair": {"total_bytes": 1000, "warn_bytes": 600}},
+            "files": [{"path": "A.md", "class": "pair"},
+                      {"path": "B.md", "class": "pair"}]}
+    def _rows(a, b, cls="pair"):
+        return [{"path": "A.md", "class": cls, "bytes": a, "findings": [], "status": "ok"},
+                {"path": "B.md", "class": cls, "bytes": b, "findings": [], "status": "ok"}]
+    tot = {c["class"]: c for c in class_totals(pair, _rows(600, 600))}["pair"]
+    check("a class total fires while every member is individually green",
+          tot["bytes"] == 1200 and tot["status"] == "over")
+    tot = {c["class"]: c for c in class_totals(pair, _rows(300, 200))}["pair"]
+    check("a class total under both its ceiling and its warn line passes",
+          tot["bytes"] == 500 and tot["status"] == "ok")
+    tot = {c["class"]: c for c in class_totals(pair, _rows(400, 300))}["pair"]
+    check("a class past its warn line but under its ceiling WARNS -- the seed has "
+          "declared classes.resident.warn_bytes since it shipped and nothing read it",
+          tot["bytes"] == 700 and tot["status"] == "warn")
+    check("moving bytes between members leaves the total unmoved -- the hole per-file "
+          "ceilings cannot see",
+          class_totals(pair, _rows(900, 300))[-1]["bytes"]
+          == class_totals(pair, _rows(300, 900))[-1]["bytes"] == 1200)
+    three = {"classes": {"resident": {"total_bytes": 100}, "pair": {"total_bytes": 1000},
+                         "third": {"total_bytes": 50}}, "files": []}
+    got = {c["class"]: c["bytes"] for c in class_totals(
+        three, _rows(600, 600) + _rows(80, 5, "third") + _rows(40, 0, "resident"))}
+    check("a third class totals on its OWN members",
+          got == {"resident": 40, "pair": 1200, "third": 85})
+    check("declared classes report in a deterministic order, resident first",
+          [c["class"] for c in class_totals(
+              {"classes": {"zeta": {}, "alpha": {}, "resident": {}}}, [])]
+          == ["resident", "alpha", "zeta"])
+    check("a declared class with no members totals 0 rather than vanishing",
+          class_totals({"classes": {"ghost": {"total_bytes": 10}}}, [])[-1]["bytes"] == 0)
+    check("this function's own pseudo-row is not counted a second time",
+          class_totals(pair, _rows(600, 600) + [{"path": "(pair total)", "class": "pair",
+                                                 "bytes": 1200, "findings": [],
+                                                 "aggregate": True,
+                                                 "status": "over"}])[-1]["bytes"] == 1200)
+    check("a DECLARED file whose name starts with '(' is still counted",
+          class_totals({"classes": {"pair": {"total_bytes": 1000}}},
+                       [{"path": "(draft) notes.md", "class": "pair", "bytes": 1200,
+                         "findings": [], "status": "ok"}])[-1]["bytes"] == 1200)
+    check("a declared class ceiling of 0 is a ceiling, not an absent one",
+          class_totals({"classes": {"z": {"total_bytes": 0}}},
+                       [{"path": "a", "class": "z", "bytes": 1, "findings": [],
+                         "status": "ok"}])[-1]["status"] == "over")
+
+    # --- the reserve identity: framework_share := READ_CAP_BYTES - adopter_reserve_bytes
+    check("READ_CAP_BYTES is computed from the cap, never written",
+          READ_CAP_BYTES == int(READ_CAP_TOKENS * MIN_BYTES_PER_TOKEN) == 56750)
+    check("the framework share is the cap minus the reserve",
+          framework_share({"adopter_reserve_bytes": 28000}) == (28750, 28000, 56750))
+    check("a derived class ceiling ignores the number written beside it",
+          class_ceiling({}, {"total_bytes": 999, "derive_from_read_cap": True})
+          == (56750, True))
+    check("a written ceiling that disagrees with the derivation is REPORTED",
+          config_defects({"classes": {"r": {"total_bytes": 999,
+                                            "derive_from_read_cap": True}}}) != [])
+    check("a written ceiling that agrees is clean",
+          config_defects({"classes": {"r": {"total_bytes": 56750,
+                                            "derive_from_read_cap": True}}}) == [])
+    check("a reserve that consumes the whole cap is refused",
+          config_defects({"adopter_reserve_bytes": 56750}) != [])
+    check("a config with no classes key does not raise", class_spec({}, "resident") == {})
+
     check("--force is not offered", "--force" not in open(__file__).read()
           .split("def selftest")[0])
     print()
@@ -638,19 +1332,43 @@ def main():
     if "--precommit" in args:
         return precommit(root, cfg)
 
-    results = [measure_file(root, s) for s in cfg.get("files", [])]
+    results = [measure_file(root, s, cfg) for s in cfg.get("files", [])]
     synced = [check_synced(root, s) for s in cfg.get("synced", [])]
+    # config_defects() had NO call site: it was defined, unit-tested, and never run, while
+    # the distributed seed told adopters "a max_tokens above this is rejected as a config
+    # defect". A guard nothing calls is a comment shaped like a guard. Wired here so the
+    # reserve identity above is genuinely asserted at run time rather than merely written.
+    defects = config_defects(cfg)
     resident = sum(r.get("bytes", 0) for r in results if r["class"] == "resident")
+    # `resident_bytes` stays the growth-run series' key -- load_history()/growth_run()
+    # read it out of every record already on disk, so renaming it would silently reset
+    # the run to zero on a file that looks fine. class_bytes is additive beside it.
     snapshot = {"resident_bytes": resident,
+                "class_bytes": {c["class"]: c["bytes"] for c in class_totals(cfg, results)},
                 "files": {r["path"]: r.get("bytes") for r in results}}
 
-    tot = cfg["classes"]["resident"]
-    if resident > tot["total_bytes"]:
-        results.append({"path": "(resident total)", "class": "resident", "status": "over",
-                        "bytes": resident, "max_bytes": tot["total_bytes"], "findings":
-                        [{"kind": "bytes", "msg":
-                          f"{resident:,} B across all auto-loaded files exceeds the "
-                          f"{tot['total_bytes']:,} B ceiling"}]})
+    # Computed BEFORE the pseudo-rows below are appended: class_totals() excludes
+    # parenthesised paths for the same reason, but relying on one guard where two are
+    # cheap is how a double count gets shipped.
+    totals = class_totals(cfg, results)
+    for ct in totals:
+        ceil = ct["total_bytes"]
+        if not ceil or ct["bytes"] <= ceil:
+            continue
+        # "auto-loaded" describes the resident class specifically, so the resident wording
+        # -- and therefore the (resident total) row the adopters are compared on -- is
+        # unchanged, while another class gets a sentence that is true of it.
+        where = ("across all auto-loaded files" if ct["class"] == "resident"
+                 else f"across the {ct['class']} class")
+        results.append({"path": f"({ct['class']} total)", "class": ct["class"],
+                        "status": "over", "bytes": ct["bytes"], "max_bytes": ceil,
+                        # The marker class_totals() filters on. A flag, never the path:
+                        # the path is user-supplied data and a project may legitimately
+                        # declare a file whose name starts with "(".
+                        "aggregate": True,
+                        "findings": [{"kind": "bytes", "msg":
+                                      f"{ct['bytes']:,} B {where} exceeds the "
+                                      f"{ceil:,} B ceiling"}]})
 
     hist = load_history(root)
     run_len, run_hit = growth_run(hist, snapshot, cfg.get("growth_run", 10))
@@ -658,12 +1376,20 @@ def main():
 
     if "--json" in args:
         print(json.dumps({"resident_bytes": resident, "growth_run": run_len,
-                          "files": results, "synced": synced}, indent=2, default=str))
+                          "class_totals": totals, "config_defects": defects,
+                          "files": results, "synced": synced},
+                         indent=2, default=str))
     else:
-        render(root, results, synced, run_len, run_hit, cfg, snapshot)
+        render(root, results, synced, run_len, run_hit, cfg, snapshot, totals,
+               defects)
 
-    states = [r["status"] for r in results + synced]
-    if "over" in states or "instrument-failed" in states:
+    # Class totals vote too. Without them a class in WARN was invisible to the exit code,
+    # so a CI step gating on it could not see the one signal that arrives before a breach.
+    states = [r["status"] for r in results + synced] + [c["status"] for c in totals]
+    # A config defect is an INSTRUMENT failure, which this tool's own ordering already
+    # ranks above `over`: if a declared ceiling is not the one in force, every verdict
+    # measured against it is unreliable, including the green ones.
+    if defects or "over" in states or "instrument-failed" in states:
         return BREACH
     if "warn" in states or "unmeasured" in states or run_hit:
         return WARN

--- a/tools/test_context_budget.py
+++ b/tools/test_context_budget.py
@@ -1,0 +1,1311 @@
+#!/usr/bin/env python3
+"""Behaviour tests for starter-kit/context_budget.py — the FM #28 size-budget gate.
+
+CANONICAL-ONLY. Not in bin/_manifest.py, so adopters do not receive it. The tool's own
+`--selftest` ships to them and covers every pure gate; what cannot ship is this file's
+git fixtures, which need a scratch repository with a real merge in it.
+
+WHY THIS FILE EXISTS AT ALL. Until the 2026-08-15 `calibrate()` repair it had no test asserting
+its arithmetic — the tool's bin/tests.sh block covered install-hook, sync distribution and the
+selftest gates, all of which stayed green while the fit itself returned noise on any repo
+that had merged another lineage of its regressor. A shipped executable can be arbitrarily
+wrong in a dimension nothing asserts. That is the same argument the harness already makes
+for the ledger trimmer at bin/tests.sh:237-244.
+
+DISCIPLINE THIS FILE IS WRITTEN UNDER (inherited from tools/test_methodology_trim.py):
+
+  * PROVE THE FIXTURE FIRST. Every fixture asserts what it IS before anything is asserted
+    about what the code does to it. A merge fixture that failed to create a merge would
+    make the D1 tests pass for the wrong reason, forever.
+  * DRIVE EACH GUARD RED. Green is not evidence until red has been observed. Each defect
+    below is exhibited as well as fixed: D1 through `first_parent=False`, which is the
+    real pre-change behaviour preserved as a parameter for exactly this purpose, and D2
+    through `_string_size_at`, a verbatim re-implementation of the shipped comparison.
+  * NARROW THE GUARD, DO NOT ONLY DELETE IT. The plausible weaker implementation is shown
+    to give the WRONG answer on the same fixture, which is what makes the strong version
+    load-bearing rather than merely present.
+  * ASSERT ON VALUES, NEVER ON A TOOL'S EXIT CODE. An exit code is a union over every
+    check the tool runs, so adding a check silently re-labels unrelated assertions.
+
+THE PRE-CHANGE TOOL is blob be2721a5fa12df027636d1451d84301293467fae — `git cat-file blob
+be2721a` — should anyone need to re-run the four-way fit that motivated this.
+"""
+
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.dont_write_bytecode = True          # no starter-kit/__pycache__ from this import
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent
+CB_PY = REPO / "starter-kit" / "context_budget.py"
+
+_spec = importlib.util.spec_from_file_location("context_budget", str(CB_PY))
+cb = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(cb)
+
+
+def git(repo, *args, when=None, check=True):
+    """Run git in `repo`. `when` pins BOTH author and committer date, which is what makes
+    the ordering fixtures reproducible — %cI reads the committer date, not the author's.
+    `check=False` is for the deliberate conflict in the merge fixture."""
+    env = dict(os.environ, GIT_AUTHOR_NAME="t", GIT_AUTHOR_EMAIL="t@t",
+               GIT_COMMITTER_NAME="t", GIT_COMMITTER_EMAIL="t@t")
+    if when:
+        env["GIT_AUTHOR_DATE"] = env["GIT_COMMITTER_DATE"] = when
+    p = subprocess.run(["git", "-C", str(repo), *args], env=env,
+                       capture_output=True, text=True)
+    if check and p.returncode:
+        raise AssertionError(f"git {' '.join(args)} failed: {p.stderr.strip()}")
+    return p.stdout.strip()
+
+
+def write_commit(repo, name, size, when, msg=None):
+    (Path(repo) / name).write_text("x" * size)
+    git(repo, "add", name)
+    git(repo, "commit", "-m", msg or f"{name} -> {size}", when=when)
+
+
+def new_repo(d):
+    git(d, "init", "-q", "-b", "main")
+    return d
+
+
+# ---------------------------------------------------------------------------------
+# D1 — lineage. `git log -- <path>` walks ALL merged ancestry, so on a repository that
+# has merged another lineage of the same file, two size series interleave by commit
+# date and "the size of X at time T" stops being a function.
+# ---------------------------------------------------------------------------------
+
+class TestLineage(unittest.TestCase):
+
+    def _forked_repo(self, d):
+        """main: 100 B at t0, 200 B at t2. A side branch carries 50,000 B at t1 — a size
+        that NEVER existed on main — and is merged at t3, the merge RESOLVING the file to
+        300 B.
+
+        The resolution matters, and the first draft of this fixture got it wrong. A merge
+        taken with `-s ours` leaves the tree TREESAME to the first parent, and git's
+        DEFAULT history simplification then prunes the side branch from `git log -- <path>`
+        on its own — so the defect does not reproduce and every assertion below would have
+        passed against the broken code. D1 requires a merge that genuinely changed the
+        target, which is exactly the case this framework's own workflow produces: a fork
+        syncing an upstream that has edited the same file.
+        """
+        new_repo(d)
+        write_commit(d, "CLAUDE.md", 100, "2026-01-01T00:00:00+00:00")
+        git(d, "checkout", "-q", "-b", "side")
+        write_commit(d, "CLAUDE.md", 50000, "2026-01-02T00:00:00+00:00")
+        git(d, "checkout", "-q", "main")
+        write_commit(d, "CLAUDE.md", 200, "2026-01-03T00:00:00+00:00")
+        git(d, "merge", "--no-commit", "--no-ff", "side", check=False)   # conflicts, by design
+        (Path(d) / "CLAUDE.md").write_text("x" * 300)                    # the resolution
+        git(d, "add", "CLAUDE.md")
+        git(d, "commit", "-m", "merge side", when="2026-01-04T00:00:00+00:00")
+        return d
+
+    def test_fixture_really_has_a_merge_and_a_foreign_size(self):
+        """PROVE THE FIXTURE. Without a real two-parent merge, without the side branch's
+        size being reachable through the ancestry walk, and without the merge having
+        actually changed the file, every assertion below would pass vacuously. This test
+        failed first on the original fixture and is the only reason that was caught."""
+        with tempfile.TemporaryDirectory() as d:
+            self._forked_repo(d)
+            parents = git(d, "rev-list", "--parents", "-n", "1", "HEAD").split()
+            self.assertEqual(len(parents), 3, "HEAD is not a two-parent merge")
+            allsizes = {s for _, s in cb.size_history(d, "CLAUDE.md", first_parent=False)[0]}
+            self.assertIn(50000, allsizes, "the foreign lineage is not reachable at all")
+            self.assertEqual((Path(d) / "CLAUDE.md").stat().st_size, 300,
+                             "the merge did not change the file, so it is TREESAME-pruned")
+
+    def test_first_parent_excludes_the_foreign_lineage(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._forked_repo(d)
+            hist, skipped, err = cb.size_history(d, "CLAUDE.md")
+            self.assertIsNone(err)
+            self.assertEqual(skipped, 0)
+            self.assertEqual([s for _, s in hist], [100, 200, 300])
+
+    def test_the_defect_it_replaces_admits_a_size_that_never_existed_here(self):
+        """DRIVE IT RED. first_parent=False is the shipped pre-change behaviour."""
+        with tempfile.TemporaryDirectory() as d:
+            self._forked_repo(d)
+            defective, _, _ = cb.size_history(d, "CLAUDE.md", first_parent=False)
+            self.assertIn(50000, [s for _, s in defective])
+
+    def test_size_at_disagrees_between_the_two_views_on_the_same_instant(self):
+        """The consequence, stated as the quantity that actually feeds the regression:
+        at 2026-01-02T12:00Z main's CLAUDE.md was 100 B. The ancestry-walking view says
+        50,000 B — a 500x error in the regressor, silently."""
+        with tempfile.TemporaryDirectory() as d:
+            self._forked_repo(d)
+            when = cb.parse_iso("2026-01-02T12:00:00Z")
+            good = cb.size_at(cb.size_history(d, "CLAUDE.md")[0], when)
+            bad = cb.size_at(cb.size_history(d, "CLAUDE.md", first_parent=False)[0], when)
+            self.assertEqual(good, 100)
+            self.assertEqual(bad, 50000)
+
+    def test_a_treesame_merge_is_pruned_even_without_first_parent(self):
+        """The boundary of D1, pinned so nobody re-derives it the hard way (this session
+        did): git's default history simplification already drops a side branch whose merge
+        did not change the target. The defect needs a merge that DID."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            write_commit(d, "CLAUDE.md", 100, "2026-01-01T00:00:00+00:00")
+            git(d, "checkout", "-q", "-b", "side")
+            write_commit(d, "CLAUDE.md", 50000, "2026-01-02T00:00:00+00:00")
+            git(d, "checkout", "-q", "main")
+            write_commit(d, "CLAUDE.md", 200, "2026-01-03T00:00:00+00:00")
+            git(d, "merge", "-q", "-s", "ours", "side", "-m", "merge",
+                when="2026-01-04T00:00:00+00:00")
+            self.assertNotIn(50000, [s for _, s in
+                                     cb.size_history(d, "CLAUDE.md", first_parent=False)[0]])
+
+    def test_presence_control_no_merge_means_the_two_views_agree(self):
+        """Without this the D1 tests could be passing because --first-parent drops
+        something unconditionally, rather than because it drops the foreign lineage."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            write_commit(d, "CLAUDE.md", 100, "2026-01-01T00:00:00+00:00")
+            write_commit(d, "CLAUDE.md", 200, "2026-01-03T00:00:00+00:00")
+            self.assertEqual(cb.size_history(d, "CLAUDE.md")[0],
+                             cb.size_history(d, "CLAUDE.md", first_parent=False)[0])
+
+    def test_a_missing_target_is_an_empty_history_not_an_error(self):
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            write_commit(d, "other.md", 10, "2026-01-01T00:00:00+00:00")
+            hist, skipped, err = cb.size_history(d, "CLAUDE.md")
+            self.assertEqual((hist, skipped, err), ([], 0, None))
+
+    def test_a_non_repository_surfaces_the_error_never_an_empty_history(self):
+        """'no history' and 'git could not run' must not be the same value — that
+        conflation is the defect run() was written to avoid (tool docstring :54)."""
+        with tempfile.TemporaryDirectory() as d:
+            hist, _, err = cb.size_history(d, "CLAUDE.md")
+            self.assertIsNone(hist)
+            self.assertTrue(err)
+
+
+# ---------------------------------------------------------------------------------
+# D2 — timezone. git %cI emits a numeric offset that moves with the season; transcripts
+# end in Z. Ordered as STRINGS that is not chronological.
+# ---------------------------------------------------------------------------------
+
+def _string_size_at(hist_iso, iso):
+    """The shipped pre-change comparison, verbatim (context_budget.py:402/:410 at blob
+    be2721a): sort ISO strings, take the last one <= the target string."""
+    best = None
+    for when, size in sorted(hist_iso):
+        if when <= iso:
+            best = size
+    return best
+
+
+class TestTimezone(unittest.TestCase):
+
+    # The real pair from the authoring fork: its commit 7603f10 shrank CLAUDE.md
+    # 52,909 -> 8,519 B at 19:42:50-05:00, which is 2026-08-02T00:42:50Z — AFTER a session
+    # that opened at 2026-08-01T21:25:28Z. String order says the opposite.
+    COMMIT = "2026-08-01T19:42:50-05:00"
+    SESSION = "2026-08-01T21:25:28Z"
+
+    def test_fixture_the_string_comparison_really_is_wrong_here(self):
+        """PROVE THE FIXTURE. If these strings did not mis-order, the pair would be a
+        decoration rather than a regression test."""
+        self.assertLess(self.COMMIT, self.SESSION, "chosen pair does not mis-order as strings")
+        self.assertGreater(cb.parse_iso(self.COMMIT), cb.parse_iso(self.SESSION),
+                           "chosen pair is not actually inverted in real time")
+
+    def test_size_at_scores_the_session_against_the_size_that_was_live(self):
+        hist = [(cb.parse_iso("2026-07-20T12:00:00-04:00"), 52909),
+                (cb.parse_iso(self.COMMIT), 8519)]
+        self.assertEqual(cb.size_at(hist, cb.parse_iso(self.SESSION)), 52909)
+
+    def test_the_defect_it_replaces_scores_it_against_the_wrong_size(self):
+        """DRIVE IT RED against the narrowed implementation."""
+        hist_iso = [("2026-07-20T12:00:00-04:00", 52909), (self.COMMIT, 8519)]
+        self.assertEqual(_string_size_at(hist_iso, self.SESSION), 8519)
+
+    # A DST-straddling pair whose lexical order is the REVERSE of its real order. Not
+    # every mixed-offset pair inverts — the first pair tried here did not, which is why
+    # the fixture is asserted below before it is relied on.
+    EARLIER = "2026-08-01T20:00:00-04:00"     # = 2026-08-02T00:00:00Z, first in real time
+    LATER = "2026-08-01T19:30:00-05:00"       # = 2026-08-02T00:30:00Z, second in real time
+
+    def test_fixture_the_dst_pair_really_inverts(self):
+        """PROVE THE FIXTURE, again: lexically LATER sorts before EARLIER."""
+        self.assertLess(self.LATER, self.EARLIER, "pair does not invert lexically")
+        self.assertLess(cb.parse_iso(self.EARLIER), cb.parse_iso(self.LATER),
+                        "pair is not in the claimed real-time order")
+
+    def test_history_is_ordered_chronologically_not_lexically(self):
+        """A repository whose commits straddle a DST boundary — every long-lived one."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            write_commit(d, "CLAUDE.md", 100, self.EARLIER)
+            write_commit(d, "CLAUDE.md", 200, self.LATER)
+            hist, _, _ = cb.size_history(d, "CLAUDE.md")
+            self.assertEqual([s for _, s in hist], [100, 200])
+            # The narrowed implementation orders the same two records the other way.
+            self.assertEqual([s for _, s in sorted([(self.EARLIER, 100), (self.LATER, 200)])],
+                             [200, 100])
+
+    def test_offsets_and_z_agree_on_the_instant(self):
+        self.assertEqual(cb.parse_iso("2026-08-02T00:42:50Z"), cb.parse_iso(self.COMMIT))
+        self.assertEqual(cb.parse_iso("2026-08-02T02:42:50+02:00"), cb.parse_iso(self.COMMIT))
+
+    def test_unparseable_stamps_are_counted_not_silently_dropped(self):
+        self.assertIsNone(cb.parse_iso("yesterday"))
+        self.assertIsNone(cb.parse_iso(""))
+        self.assertIsNone(cb.parse_iso("2026-02-30T00:00:00Z"))     # shape ok, date not
+
+    def test_a_naive_stamp_is_read_as_utc(self):
+        """Documented assumption, pinned so it is a decision rather than an accident."""
+        self.assertEqual(cb.parse_iso("2026-08-02T00:42:50"), cb.parse_iso("2026-08-02T00:42:50Z"))
+
+
+# ---------------------------------------------------------------------------------
+# D3 — goodness of fit. The tool must not hand back a constant it cannot support.
+# ---------------------------------------------------------------------------------
+
+class TestFitGate(unittest.TestCase):
+
+    def test_a_known_line_is_recovered_exactly(self):
+        slope, inter, r2 = cb.linfit([(x, 3*x + 7) for x in range(1, 12)])
+        self.assertAlmostEqual(slope, 3.0, places=9)
+        self.assertAlmostEqual(inter, 7.0, places=9)
+        self.assertAlmostEqual(r2, 1.0, places=9)
+
+    def test_this_repos_own_four_way_fit_is_reproduced_from_its_recorded_points(self):
+        """The 2026-08-15 `calibrate()` repair's table is a claim about arithmetic; this pins it.
+        Points chosen so the corrected fit is strong and the scrambled one is not."""
+        good = [(8519, 45000), (11064, 46000), (20000, 49000), (52909, 61000)]
+        _, _, r2_good = cb.linfit(good)
+        self.assertGreater(r2_good, 0.9)
+        scrambled = [(8519, 61000), (11064, 45000), (20000, 46000), (52909, 49000)]
+        _, _, r2_bad = cb.linfit(scrambled)
+        self.assertLess(r2_bad, cb.MIN_R2)
+
+    def test_no_regressor_variance_is_None_not_a_fabricated_line(self):
+        self.assertIsNone(cb.linfit([(5, 1), (5, 2), (5, 3)]))
+
+    def test_no_response_variance_leaves_r2_undefined_never_perfect(self):
+        self.assertIsNone(cb.linfit([(1, 9), (2, 9), (3, 9)])[2])
+
+    def test_the_floor_admits_and_refuses(self):
+        self.assertIsNone(cb.calibration_verdict(0.3557, 0.8054, cb.MIN_R2))
+        self.assertIsNotNone(cb.calibration_verdict(0.0678, 0.0503, cb.MIN_R2))
+
+    def test_the_boundary_is_inclusive(self):
+        """A floor that refused its own boundary value would be a different floor."""
+        self.assertIsNone(cb.calibration_verdict(0.3557, cb.MIN_R2, cb.MIN_R2))
+        self.assertIsNotNone(cb.calibration_verdict(0.3557, cb.MIN_R2 - 1e-9, cb.MIN_R2))
+
+    def test_a_negative_slope_is_refused_however_tight_the_fit(self):
+        """NARROWED-GUARD CHECK. An R²-only gate — the obvious weaker implementation —
+        would accept this and print a NEGATIVE bytes-per-token."""
+        self.assertIsNotNone(cb.calibration_verdict(-0.3557, 0.999, cb.MIN_R2))
+
+    def test_an_undefined_r2_is_refused(self):
+        self.assertIsNotNone(cb.calibration_verdict(0.3557, None, cb.MIN_R2))
+
+    def test_the_refusal_says_which_test_failed(self):
+        """A refusal that does not name its cause sends the reader back to the source."""
+        self.assertIn("R²", cb.calibration_verdict(0.0678, 0.0503, cb.MIN_R2))
+        self.assertIn("slope", cb.calibration_verdict(-0.3557, 0.999, cb.MIN_R2))
+
+    def test_the_floor_is_configurable_per_project(self):
+        self.assertIsNone(cb.calibration_verdict(0.3557, 0.30, 0.25))
+        self.assertIsNotNone(cb.calibration_verdict(0.3557, 0.30, 0.75))
+
+
+class TestFitGateEndToEnd(unittest.TestCase):
+    """The unit gate above proves the verdict; this proves calibrate() ACTS on it — that
+    a refused fit suppresses the number rather than printing it with a caveat beside it.
+
+    It can only run where transcripts for this repository exist, which is a developer
+    machine and not CI, so it skips rather than failing. Skipped is honest; asserting
+    against whatever transcripts happen to be present would not be.
+    """
+
+    def setUp(self):
+        slug = "-" + str(REPO).strip("/").replace("/", "-")
+        self.tdir = Path.home() / ".claude" / "projects" / slug
+        if not self.tdir.exists() or not any(self.tdir.glob("*.jsonl")):
+            self.skipTest(f"no transcripts at {self.tdir}")
+        cfgp = REPO / ".context-budget.json"
+        if not cfgp.exists():
+            self.skipTest("this repo has no .context-budget.json")
+        self.cfg = json.loads(cfgp.read_text())
+
+    def _run(self, floor):
+        import contextlib, io
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = cb.calibrate(str(REPO), {**self.cfg, "calibrate_min_r2": floor})
+        return rc, buf.getvalue()
+
+    def test_an_impossible_floor_suppresses_the_constant_entirely(self):
+        rc, out = self._run(1.01)
+        self.assertEqual(rc, cb.WARN)
+        self.assertIn("no constant recommended", out)
+        self.assertNotIn("bytes/token", out)
+
+    def test_an_admitting_floor_prints_the_constant(self):
+        """Presence control: without it, a calibrate() that never printed anything would
+        pass the test above."""
+        rc, out = self._run(0.0)
+        self.assertEqual(rc, cb.CLEAN)
+        self.assertIn("bytes/token", out)
+        self.assertNotIn("no constant recommended", out)
+
+
+# ---------------------------------------------------------------------------------
+# D4 / D5 — what the ledger row and the remediation text say.
+# ---------------------------------------------------------------------------------
+
+class TestLedgerRow(unittest.TestCase):
+
+    OVER_BYTES = {"class": "read-mandated", "lines": 359, "max_lines": 1200,
+                  "bytes": 72449, "max_bytes": 65536, "status": "over",
+                  "findings": [{"kind": "bytes", "msg": "x"}]}
+
+    def test_a_read_mandated_file_over_BYTES_reports_bytes(self):
+        self.assertEqual(cb.ledger_dimension(self.OVER_BYTES), ("72,449 B", "65,536 B"))
+
+    def test_the_defect_it_replaces_named_the_ceiling_that_did_not_fire(self):
+        """DRIVE IT RED against the narrowed implementation: class-only selection, which
+        is what the tool did, reports lines for this row — the ceiling that passed."""
+        r = self.OVER_BYTES
+        by_class = (f"{r['lines']:,} ln" if r["class"] == "read-mandated"
+                    else f"{r['bytes']:,} B")
+        self.assertEqual(by_class, "359 ln")
+        self.assertNotEqual(by_class, cb.ledger_dimension(r)[0])
+
+    def test_a_read_mandated_file_over_LINES_still_reports_lines(self):
+        r = {**self.OVER_BYTES, "lines": 1500,
+             "findings": [{"kind": "lines", "msg": "x"}]}
+        self.assertEqual(cb.ledger_dimension(r), ("1,500 ln", "1,200 ln"))
+
+    def test_over_both_reports_bytes_deterministically(self):
+        r = {**self.OVER_BYTES, "lines": 1500,
+             "findings": [{"kind": "bytes", "msg": "x"}, {"kind": "lines", "msg": "y"}]}
+        self.assertEqual(cb.ledger_dimension(r)[0], "72,449 B")
+
+    def test_nothing_fired_falls_back_to_bytes_for_every_class(self):
+        """2026-08-26 CHANGED THIS EXPECTATION; the change is the assertion. A read-mandated file
+        used to fall back to LINES because that was the unit the surrounding trim rule was written
+        in. The rule is byte-denominated now, and the cap it proxies always was token-denominated,
+        so lines were the figure least able to explain the verdict -- across these same files the
+        B/line spread is 8.6x against 1.33x for B/token. The class no longer selects a dimension
+        at all; bytes are the fallback for everyone."""
+        self.assertEqual(cb.ledger_dimension({**self.OVER_BYTES, "findings": [],
+                                              "status": "ok"}), ("72,449 B", "65,536 B"))
+        self.assertEqual(cb.ledger_dimension({"class": "resident", "bytes": 900,
+                                              "lines": 9, "max_bytes": 1000,
+                                              "findings": []}), ("900 B", "1,000 B"))
+
+    def test_a_non_size_finding_does_not_hijack_the_dimension(self):
+        """Unchanged in intent, re-pointed 2026-08-26: a `protected` finding still must not select
+        a dimension, so the row falls through to the default -- which is now bytes. Paired with
+        the line case below, so this cannot pass merely because everything reports bytes."""
+        r = {**self.OVER_BYTES, "findings": [{"kind": "protected", "msg": "x"}]}
+        self.assertEqual(cb.ledger_dimension(r)[0], "72,449 B")
+
+    def test_a_line_finding_still_selects_lines(self):
+        """The control that keeps the test above honest. 2026-08-26 moved the DEFAULT, not the
+        dispatch: a fired `lines` ceiling must still be reported in lines, or the row would once
+        again name a ceiling that did not fire -- the exact defect ledger_dimension exists for."""
+        r = {**self.OVER_BYTES, "findings": [{"kind": "lines", "msg": "x"}]}
+        self.assertEqual(cb.ledger_dimension(r), ("359 ln", "1,200 ln"))
+
+    def test_an_undeclared_ceiling_renders_rather_than_crashing(self):
+        """The pre-change expression formatted max_bytes unconditionally, so a resident
+        file declaring only max_lines raised TypeError inside the renderer."""
+        self.assertEqual(cb.ledger_dimension({"class": "resident", "bytes": 10,
+                                              "lines": 1, "findings": []}), ("10 B", "—"))
+
+    def test_the_resident_total_pseudo_row_renders(self):
+        """main() appends a synthetic row that has no line count at all."""
+        self.assertEqual(cb.ledger_dimension(
+            {"path": "(resident total)", "class": "resident", "status": "over",
+             "bytes": 20000, "max_bytes": 18600,
+             "findings": [{"kind": "bytes", "msg": "x"}]}), ("20,000 B", "18,600 B"))
+
+
+class TestRemediationText(unittest.TestCase):
+
+    def test_no_remedy_names_a_directory_from_the_tools_home_project(self):
+        """server/, mobile/*/ and database/ exist in no repository but the one the tool
+        was written in, and were printed verbatim to every adopter."""
+        for kind, remedies in cb.REMEDIES.items():
+            for name, how in remedies:
+                for token in ("server/", "mobile/", "database/"):
+                    self.assertNotIn(token, how, f"{kind}/{name} names {token}")
+
+    def test_measured_claims_are_attributed_not_deictic(self):
+        """'10 of 11 rows of one table HERE were wrong' reads, in an adopter's terminal,
+        as a claim about the adopter's own repository. It was never measured there."""
+        compute = dict((n, h) for n, h in cb.REMEDIES["bytes"])["Compute"]
+        self.assertIn("10 of 11", compute)
+        self.assertNotIn("table here", compute)
+
+    def test_raising_the_ceiling_is_still_offered_last(self):
+        """Ordering is the message: it is the only remedy that removes the signal."""
+        self.assertEqual(cb.REMEDIES["bytes"][-1][0], "Raise the ceiling")
+
+
+class TestToolInvariants(unittest.TestCase):
+
+    def test_the_tool_and_its_selftest_agree_the_gates_all_fire(self):
+        p = subprocess.run([sys.executable, str(CB_PY), "--selftest"],
+                           capture_output=True, text=True, cwd=str(REPO))
+        rows = [l for l in p.stdout.splitlines() if l.strip().startswith(("PASS", "FAIL"))]
+        self.assertGreater(len(rows), 30, "selftest row population collapsed")
+        self.assertEqual([l for l in rows if l.strip().startswith("FAIL")], [])
+
+    def test_there_is_still_no_force_escape_hatch(self):
+        src = CB_PY.read_text().split("def selftest")[0]
+        self.assertNotIn('"--force" in args', src)
+
+
+class TestTokenCeiling(unittest.TestCase):
+    """The ceiling is denominated in TOKENS, the unit the read cap is actually in.
+
+    WHY THIS CLASS EXISTS. A byte ceiling is `tokens x density`, and density is a property
+    of the content, so every compaction silently moves it. Measured on the authoring fork: the
+    declared 73,728 B ceiling for starter-kit/FRAMEWORK_LEARNINGS.md certified `ok` a size
+    the agent read tool REFUSES at 25,486 tokens, and four of the five configured ceilings
+    converted to more than the 25,000-token cap. Nothing went red, because nothing checked.
+
+    THE CLASS GATE IS THE LOAD-BEARING PART, and it is Learning #34's: the read cap binds a
+    file that is read WHOLE. A file read in PART is not bound by it -- measured over 80
+    transcripts, one such file was read whole once and in part 243 times. So an on-demand
+    file must NOT be judged against the cap, and test_narrowing_* below shows that dropping
+    the class gate gives the WRONG answer on the same fixture rather than merely a louder one.
+    """
+
+    def _spec(self, **kw):
+        d = {"path": "t.md", "class": "read-mandated"}
+        d.update(kw)
+        return d
+
+    # --- fixture proof -------------------------------------------------------------
+
+    def test_fixture_is_what_the_other_tests_assume(self):
+        """Prove the fixture BEFORE asserting anything about the code that reads it."""
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "t.md").write_bytes(b"x" * 60000)
+            self.assertEqual(os.path.getsize(os.path.join(d, "t.md")), 60000)
+            r = cb.measure_file(d, self._spec())
+            self.assertEqual(r["bytes"], 60000, "fixture size must reach measure_file intact")
+            self.assertEqual(r["class"], "read-mandated")
+
+    # --- the guard that makes the shipped defect unrepresentable -------------------
+
+    def test_a_max_tokens_above_the_read_cap_is_a_config_defect(self):
+        cfg = {"read_cap_tokens": 25000}
+        bad = cb.config_defects({"files": [self._spec(max_tokens=26000)]}, cfg)
+        self.assertTrue(bad, "a ceiling above the read cap must be reported, not clamped silently")
+        self.assertIn("26,000", " ".join(bad))
+
+    def test_a_max_tokens_at_or_below_the_cap_is_clean(self):
+        cfg = {"read_cap_tokens": 25000}
+        self.assertEqual(cb.config_defects({"files": [self._spec(max_tokens=25000)]}, cfg), [])
+
+    # --- the core check ------------------------------------------------------------
+
+    def test_a_whole_read_file_over_its_token_ceiling_is_over(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "t.md").write_bytes(b"x" * 60000)
+            r = cb.measure_file(d, self._spec(max_tokens=20000),
+                                cfg={"bytes_per_token": 2.5})
+            self.assertEqual(r["tokens"], 24000, "60,000 B / 2.5 = 24,000 tok")
+            self.assertEqual(r["status"], "over")
+            self.assertTrue([f for f in r["findings"] if f["kind"] == "tokens"])
+
+    def test_a_whole_read_file_under_its_token_ceiling_is_ok(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "t.md").write_bytes(b"x" * 40000)
+            r = cb.measure_file(d, self._spec(max_tokens=20000),
+                                cfg={"bytes_per_token": 2.5})
+            self.assertEqual(r["tokens"], 16000)
+            self.assertEqual(r["status"], "ok")
+
+    # --- the class gate, narrowed rather than merely deleted -----------------------
+
+    def test_an_on_demand_file_is_not_judged_against_the_read_cap(self):
+        """Learning #34: the cap binds a WHOLE read. One adopter ships a 1.2 MB on-demand file."""
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "t.md").write_bytes(b"x" * 900000)
+            r = cb.measure_file(d, self._spec(**{"class": "on-demand", "max_tokens": 20000}),
+                                cfg={"bytes_per_token": 2.5})
+            self.assertIsNone(r.get("tokens"),
+                              "an on-demand file must not be given a token verdict at all")
+            self.assertEqual(r["status"], "ok")
+
+    def test_narrowing_the_class_gate_to_all_classes_gives_the_wrong_answer(self):
+        """The weaker implementation (no class gate) is shown WRONG on the same fixture."""
+        self.assertNotIn("on-demand", cb.WHOLE_READ_CLASSES,
+                         "on-demand inside WHOLE_READ_CLASSES would redden every "
+                         "partially-read file -- the per-file-vs-per-row error itself")
+        # A FROZEN LITERAL, not a set derived from the tuple -- deriving it would make this
+        # an identity that no narrowing mutant can falsify. Widened DELIBERATELY on 2026-08-30 to
+        # admit "read-set", the Phase 0 mandatory read pair (SESSION_RUNNER.md +
+        # SAFEGUARDS.md). That pair is read WHOLE, which is exactly Learning #34's condition
+        # for the cap to bind, so gating it in BYTES ONLY would have reintroduced the density
+        # drift the token arm exists to remove -- on the two files the read-set PR is about.
+        # The assertion above is the one that carries this test's purpose and is unchanged:
+        # "on-demand" must stay OUT.
+        self.assertEqual(set(cb.WHOLE_READ_CLASSES),
+                         {"resident", "read-mandated", "read-set"})
+
+    # --- adopter compatibility: an un-migrated config keeps working ----------------
+
+    def test_max_tokens_is_derived_from_max_bytes_when_absent(self):
+        """Every shipped adopter config declares max_bytes and nothing else."""
+        mt, derived = cb.token_ceiling({}, self._spec(max_bytes=45400))
+        self.assertTrue(derived)
+        self.assertEqual(mt, 20000, "45,400 / 2.27 = 20,000 -- derived at the FLOOR")
+
+    def test_the_derived_ceiling_is_conservative_not_optimistic(self):
+        """Dividing by the FLOOR maximises the token estimate, so it can never certify
+        an unreadable file as fine. Direction matters and has been got wrong twice."""
+        lo, _ = cb.token_ceiling({}, self._spec(max_bytes=100000))
+        self.assertGreater(100000 / 2.27, 100000 / 2.89)
+        self.assertEqual(lo, min(int(100000 / 2.27), 25000))
+
+    def test_a_derived_ceiling_is_clamped_at_the_read_cap(self):
+        """vscode_quarto_ext declares 65,536 B = 28,870 tok. It must not become a
+        ceiling ABOVE the cap -- that is the defect being fixed."""
+        mt, derived = cb.token_ceiling({}, self._spec(max_bytes=65536))
+        self.assertTrue(derived)
+        self.assertEqual(mt, 25000)
+
+    def test_a_file_with_no_ceiling_of_either_kind_gets_no_token_verdict(self):
+        mt, derived = cb.token_ceiling({}, self._spec())
+        self.assertIsNone(mt)
+
+    # --- density: per-file measured beats global beats floor -----------------------
+
+    def test_a_per_file_measured_density_overrides_the_global(self):
+        bpt, src = cb.file_density({"bytes_per_token": 2.8},
+                                   self._spec(bytes_per_token=2.4193))
+        self.assertAlmostEqual(bpt, 2.4193)
+        self.assertEqual(src, "measured")
+
+    def test_the_floor_is_used_when_nothing_is_declared(self):
+        bpt, src = cb.file_density({}, self._spec())
+        self.assertAlmostEqual(bpt, cb.MIN_BYTES_PER_TOKEN)
+        self.assertEqual(src, "floor")
+
+    # --- a green you cannot justify becomes a warn --------------------------------
+
+    def test_a_file_that_has_drifted_from_its_measured_density_warns(self):
+        """A 2026-08-27 compaction cut a file 23.6%; its density moved 3.0444 -> 2.8897, which is
+        what inverted the ceiling. Drift past the threshold must stop the confident ok."""
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "t.md").write_bytes(b"x" * 40000)
+            spec = self._spec(max_tokens=20000, bytes_per_token=2.5, measured_bytes=60000)
+            r = cb.measure_file(d, spec, cfg={})
+            self.assertEqual(r["status"], "warn",
+                             "33% drift from the measured size must not report a bare ok")
+            self.assertTrue([f for f in r["findings"] if f["kind"] == "density"])
+
+    def test_no_drift_leaves_the_ok_intact(self):
+        with tempfile.TemporaryDirectory() as d:
+            Path(d, "t.md").write_bytes(b"x" * 40000)
+            spec = self._spec(max_tokens=20000, bytes_per_token=2.5, measured_bytes=40000)
+            r = cb.measure_file(d, spec, cfg={})
+            self.assertEqual(r["status"], "ok")
+
+    # --- the second enforcement site must move with the first ---------------------
+
+    def test_a_fired_token_ceiling_is_reported_in_tokens(self):
+        """The row must show the figure behind its own verdict. A file UNDER its byte
+        ceiling and OVER the read cap is the case bytes cannot explain."""
+        r = {"class": "read-mandated", "bytes": 56673, "max_bytes": 73728,
+             "tokens": 25514, "max_tokens": 25000,
+             "findings": [{"kind": "tokens", "msg": "x"}]}
+        self.assertEqual(cb.ledger_dimension(r), ("≈25,514 tok", "25,000 tok"))
+
+    def test_bytes_still_win_when_both_fire(self):
+        """The first size finding decides the dimension; bytes are appended first."""
+        r = {"class": "read-mandated", "bytes": 162781, "max_bytes": 65536,
+             "tokens": 65979, "max_tokens": 25000,
+             "findings": [{"kind": "bytes", "msg": "x"}, {"kind": "tokens", "msg": "y"}]}
+        self.assertEqual(cb.ledger_dimension(r)[0], "162,781 B")
+
+    def test_main_passes_cfg_into_measure_file(self):
+        """cfg is optional on measure_file so old callers keep working -- which means a
+        caller that forgets it runs the token arm at the FLOOR and silently ignores every
+        per-file measured density. Green tests would not have caught it; this does."""
+        src = CB_PY.read_text()
+        self.assertIn("measure_file(root, s, cfg)", src,
+                      "main() must pass cfg, or the density and read_cap_tokens a "
+                      "project declares are computed and then discarded")
+
+    def test_precommit_enforces_the_token_ceiling_too(self):
+        """The plan's own lesson: cfg['classes'] was a KeyError at BOTH sites. A gate that
+        reports and cannot refuse is half a gate."""
+        src = CB_PY.read_text()
+        pre = src.split("def precommit")[1].split("# === SELFTEST")[0]
+        self.assertIn("token_ceiling", pre,
+                      "precommit still gates on bytes alone while the report gates on tokens")
+
+
+# ---------------------------------------------------------------------------------
+# D3 — the size a GATE measures. run() returns p.stdout.strip(), so precommit()'s
+# `len(staged.encode())` measured one byte short on any content ending in a newline,
+# which is all of it. The error is silent, self-consistent, and in the direction that
+# makes an over-budget file look smaller than it is.
+# ---------------------------------------------------------------------------------
+
+def _stripped_size(repo, rev):
+    """VERBATIM re-implementation of the pre-change measurement, kept so the defect can be
+    exhibited rather than only described -- the same role `_string_size_at` plays for D2.
+    This is what precommit() computed before blob_bytes() existed."""
+    rc, out, _ = cb.run(["git", "show", rev], cwd=str(repo))
+    return len(out.encode()) if rc == 0 else None
+
+
+class TestBlobBytes(unittest.TestCase):
+    """The gate's unit of measurement.
+
+    WHY THIS CLASS EXISTS. A one-byte undercount sounds cosmetic. It is not: a ceiling is a
+    strict `>` comparison, so a file at exactly ceiling+1 true bytes measures at exactly the
+    ceiling and the gate ALLOWS it. The defect is therefore not "a slightly wrong number in
+    a report" but "a commit that is over budget passes" -- exhibited below on a fixture
+    built to sit on that edge, because a fixture 500 B over would be caught either way and
+    would prove nothing about the boundary.
+    """
+
+    CEIL = 1000
+
+    def _repo(self, d):
+        """BIG.md at exactly CEIL+1 true bytes: CEIL 'x' plus one newline. HEAD holds a
+        5-byte version, so the relative rule's `new > old` arm is satisfied and cannot be
+        what decides these tests."""
+        new_repo(d)
+        Path(d, ".context-budget.json").write_text(json.dumps({
+            "classes": {"resident": {"total_bytes": 999999}},
+            "files": [{"path": "BIG.md", "class": "resident", "max_bytes": self.CEIL}]}))
+        Path(d, "BIG.md").write_text("tiny\n")
+        git(d, "add", "-A"); git(d, "commit", "-m", "base", when="2026-01-01T00:00:00Z")
+        Path(d, "BIG.md").write_text("x" * self.CEIL + "\n")
+        git(d, "add", "BIG.md")
+        return d
+
+    # --- fixture proof -------------------------------------------------------------
+
+    def test_fixture_sits_exactly_one_byte_past_the_ceiling(self):
+        """Prove the fixture BEFORE asserting anything about the code that reads it. If it
+        drifts off the edge these tests keep passing while testing nothing about it."""
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            true = int(git(d, "cat-file", "-s", ":BIG.md"))
+            self.assertEqual(true, self.CEIL + 1,
+                             "fixture must sit exactly one byte over, or the edge is untested")
+            self.assertEqual(int(git(d, "cat-file", "-s", "HEAD:BIG.md")), 5)
+
+    # --- the defect, exhibited ------------------------------------------------------
+
+    def test_the_pre_change_expression_measures_one_byte_short(self):
+        """RED: green is not evidence until red has been observed."""
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            self.assertEqual(_stripped_size(d, ":BIG.md"), self.CEIL,
+                             "the pre-change expression must land exactly ON the ceiling")
+
+    def test_blob_bytes_reports_the_true_object_size(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            self.assertEqual(cb.blob_bytes(d, ":BIG.md"), self.CEIL + 1)
+            self.assertEqual(cb.blob_bytes(d, "HEAD:BIG.md"), 5)
+
+    def test_the_two_measurements_differ_by_exactly_the_trailing_newline(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            self.assertEqual(cb.blob_bytes(d, ":BIG.md") - _stripped_size(d, ":BIG.md"), 1)
+
+    # --- and the one byte is enough to flip the verdict -----------------------------
+
+    def test_one_byte_decides_whether_an_over_budget_commit_is_refused(self):
+        """The whole point. Same fixture, same ceiling, opposite answers."""
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            true, stripped = cb.blob_bytes(d, ":BIG.md"), _stripped_size(d, ":BIG.md")
+            self.assertGreater(true, self.CEIL, "true size IS over the ceiling")
+            self.assertFalse(stripped > self.CEIL,
+                             "the pre-change size is NOT over it — so the gate passed")
+
+    def test_precommit_now_refuses_that_commit(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            cfg = json.loads(Path(d, ".context-budget.json").read_text())
+            self.assertEqual(cb.precommit(d, cfg), cb.BREACH)
+
+    # --- the relative rule must survive the fix, or the gate blocks its own remedy ---
+
+    def _restage(self, d, size):
+        Path(d, "BIG.md").write_text("x" * size + "\n")
+        git(d, "add", "BIG.md")
+
+    def test_a_commit_that_shrinks_an_over_budget_file_still_passes(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            git(d, "commit", "-m", "over", "--no-verify", when="2026-01-02T00:00:00Z")
+            self._restage(d, 900)
+            cfg = json.loads(Path(d, ".context-budget.json").read_text())
+            self.assertEqual(cb.blob_bytes(d, "HEAD:BIG.md"), self.CEIL + 1,
+                             "fixture proof: HEAD really is the over-budget version")
+            self.assertEqual(cb.precommit(d, cfg), cb.CLEAN)
+
+    def test_a_commit_that_grows_an_already_over_budget_file_is_refused(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            git(d, "commit", "-m", "over", "--no-verify", when="2026-01-02T00:00:00Z")
+            self._restage(d, 1500)
+            cfg = json.loads(Path(d, ".context-budget.json").read_text())
+            self.assertEqual(cb.precommit(d, cfg), cb.BREACH)
+
+    # --- narrowing, not only deletion ----------------------------------------------
+
+    def test_blob_bytes_is_none_rather_than_zero_for_a_rev_that_does_not_resolve(self):
+        """None and 0 are different facts. A missing HEAD blob means 'new file', which the
+        caller turns into 0; a helper that returned 0 itself would make 'absent' and
+        'empty' the same, and an empty file would read as unchanged rather than as new."""
+        with tempfile.TemporaryDirectory() as d:
+            self._repo(d)
+            self.assertIsNone(cb.blob_bytes(d, "HEAD:NOT_THERE.md"))
+            self.assertIsNone(cb.blob_bytes(d, ":NOT_THERE.md"))
+            Path(d, "EMPTY.md").write_text("")
+            git(d, "add", "EMPTY.md")
+            self.assertEqual(cb.blob_bytes(d, ":EMPTY.md"), 0,
+                             "an EMPTY staged file is 0 bytes, which is not the same as absent")
+
+    def test_blob_bytes_survives_content_that_is_not_valid_utf8(self):
+        """The narrowed alternative does not merely give a wrong NUMBER here — it CRASHES.
+
+        run() passes text=True, and subprocess decodes with the strict default, so a
+        budgeted file that is not valid UTF-8 raises UnicodeDecodeError inside run(). That
+        exception is not one of the four run() catches (FileNotFoundError, Timeout, OSError
+        and its subclasses), so it propagates out of precommit() and takes the pre-commit
+        hook — and therefore the commit — down with it. `git cat-file -s` never decodes,
+        so it answers correctly instead. Found by running this test, not by predicting it.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            Path(d, "B.bin").write_bytes(b"\xff\xfe\x00abc")
+            git(d, "add", "B.bin")
+            self.assertEqual(cb.blob_bytes(d, ":B.bin"), 6)
+            with self.assertRaises(UnicodeDecodeError):
+                _stripped_size(d, ":B.bin")
+
+    def test_precommit_completes_on_a_repo_with_a_non_utf8_budgeted_file(self):
+        """The end-to-end consequence of the line above: before the fix this call raised."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            Path(d, "B.bin").write_bytes(b"\xff\xfe\x00abc")
+            git(d, "add", "B.bin")
+            cfg = {"classes": {"resident": {"total_bytes": 999999}},
+                   "files": [{"path": "B.bin", "class": "resident", "max_bytes": 4}]}
+            self.assertEqual(cb.precommit(d, cfg), cb.BREACH,
+                             "6 B over a 4 B ceiling, measured without decoding")
+
+    def test_crlf_content_loses_more_than_the_single_trailing_byte(self):
+        """A SECOND, INDEPENDENT loss path, and the larger one. run() passes text=True, so
+        subprocess applies universal-newline translation and every CRLF collapses to LF
+        BEFORE .strip() takes the trailing one. Deleting .strip() would not have fixed
+        this; not decoding at all does. The plan's 'one byte short' framing is the
+        floor of the error, not its size."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            Path(d, "CRLF.md").write_bytes(b"alpha\r\nbeta\r\n")   # 13 B on disk
+            git(d, "add", "CRLF.md")
+            self.assertEqual(cb.blob_bytes(d, ":CRLF.md"), 13)
+            self.assertEqual(_stripped_size(d, ":CRLF.md"), 10,
+                             "2 B to newline translation + 1 B to strip = 3 B lost")
+            self.assertEqual(cb.blob_bytes(d, ":CRLF.md")
+                             - _stripped_size(d, ":CRLF.md"), 3)
+
+    def test_precommit_no_longer_measures_through_a_stripped_stdout(self):
+        """Pin the call site, not just the helper: a later edit could reintroduce the
+        stripped read beside a blob_bytes() that is still defined and no longer used."""
+        src = CB_PY.read_text()
+        pre = src.split("def precommit")[1].split("# === SELFTEST")[0]
+        self.assertIn("blob_bytes(root", pre)
+        self.assertNotIn("len(staged.encode())", pre)
+        self.assertNotIn("len(head.encode())", pre)
+
+
+# ---------------------------------------------------------------------------------
+# D4 — cfg["classes"]["resident"] was a DIRECT key access at two sites. A config that
+# declares no `classes` key raised KeyError, and an adopter's hand-written config is
+# exactly the one that will lack it.
+# ---------------------------------------------------------------------------------
+
+def _direct_class_access(cfg):
+    """VERBATIM re-implementation of the pre-change access, so the crash is exhibited."""
+    return cfg["classes"]["resident"]
+
+
+class TestClassSpec(unittest.TestCase):
+
+    NO_CLASSES = {"files": [{"path": "CLAUDE.md", "class": "resident", "max_bytes": 100000}]}
+
+    def test_the_pre_change_access_raises_on_a_config_with_no_classes_key(self):
+        """RED."""
+        with self.assertRaises(KeyError):
+            _direct_class_access(self.NO_CLASSES)
+
+    def test_class_spec_returns_an_empty_mapping_instead(self):
+        self.assertEqual(cb.class_spec(self.NO_CLASSES, "resident"), {})
+        self.assertEqual(cb.class_spec({"classes": None}, "resident"), {})
+        self.assertEqual(cb.class_spec({"classes": {}}, "resident"), {})
+        self.assertEqual(cb.class_spec(None, "resident"), {})
+
+    def test_class_spec_returns_the_declared_budget_when_there_is_one(self):
+        cfg = {"classes": {"resident": {"total_bytes": 34000, "warn_bytes": 30000}}}
+        self.assertEqual(cb.class_spec(cfg, "resident")["total_bytes"], 34000)
+        self.assertEqual(cb.class_spec(cfg, "read-mandated"), {},
+                         "a class the config does not declare has no budget, not a crash")
+
+    def test_neither_site_still_reaches_through_the_classes_key_directly(self):
+        """Both sites had to move together or the crash relocates rather than closing.
+        Scoped past the docstring that quotes the old expression on purpose."""
+        src = CB_PY.read_text()
+        code = src.split('def class_spec')[0] + src.split('    return ((cfg or {})')[1]
+        self.assertNotIn('cfg["classes"]', code)
+
+    def test_a_run_over_a_config_with_no_classes_key_completes(self):
+        """End to end: the crash was in render() and main(), not in a helper."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            Path(d, ".context-budget.json").write_text(json.dumps(self.NO_CLASSES))
+            Path(d, "CLAUDE.md").write_text("hello\n")
+            p = subprocess.run([sys.executable, str(CB_PY)], cwd=d,
+                               capture_output=True, text=True)
+            self.assertNotIn("KeyError", p.stderr)
+            self.assertIn("resident total", p.stdout)
+            self.assertIn("no ceiling declared", p.stdout,
+                          "an undeclared ceiling must SAY so, not print a bare number")
+
+    def test_the_over_ceiling_pseudo_row_is_still_labelled_resident_total(self):
+        """A NON-VACUOUS WITNESS for the parenthesised label. It is emitted ONLY when the
+        class is over its ceiling, and none of the three instrumented adopters is over --
+        so an assertion taken against their output runs on an empty population and passes
+        whatever the code does. This fixture is deliberately OVER so the row exists."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            Path(d, ".context-budget.json").write_text(json.dumps({
+                "classes": {"resident": {"total_bytes": 1000}},
+                "files": [{"path": "CLAUDE.md", "class": "resident"}]}))
+            Path(d, "CLAUDE.md").write_text("x" * 1500)
+            p = subprocess.run([sys.executable, str(CB_PY), "--json"], cwd=d,
+                               capture_output=True, text=True)
+            rows = json.loads(p.stdout)
+            paths = [r["path"] for r in rows["files"]]
+            self.assertIn("(resident total)", paths,
+                          "the pseudo-row must exist when the class is over")
+            row = [r for r in rows["files"] if r["path"] == "(resident total)"][0]
+            self.assertEqual(row["bytes"], 1500)
+            self.assertEqual(row["status"], "over")
+            self.assertIn("across all auto-loaded files", row["findings"][0]["msg"],
+                          "the resident wording is what the adopters are compared on")
+
+    def test_a_declared_ceiling_still_renders_exactly_as_before(self):
+        """The byte-identity criterion, asserted on the rendered text rather than assumed:
+        the instrumented adopters all declare a resident total, and their line must not
+        move because a class they do not declare became representable."""
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            Path(d, ".context-budget.json").write_text(json.dumps({
+                "classes": {"resident": {"total_bytes": 34000}},
+                "files": [{"path": "CLAUDE.md", "class": "resident", "max_bytes": 100000}]}))
+            Path(d, "CLAUDE.md").write_text("x" * 4999 + "\n")
+            p = subprocess.run([sys.executable, str(CB_PY)], cwd=d,
+                               capture_output=True, text=True)
+            plain = re.sub(r"\x1b\[[0-9;]*m", "", p.stdout)
+            self.assertIn("resident total 5,000 B / 34,000 B ceiling", plain)
+
+
+# ---------------------------------------------------------------------------------
+# D5 — the class aggregate. Two per-file ceilings DO NOT SUM: bytes can move out of
+# SAFEGUARDS.md into SESSION_RUNNER.md leaving both rows green while the Phase 0 read
+# is unchanged. main() reports the total; precommit() must be able to REFUSE on it, or
+# the tool ships an aggregate that reports and cannot gate.
+# ---------------------------------------------------------------------------------
+
+class TestClassTotals(unittest.TestCase):
+
+    def _cfg(self, total=1000, **kw):
+        c = {"classes": {"pair": dict({"total_bytes": total}, **kw)},
+             "files": [{"path": "A.md", "class": "pair"},
+                       {"path": "B.md", "class": "pair"}]}
+        return c
+
+    def _results(self, a, b, cls="pair"):
+        return [{"path": "A.md", "class": cls, "bytes": a, "findings": [], "status": "ok"},
+                {"path": "B.md", "class": cls, "bytes": b, "findings": [], "status": "ok"}]
+
+    # --- the core arithmetic --------------------------------------------------------
+
+    def test_a_class_total_is_the_sum_of_its_members(self):
+        t = cb.class_totals(self._cfg(), self._results(400, 300))
+        pair = [c for c in t if c["class"] == "pair"][0]
+        self.assertEqual(pair["bytes"], 700)
+        self.assertEqual(pair["status"], "ok")
+
+    def test_the_total_fires_while_every_member_is_individually_green(self):
+        """THE WHOLE POINT. Neither file has a per-file ceiling at all here, so nothing
+        could have caught this except the aggregate."""
+        t = cb.class_totals(self._cfg(total=1000), self._results(600, 600))
+        pair = [c for c in t if c["class"] == "pair"][0]
+        self.assertEqual(pair["bytes"], 1200)
+        self.assertEqual(pair["status"], "over")
+
+    def test_moving_bytes_between_members_leaves_the_total_unmoved(self):
+        """The failure mode in one assertion: a transfer both per-file rows would allow.
+
+        The first version of this test read `assertEqual(a, b, 1200)`, where unittest takes
+        the third positional as the failure MESSAGE. It therefore asserted only that
+        class_totals is symmetric under swapping member sizes — which addition is by
+        construction — and stayed green against a mutant that halved every total.
+        """
+        a = cb.class_totals(self._cfg(), self._results(900, 300))
+        b = cb.class_totals(self._cfg(), self._results(300, 900))
+        self.assertEqual(a[-1]["bytes"], 1200)
+        self.assertEqual(b[-1]["bytes"], 1200)
+        self.assertEqual(a[-1]["bytes"], b[-1]["bytes"])
+
+    def test_a_class_exactly_at_its_ceiling_is_not_over(self):
+        """THE EDGE. `total > ceil` and `total >= ceil` agree on every fixture except a
+        class sitting exactly ON the ceiling, so without this case the `>`/`>=` mutant
+        survives the whole suite — it did, until this test was added."""
+        t = cb.class_totals(self._cfg(total=1000), self._results(500, 500))
+        pair = [c for c in t if c["class"] == "pair"][0]
+        self.assertEqual(pair["bytes"], 1000)
+        self.assertEqual(pair["status"], "ok", "at the ceiling is not over it")
+
+    def test_one_byte_past_the_ceiling_is_over(self):
+        """Paired control: without it, 'at the ceiling is ok' could be satisfied by a
+        predicate that never fires at all."""
+        t = cb.class_totals(self._cfg(total=1000), self._results(500, 501))
+        self.assertEqual([c for c in t if c["class"] == "pair"][0]["status"], "over")
+
+    def test_a_declared_ceiling_of_zero_is_still_a_ceiling(self):
+        """`if ceil and ...` made a DECLARED 0 indistinguishable from an undeclared one,
+        which silently disables the gate for a config that plainly declares it."""
+        t = cb.class_totals({"classes": {"z": {"total_bytes": 0}}},
+                            [{"path": "a", "class": "z", "bytes": 1,
+                              "findings": [], "status": "ok"}])
+        self.assertEqual(t[-1]["status"], "over")
+
+    def test_a_declared_file_whose_name_starts_with_a_paren_is_counted(self):
+        """The pseudo-row filter must key on a FLAG we set, never on a path the project
+        supplies. Filtering on `path.startswith("(")` dropped this file from every class
+        total while main()'s resident sum and precommit()'s arm still counted it."""
+        t = cb.class_totals({"classes": {"pair": {"total_bytes": 1000}}},
+                            [{"path": "(draft) notes.md", "class": "pair", "bytes": 1200,
+                              "findings": [], "status": "ok"}])
+        self.assertEqual(t[-1]["bytes"], 1200)
+        self.assertEqual(t[-1]["status"], "over")
+
+    def test_a_class_warn_line_is_read_rather_than_merely_declared(self):
+        """The distributed SEED has carried classes.resident.warn_bytes since it shipped
+        and NOTHING read it. A declared number no code consults is a false claim."""
+        t = cb.class_totals(self._cfg(total=1000, warn_bytes=600), self._results(400, 300))
+        self.assertEqual([c for c in t if c["class"] == "pair"][0]["status"], "warn")
+
+    # --- narrowing, not only deleting -----------------------------------------------
+
+    def test_a_declared_class_with_no_members_totals_zero_rather_than_vanishing(self):
+        t = cb.class_totals({"classes": {"ghost": {"total_bytes": 10}}, "files": []}, [])
+        self.assertIn("ghost", [c["class"] for c in t],
+                      "a class that disappears when its files are renamed is a gate that "
+                      "stops gating without saying so")
+        self.assertEqual([c for c in t if c["class"] == "ghost"][0]["bytes"], 0)
+
+    def test_pseudo_rows_are_not_counted_a_second_time(self):
+        """main() appends `(pair total)` INTO results. A second call must not re-sum it."""
+        res = self._results(600, 600) + [
+            {"path": "(pair total)", "class": "pair", "bytes": 1200, "aggregate": True,
+             "findings": [], "status": "over"}]
+        self.assertEqual(cb.class_totals(self._cfg(), res)[-1]["bytes"], 1200,
+                         "an aggregate-flagged row is this function's own output, "
+                         "not a member")
+
+    def test_resident_is_reported_even_when_the_config_declares_no_class(self):
+        t = cb.class_totals({"files": []}, [])
+        self.assertEqual([c["class"] for c in t], ["resident"])
+        self.assertIsNone(t[0]["total_bytes"])
+
+    def test_resident_leads_and_the_rest_are_alphabetical(self):
+        """Deterministic, and NOT dict order — otherwise the rendered output depends on
+        how the config happened to be typed."""
+        cfg = {"classes": {"zeta": {}, "alpha": {}, "resident": {}}, "files": []}
+        self.assertEqual([c["class"] for c in cb.class_totals(cfg, [])],
+                         ["resident", "alpha", "zeta"])
+
+    # --- a SYNTHETIC THIRD CLASS, the phase's own DONE criterion ---------------------
+
+    def test_a_synthetic_third_class_totals_correctly(self):
+        cfg = {"classes": {"resident": {"total_bytes": 100},
+                           "pair": {"total_bytes": 1000},
+                           "third": {"total_bytes": 50}},
+               "files": []}
+        res = (self._results(600, 600)
+               + [{"path": "C.md", "class": "third", "bytes": 80,
+                   "findings": [], "status": "ok"},
+                  {"path": "D.md", "class": "third", "bytes": 5,
+                   "findings": [], "status": "ok"},
+                  {"path": "CLAUDE.md", "class": "resident", "bytes": 40,
+                   "findings": [], "status": "ok"}])
+        got = {c["class"]: (c["bytes"], c["status"]) for c in cb.class_totals(cfg, res)}
+        self.assertEqual(got["resident"], (40, "ok"))
+        self.assertEqual(got["pair"], (1200, "over"))
+        self.assertEqual(got["third"], (85, "over"),
+                         "the third class must be totalled on its OWN members, 80 + 5")
+
+
+class TestPrecommitClassArm(unittest.TestCase):
+    """A gate that reports and cannot refuse is half a gate (plan 3.4(b))."""
+
+    CEIL = 1000
+
+    def _repo(self, d, a, b):
+        new_repo(d)
+        Path(d, ".context-budget.json").write_text(json.dumps({
+            "classes": {"pair": {"total_bytes": self.CEIL}},
+            "files": [{"path": "A.md", "class": "pair"},
+                      {"path": "B.md", "class": "pair"}]}))
+        Path(d, "A.md").write_text("a" * a)
+        Path(d, "B.md").write_text("b" * b)
+        git(d, "add", "-A"); git(d, "commit", "-m", "base", when="2026-01-01T00:00:00Z")
+        return json.loads(Path(d, ".context-budget.json").read_text())
+
+    def _stage(self, d, a, b):
+        Path(d, "A.md").write_text("a" * a)
+        Path(d, "B.md").write_text("b" * b)
+        git(d, "add", "-A")
+
+    def test_fixture_starts_under_the_class_ceiling(self):
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 400, 300)
+            self.assertEqual(cb.precommit(d, cfg), cb.CLEAN)
+
+    def test_a_commit_that_pushes_the_class_over_is_refused(self):
+        """Neither file has a per-file ceiling, so ONLY the aggregate can catch this."""
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 400, 300)
+            self._stage(d, 600, 600)
+            self.assertEqual(cb.precommit(d, cfg), cb.BREACH)
+
+    def test_a_commit_that_shrinks_an_over_budget_class_passes(self):
+        """The relative rule on the aggregate: the gate must never block its own remedy.
+
+        The interesting case is a commit that is STILL OVER the ceiling and merely smaller
+        than HEAD. Shrinking to green would pass under any implementation and would prove
+        nothing about the relative rule; this fixture is over on both sides.
+        """
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 600, 600)
+            self.assertEqual(cb.blob_bytes(d, "HEAD:A.md")
+                             + cb.blob_bytes(d, "HEAD:B.md"), 1200)
+            self.assertGreater(1200, self.CEIL,
+                               "fixture proof: HEAD is already over the class ceiling")
+            self._stage(d, 550, 550)                       # 1,100 — still over, but smaller
+            self.assertGreater(1100, self.CEIL, "fixture proof: the remedy is still over")
+            self.assertEqual(cb.precommit(d, cfg), cb.CLEAN,
+                             "a reduction must pass even while the class stays over")
+
+    def test_the_same_over_class_still_refuses_a_commit_that_grows_it(self):
+        """Paired control for the test above: over-and-shrinking passes, over-and-growing
+        does not. Without this pair, 'passes' could just mean 'never refuses'."""
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 600, 600)
+            self._stage(d, 700, 600)                       # 1,300 — over and grown
+            self.assertEqual(cb.precommit(d, cfg), cb.BREACH)
+
+    def test_moving_bytes_between_members_is_refused_though_both_files_are_green(self):
+        """The exact hole the aggregate exists to close, driven end to end."""
+        with tempfile.TemporaryDirectory() as d:
+            cfg = json.loads(json.dumps(self._repo(d, 400, 300)))
+            for f in cfg["files"]:
+                f["max_bytes"] = 5000          # per-file ceilings neither file can trip
+            self._stage(d, 1100, 100)          # 1,200 total: over the CLASS ceiling only
+            self.assertEqual(cb.precommit(d, cfg), cb.BREACH)
+
+    def test_without_the_class_arm_that_same_commit_would_pass(self):
+        """NARROW the guard rather than only deleting it: the weaker implementation —
+        per-file ceilings alone — is shown to give the WRONG answer on the same fixture."""
+        with tempfile.TemporaryDirectory() as d:
+            cfg = json.loads(json.dumps(self._repo(d, 400, 300)))
+            for f in cfg["files"]:
+                f["max_bytes"] = 5000
+            self._stage(d, 1100, 100)
+            weaker = dict(cfg); weaker["classes"] = {}      # aggregate removed, nothing else
+            self.assertEqual(cb.precommit(d, weaker), cb.CLEAN,
+                             "per-file ceilings alone must be shown to MISS this")
+
+    def test_deleting_a_member_is_credited_as_the_reduction_it_is(self):
+        """THE REMEDY THE GATE MUST NOT BLOCK. Removing a member is the most direct way to
+        shrink an over-budget class. The first version of this arm skipped any member
+        absent from the WORKTREE before bookkeeping, so `git rm` dropped the member from
+        the HEAD side too and the survivors read as pure growth: a measured 60,000 ->
+        45,000 B reduction was REFUSED, reported as `30,000 -> 45,000`."""
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 30000, 30000)
+            cfg["classes"]["pair"]["total_bytes"] = 40000
+            self.assertEqual(cb.blob_bytes(d, "HEAD:A.md")
+                             + cb.blob_bytes(d, "HEAD:B.md"), 60000)
+            git(d, "rm", "-q", "B.md")
+            Path(d, "A.md").write_text("a" * 45000)
+            git(d, "add", "-A")
+            self.assertEqual(cb.precommit(d, cfg), cb.CLEAN,
+                             "60,000 -> 45,000 B is a reduction and must pass")
+
+    def test_a_member_staged_but_absent_from_the_worktree_is_still_counted(self):
+        """The mirror failure: the index is what gets committed. A member present in the
+        index but deleted from disk was skipped and counted as ZERO, so an index holding
+        1,800 B against a 1,000 B ceiling PASSED."""
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 100, 100)
+            self._stage(d, 900, 900)
+            os.remove(os.path.join(d, "B.md"))          # gone from disk, still in the index
+            self.assertEqual(cb.blob_bytes(d, ":B.md"), 900,
+                             "fixture proof: the index still holds B.md")
+            self.assertEqual(cb.precommit(d, cfg), cb.BREACH,
+                             "1,800 B against a 1,000 B ceiling must refuse")
+
+    def test_a_rename_that_shrinks_the_class_passes(self):
+        """The second entry point, found only by an adversarial reviewer. Here the deleted
+        path is not a config member at all — the config was updated to name the new file —
+        so the worktree fix does not reach it. The HEAD baseline must therefore be summed
+        over HEAD'S OWN config, not today's, or every member that LEAVES a class takes its
+        HEAD bytes out of the baseline the relative rule compares against."""
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 30000, 30000)
+            cfg["classes"]["pair"]["total_bytes"] = 40000
+            git(d, "mv", "B.md", "C.md")
+            Path(d, "C.md").write_text("c" * 20000)     # 60,000 -> 50,000: a reduction
+            cfg["files"] = [{"path": "A.md", "class": "pair"},
+                            {"path": "C.md", "class": "pair"}]
+            Path(d, ".context-budget.json").write_text(json.dumps(cfg))
+            git(d, "add", "-A")
+            self.assertEqual(cb.precommit(d, cfg), cb.CLEAN,
+                             "a rename that shrinks the class must not be refused")
+
+    def test_the_head_baseline_comes_from_heads_config_not_the_staged_one(self):
+        """Pin the mechanism, not just the symptom."""
+        src = CB_PY.read_text()
+        pre = src.split("def precommit")[1].split("# === SELFTEST")[0]
+        self.assertIn('f"HEAD:{CONFIG_NAME}"', pre,
+                      "the baseline must consult HEAD's own declaration of the class")
+
+    def test_an_undeclared_class_total_gates_nothing(self):
+        with tempfile.TemporaryDirectory() as d:
+            cfg = self._repo(d, 600, 600)
+            cfg["classes"]["pair"].pop("total_bytes")
+            self.assertEqual(cb.precommit(d, cfg), cb.CLEAN)
+
+
+class TestReserveIdentity(unittest.TestCase):
+    """framework_share := READ_CAP_BYTES - adopter_reserve_bytes, plan 3.4(c)."""
+
+    def test_read_cap_bytes_is_computed_not_written(self):
+        self.assertEqual(cb.READ_CAP_BYTES,
+                         int(cb.READ_CAP_TOKENS * cb.MIN_BYTES_PER_TOKEN))
+        self.assertEqual(cb.READ_CAP_BYTES, 56750)
+
+    def test_it_agrees_with_the_trimmer_which_computes_it_the_same_way(self):
+        """Two tools carrying the same cap must not drift by someone editing a literal."""
+        src = (REPO / "starter-kit" / "methodology_trim.py").read_text()
+        self.assertIn("READ_CAP_BYTES = int(READ_CAP_TOKENS * MIN_BYTES_PER_TOKEN)", src)
+
+    def test_the_share_is_the_cap_minus_the_reserve(self):
+        self.assertEqual(cb.framework_share({}), (56750, 0, 56750))
+        self.assertEqual(cb.framework_share({"adopter_reserve_bytes": 28000}),
+                         (28750, 28000, 56750))
+
+    def test_a_derived_class_ceiling_ignores_the_written_number(self):
+        """DERIVED, NOT PICKED: the computed value is what is in force."""
+        ceil, derived = cb.class_ceiling({"adopter_reserve_bytes": 6750},
+                                         {"total_bytes": 999, "derive_from_read_cap": True})
+        self.assertTrue(derived)
+        self.assertEqual(ceil, 50000)
+
+    def test_a_written_ceiling_that_disagrees_with_the_derivation_is_reported(self):
+        bad = cb.config_defects({"classes": {"read-set":
+                                {"total_bytes": 999, "derive_from_read_cap": True}}})
+        self.assertTrue(bad, "a number not in force must be reported, never silently used")
+        self.assertIn("56,750", " ".join(bad))
+
+    def test_a_written_ceiling_that_agrees_is_clean(self):
+        self.assertEqual(cb.config_defects({"classes": {"read-set":
+                         {"total_bytes": 56750, "derive_from_read_cap": True}}}), [])
+
+    def test_a_reserve_that_consumes_the_whole_cap_is_reported(self):
+        bad = cb.config_defects({"adopter_reserve_bytes": 56750})
+        self.assertTrue(bad)
+        self.assertIn("no file can satisfy", " ".join(bad))
+
+    def test_a_negative_reserve_is_reported(self):
+        self.assertTrue(cb.config_defects({"adopter_reserve_bytes": -1}))
+
+    def test_the_identity_is_not_asserted_at_module_scope(self):
+        """A module-scope assert runs at IMPORT, so a mutant violating it dies with a
+        traceback BEFORE the code under test runs and is scored killed by the crash."""
+        src = CB_PY.read_text()
+        top = [l for l in src.splitlines()
+               if l.startswith("assert ") or l.startswith("assert(")]
+        self.assertEqual(top, [], f"module-scope assert(s) found: {top}")
+
+    def test_config_defects_is_actually_called_by_the_tool(self):
+        """It was defined, unit-tested, and NEVER RUN, while the distributed seed told
+        adopters a max_tokens above the cap 'is rejected as a config defect'. A guard
+        nothing calls is a comment shaped like a guard — and 'asserted at run time' is
+        not true of a function with no call site."""
+        src = CB_PY.read_text()
+        # Scoped to the two function BODIES. Counting "config_defects(" across the whole
+        # file matched three calls inside selftest() and one occurrence inside a comment,
+        # so the guard stayed green with BOTH real call sites deleted — a guard whose net
+        # is wider than its claim asserts nothing about the claim.
+        def body_of(fn):
+            """The body of one top-level def, ending at the next top-level def. `main()`
+            lives AFTER the SELFTEST banner, so slicing the file at that banner drops it
+            entirely — which is how the first version of this fix raised IndexError."""
+            i = src.index(f"def {fn}(")
+            rest = src[i:]
+            m = re.search(r"\n(?=def |if __name__)", rest[1:])
+            return rest[: m.start() + 1] if m else rest
+        for name, chunk in (("main()", body_of("main")),
+                            ("precommit()", body_of("precommit"))):
+            code = [l for l in chunk.splitlines()
+                    if "config_defects(" in l and not l.lstrip().startswith("#")]
+            self.assertTrue(code, f"config_defects() is not called in {name}")
+
+    def test_a_config_defect_makes_the_run_breach(self):
+        with tempfile.TemporaryDirectory() as d:
+            new_repo(d)
+            Path(d, ".context-budget.json").write_text(json.dumps({
+                "adopter_reserve_bytes": 99999,
+                "files": [{"path": "CLAUDE.md", "class": "resident"}]}))
+            Path(d, "CLAUDE.md").write_text("ok\n")
+            p = subprocess.run([sys.executable, str(CB_PY)], cwd=d,
+                               capture_output=True, text=True)
+            self.assertEqual(p.returncode, cb.BREACH)
+            self.assertIn("config defect", re.sub(r"\x1b\[[0-9;]*m", "", p.stdout))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=1)


### PR DESCRIPTION
**Base: `read-set-budgets`, not `main`.** Fourth and last of the four PRs staged there. Nothing here
is proposed for `main` yet.

## What this does

Ships the context-budget gate the first three PRs measured against: `starter-kit/context_budget.py`
`1.0.0` → `1.2.0` (29,549 → 73,040 B), its 116-test module, and a root `.context-budget.json` for
this repository. #76 and #78 shed bytes; this one **refuses growth**. On this branch, at its head:

| | bytes | ceiling | |
|---|---|---|---|
| `starter-kit/SESSION_RUNNER.md` | 52,195 | 41,364 | over by 10,831 |
| `starter-kit/SAFEGUARDS.md` | 15,386 | 15,386 | at ceiling |
| read-set pair | **67,581** | **56,750** | **over by 10,831** — exactly what #76's table left |
| `CHANGELOG.md` | 97,257 | 65,536 | over by 31,721; ≈39,416 tok at 2.4674 B/tok (91,365 B on the base; this PR's own entry is the difference) |
| `HANDOFFS.md` | 70,182 | 65,536 | over by 4,646; ≈29,677 tok at 2.3648 B/tok |

The bare run exits 2 with that table: six red findings on day one — five per-file ceilings across
three files, plus the read-set class total. The two token estimates use densities measured on the
fork's copies of these same-format ledgers, not on this tree; each ledger's `_` key gives the
doubled-file method to re-measure them here. `--precommit` refuses any commit that grows either file
in bytes (or, for a whole-read class, in estimated tokens) and passes any that shrinks one (verified:
+2 B refused; −5,000 B passed while still over); line-count and structure checks run in the bare and
`--json` modes only. **Nothing on this branch shrinks the pair; this PR makes it stop growing and say
why.**

## The tool refuses to run without a config, so this PR provisions one

Your 1.0.0 already exits 3 — *"refuses to invent budgets for a project that has not declared them"*
— at any root without `.context-budget.json`; that is unchanged. The seed adopters receive reads red
here for reasons unrelated to this series (`CLAUDE.md` is 59,168 B against the seed's 28,000). So the
config in this PR **pins** `CLAUDE.md` at its arrival size, **derives** the read-set ceiling from the
read cap (25,000 tok × 2.27 B/tok = 56,750, computed at run time — 25,000 is `read_cap_tokens` in the
config — the number in the Read tool's own refusal, `exceeds maximum allowed tokens (25000)`, Claude
Code 2.1.259; 2.27 is the tool's `MIN_BYTES_PER_TOKEN` floor at `starter-kit/context_budget.py:68`, a
constant, not a key, so a different floor is a tool edit), and **declares** the two ledgers
Phase 0 reads and the Learnings table your `bin/check-learnings` already cites this file for.

## Every ceiling in that config is yours; five are proposals rather than measurements

1. **`CLAUDE.md` pinned at 59,168 B** (growth refused, shrink passes). Alternative: the seed's
   28,000 / 34,000, which reads *over by 31,168* today.
2. **`CHANGELOG.md` and `HANDOFFS.md` at 65,536 B** — the fork's ceiling, **not the trimmer's**:
   #77's `methodology_trim.py` triggers at 196,608 B and reports *trigger does not fire* on both
   ledgers today (97,257 B and 70,182 B). Bringing either under this ceiling is
   `python3 starter-kit/methodology_trim.py --file <ledger> --budget-bytes 65536` (dry-run by
   default; add `--write`), `CHANGELOG.md` first — a `HANDOFFS.md` trim writes its own entry into
   `CHANGELOG.md`, which the gate refuses while that file is over. The trimmer stops at half the budget
   (measured on the base: 91,365 → 30,920 B, 30 of 39 records; 70,182 → 26,891 B, 7 of 10), appends
   one `CHANGELOG.md` entry per trim, and refuses on an unreconciled tree. **At the carried densities
   the token ceiling binds first** — 25,000 tok is 61,685 B for `CHANGELOG.md` and 59,120 B for
   `HANDOFFS.md` — so 65,536 B fires first only if a re-measured density comes in above 2.62 B/tok.
   Alternative: omit the byte ceiling and keep `max_tokens`, or omit both and let the trimmer's number
   govern.
3. **`SAFEGUARDS.md` pinned at 15,386 B**, so the whole 10,831 B of debt sits on `SESSION_RUNNER.md`.
4. **`FRAMEWORK_LEARNINGS.md` at 73,728 B**, on-demand, no token ceiling — at its measured 2.8897
   B/tok that sits 1,486 B above the one-read cliff; the `_` key says so.
5. **Two more numbers, neither measured:** `read-set.warn_bytes` 51,000 B is the fork's choice, marked
   PROPOSAL in its `_` key — ~10% under the derived total so the class warns before it refuses;
   inert while the class is over, which it is today — and `CLAUDE.md.max_lines` 200 is
   `starter-kit/BOOTSTRAP.md:198`'s own *"roughly 200 lines"* applied to your `CLAUDE.md` (126 lines
   today by `wc -l`; bare run only, `--precommit` ignores it). Delete either key if you do not want it.

The calibration constants are the seed's. After merge, run `python3 starter-kit/context_budget.py
--calibrate`; it writes nothing. If it admits a fit (R² ≥ 0.50, positive slope), set `bytes_per_token`
to the fitted value. Until then `CLAUDE.md`, `SESSION_RUNNER.md` and `SAFEGUARDS.md` are judged at the
seed's 2.93 B/tok — `CLAUDE.md` reads ≈20,194 tok in the header, `ok`; at the 2.27 floor the same bytes
read 26,065, `over` — and `CLAUDE.md`'s derived 26,065-token ceiling is clamped to 25,000 without a
message, because only a *declared* `max_tokens` is reported when clamped. If your harness's read cap
differs, set `read_cap_tokens` and every derived ceiling follows.

## Day one, and what does not change

- **This PR's own two commits fail the gate it ships, run by hand:** exit 3 on the first (no config
  yet — nothing evaluated), exit 2 on the second (its `CHANGELOG.md` bullet grows a file already over
  65,536 B: `95,557 -> 97,257 B`). The gate is not wired into `.githooks/pre-commit`; nothing refuses
  these commits. Both carry a ledger line because your `.githooks/pre-commit` requires one, and both
  were committed through it. If you chain the budget check in later, every commit that appends to a
  ledger is refused until **that** ledger is under 65,536 B — and the hook's documented `--no-verify`
  bypass applies to the budget check too. This PR claims no enforcement.
- **The first commit alone leaves one `bin/tests.sh` row red** (`114 passed / 2 failed`): the wired
  unit-test row fails until the second commit's config exists, because the tool exits 3 without one
  and the module's selftest test needs it. The split is deliberate — the policy file is reviewable
  apart from the code — and the first commit's message says so.
- `python3 starter-kit/context_budget.py` exits 2 with the table above and creates
  `.context-budget-history.jsonl`, untracked (the fork tracks it; your call — the `.gitignore` comment
  explains). `--precommit`, `--selftest`, `bin/tests.sh` write nothing.
- **Nothing else in your workflow changes unless you wire the hook — except one added `bin/tests.sh`
  row**, which fails whenever the unit module fails (including the two machine-dependent tests under
  Verification). `core.hooksPath` is local config; `.githooks/pre-commit` is the ledger gate and this PR
  does not chain the budget into it.
- **Do not run `install-hook` at this root.** On a clone without `core.hooksPath` it installs
  `.git/hooks/pre-commit` pointing at `<root>/context_budget.py`, which does not exist here, and every
  commit then fails with `can't open file`; recover with `rm .git/hooks/pre-commit`. With
  `core.hooksPath=.githooks` it declines.
- `SESSION_RUNNER.md` Phase 0 still never names the tool. Adding one line grows the capped file
  ~300 B. Not done here; your decision.
- The dashboard twins are untouched (`2.17.0` on the fork vs `2.10.7` here; separate series).

## What changes for adopters who sync

Exit codes are unchanged (`0/1/2/3`). On an unchanged seed config, two things differ:
(1) when nothing fires, a read-mandated row reports **bytes, not lines** (`305 ln / 400 ln ok` →
`60,048 B / 120,000 B ok`); (2) a read-mandated file **above 73,252 B** — the first size whose
truncated estimate `int(bytes / 2.93)` exceeds 25,000 tokens is 73,253 B (≈25,001 tok) — now gets a
**derived token ceiling** the old tool never had, and goes `ok` → `over`, exit 1 → 2, even under every
byte and line ceiling the adopter declared — measured at 73,253 B and 73,548 B; 73,252 B still `ok`.
Also new: ceilings may be declared in tokens (`max_tokens`); a `max_tokens` above the cap is
**clamped to the cap and reported as a config defect** — the clamp is never silent; the gate sizes
the **index** with `git cat-file -s` (the old path was 1 B short on LF, more on CRLF, and raised on
non-UTF-8 content); `precommit` gains a class-total arm; `calibrate` walks first-parent history,
compares timezone-aware stamps, and refuses a fit below R² 0.50; the ledger row names the ceiling
that fired in its own unit; remediation text no longer says *here* about a measurement taken on
another project. The seed gains `read_cap_tokens`, two `max_tokens` keys and a note on its on-demand
entry saying why that one gets none (+6 lines); it is seed-once, so no existing adopter config changes.

## Verification

Clean clone of `cea3068`, every figure taken from the tree at the head after the last edit.

| | base `cea3068` | this branch |
|---|---|---|
| `bash bin/tests.sh` | **114 passed / 1 failed** | **115 passed / 1 failed** |
| `python3 tools/test_context_budget.py` | — | **116 run, OK, 2 skipped**, exit 0 |
| `python3 starter-kit/context_budget.py --selftest` | — | **52 PASS / 0 FAIL**, exit 0 |
| bare run | exit 3 (no config) | **exit 2**, six findings, `config_defects: []` |
| `check-links` / `check-learnings` / `check-handoff` / `--all` | — | **0 / 0 / 0 / 0**, each read bare |

Diffed **row for row**: **115 shared labels, zero status flips, exactly one row added**
(`PASS: context budget gate unit tests green`). The single failure is the same on both sides:
Test 9 (`bin/sync --source=github` reads `main`, where three manifest sources are absent until this
branch merges). The 13-case `--precommit` matrix from the plan reproduces on the head: +2 B on any
budgeted file over or at its ceiling → exit 2 `REFUSED`; a shrink on a file still over → 0; +2 B on
`FRAMEWORK_LEARNINGS.md` (under) and on `README.md` (unbudgeted) → 0; a `## Versioning` → `## Version`
edit → `--precommit` 0 and the bare run 2 with `instrument-failed`; nothing staged → 0.

The two skips are `TestFitGateEndToEnd` (`tools/test_context_budget.py:330`), which needs *this
repository's* session transcripts on the running machine. **On yours they run if
`~/.claude/projects/<your-checkout-slug>/*.jsonl` exists, and they can fail for reasons that are not
the tool:** fewer than 3 commits touching `CLAUDE.md`, fewer than 4 transcripts with a usage record
dated at or after the file's first recorded size, a `CLAUDE.md` that was the same size at every usable
session, a fitted slope ≤ 0, or opening context that never varied (R² undefined). If the new
`bin/tests.sh` row is red, run `python3 tools/test_context_budget.py -v 2>&1 | grep -B1 -A1
AssertionError` — the tests capture `calibrate()`'s stdout, so its own diagnosis (*"only N usable
sessions — not enough to fit"*, *"no variation in CLAUDE.md size"*) appears only inside the
`AssertionError:` text; `grep -A2 FitGateEndToEnd` shows a `skipped` suffix naming the missing
directory.

## What a reviewer should look at

1. **`.context-budget.json`** — every `_` key states a derivation and marks what is a PROPOSAL (five
   values, eight label sites). The numbers are the maintainer's to move; the file says which.
2. **The `CHANGELOG.md` entry** — it is the PR's own record on the ledger the gate declares, and the
   second commit's bullet says the gate refuses it.
3. **`tools/test_context_budget.py`** — new upstream, 116 tests; six lines differ from the fork's copy:
   four replaced a fork-relative identifier with the date of the change, two replaced a reference to
   the fork's numbered `bin/tests.sh` block with a description of this tree's.

## What this PR deliberately does not do

- **It does not carry the dashboard twins** (`2.17.0` on the fork, ten labels above this base's
  `2.10.7`) — a separate series. Nor the fork's own root config, its measurement history, its
  `.githooks/pre-commit` additions, or its `bin/_manifest.py` comments.
- **It does not wire the gate.** `.githooks/pre-commit` is untouched; the config's `_` key and the
  ledger bullet both say the gate is measuring-only here.
- **It does not run `--calibrate`** and adopts no fitted density; the constants are the seed's.
- **Two one-line follow-ons it leaves to you, named so they are chosen rather than forgotten:**
  `bin/check-learnings:87-89` says the root config is *"a file this tree lacks"*, which stops being true
  the moment the second commit lands (the checker is canonical-only, so the fix is one comment line);
  and `starter-kit/context_budget.py:341`'s `open(path, "rb").read()` — your 1.0.0 line — surfaces a
  `ResourceWarning` on stderr under the new test module (`bin/tests.sh` redirects it; nothing fails);
  the test module's `# D1`–`# D5` section labels come from two different decision series in the fork's
  planning (the five defects of the 2026-08-15 `calibrate()` repair, `:82`–`:372`, and the 2026-08-30 gate
  decisions from `:666`), so `D3`, `D4` and `D5` each label two things — a two-line legend at the module
  head, or a renumbering, is yours; and the banner's `≈ 20,194 tok` beside the config's *"about 20,193"*
  is one quantity through two 1.0.0 rounding paths (`int()` at `:386`, `:,.0f` at `:599`).
- **One thing adopters receive that they did not before:** the seed's `_read_cap_tokens` note now names
  the fork where 1.2.0 was developed (`rmsharp/methodology`) as the site of the measurement it cites,
  rather than *"the project that authors this tool"*, which on this tree reads as you. Reword it if you
  would rather the seed not name a third repository.
